### PR TITLE
Provide basic callback infrastructure and auditing support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<artifactId>spring-data-parent</artifactId>
 		<groupId>org.springframework.data.build</groupId>
-		<version>2.2.0.M4</version>
+		<artifactId>spring-data-parent</artifactId>
+		<version>2.2.0.RC1</version>
 	</parent>
 
 	<groupId>org.neo4j.springframework.data</groupId>
@@ -106,7 +106,7 @@
 		<rxjava.version>1.3.8</rxjava.version>
 		<rxjava2.version>2.2.5</rxjava2.version>
 		<slf4j.version>1.7.26</slf4j.version>
-		<springdata-commons.version>2.2.0.M4</springdata-commons.version>
+		<springdata-commons.version>2.2.0.RC1</springdata-commons.version>
 		<neo4j-java-driver-spring-boot-starter.version>1.0.0.BUILD-SNAPSHOT</neo4j-java-driver-spring-boot-starter.version>
 		<testcontainers.version>1.10.7</testcontainers.version>
 

--- a/spring-data-neo4j-rx-examples-parent/spring-data-neo4j-rx-examples-spring-boot/pom.xml
+++ b/spring-data-neo4j-rx-examples-parent/spring-data-neo4j-rx-examples-spring-boot/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<groupId>org.springframework.boot</groupId>
-		<version>2.2.0.M3</version>
+		<version>2.2.0.M4</version>
 		<relativePath></relativePath>
 		<!-- lookup parent from repository -->
 	</parent>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/pom.xml
@@ -21,9 +21,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<artifactId>spring-boot-starter-parent</artifactId>
 		<groupId>org.springframework.boot</groupId>
-		<version>2.2.0.M3</version>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.2.0.M4</version>
 		<relativePath></relativePath>
 	</parent>
 

--- a/spring-data-neo4j-rx/pom.xml
+++ b/spring-data-neo4j-rx/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-r2dbc</artifactId>
-			<version>1.0.0.M2</version>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/EnableNeo4jAuditing.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/EnableNeo4jAuditing.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+
+/**
+ * Annotation to enable auditing for SDN-RX entities via annotation configuration.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ * @soundtrack Iron Maiden - Killers
+ */
+@Inherited
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(Neo4jAuditingRegistrar.class)
+public @interface EnableNeo4jAuditing {
+
+	/**
+	 * Configures the {@link AuditorAware} bean to be used to lookup the current principal.
+	 *
+	 * @return
+	 */
+	String auditorAwareRef() default "";
+
+	/**
+	 * Configures whether the creation and modification dates are set. Defaults to {@literal true}.
+	 *
+	 * @return
+	 */
+	boolean setDates() default true;
+
+	/**
+	 * Configures whether the entity shall be marked as modified on creation. Defaults to {@literal true}.
+	 *
+	 * @return
+	 */
+	boolean modifyOnCreate() default true;
+
+	/**
+	 * Configures a {@link DateTimeProvider} bean name that allows customizing actual date time class to be
+	 * used for setting creation and modification dates.
+	 *
+	 * @return
+	 */
+	String dateTimeProviderRef() default "";
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jAuditingRegistrar.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jAuditingRegistrar.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.config;
+
+import java.lang.annotation.Annotation;
+
+import org.neo4j.springframework.data.repository.event.AuditingBeforeBindCallback;
+import org.neo4j.springframework.data.repository.event.ReactiveAuditingBeforeBindCallback;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport;
+import org.springframework.data.auditing.config.AuditingConfiguration;
+import org.springframework.data.config.ParsingUtils;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Killers
+ * @since 1.0
+ */
+final class Neo4jAuditingRegistrar extends AuditingBeanDefinitionRegistrarSupport {
+
+	private static final boolean PROJECT_REACTOR_AVAILABLE = ClassUtils.isPresent("reactor.core.publisher.Mono",
+		Neo4jAuditingRegistrar.class.getClassLoader());
+
+	private static final String AUDITING_HANDLER_BEAN_NAME = "neo4jAuditingHandler";
+	private static final String MAPPING_CONTEXT_BEAN_NAME = "neo4jMappingContext";
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport#getAnnotation()
+	 */
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableNeo4jAuditing.class;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport#getAuditingHandlerBeanName()
+	 */
+	@Override
+	protected String getAuditingHandlerBeanName() {
+		return AUDITING_HANDLER_BEAN_NAME;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport#registerBeanDefinitions(org.springframework.core.type.AnnotationMetadata, org.springframework.beans.factory.support.BeanDefinitionRegistry)
+	 */
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata annotationMetadata, BeanDefinitionRegistry registry) {
+
+		Assert.notNull(annotationMetadata, "AnnotationMetadata must not be null!");
+		Assert.notNull(registry, "BeanDefinitionRegistry must not be null!");
+
+		super.registerBeanDefinitions(annotationMetadata, registry);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport#registerAuditListener(org.springframework.beans.factory.config.BeanDefinition, org.springframework.beans.factory.support.BeanDefinitionRegistry)
+	 */
+	@Override
+	protected void registerAuditListenerBeanDefinition(BeanDefinition auditingHandlerDefinition,
+		BeanDefinitionRegistry registry) {
+
+		Assert.notNull(auditingHandlerDefinition, "BeanDefinition must not be null!");
+		Assert.notNull(registry, "BeanDefinitionRegistry must not be null!");
+
+		BeanDefinitionBuilder listenerBeanDefinitionBuilder = BeanDefinitionBuilder
+			.rootBeanDefinition(AuditingBeforeBindCallback.class);
+		listenerBeanDefinitionBuilder
+			.addConstructorArgValue(
+				ParsingUtils.getObjectFactoryBeanDefinition(getAuditingHandlerBeanName(), registry));
+
+		registerInfrastructureBeanWithId(listenerBeanDefinitionBuilder.getBeanDefinition(),
+			AuditingBeforeBindCallback.class.getName(), registry);
+
+		if (PROJECT_REACTOR_AVAILABLE) {
+			registerReactiveAuditingEntityCallback(registry, auditingHandlerDefinition.getSource());
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.auditing.config.AuditingBeanDefinitionRegistrarSupport#getAuditHandlerBeanDefinitionBuilder(org.springframework.data.auditing.config.AuditingConfiguration)
+	 */
+	@Override
+	protected BeanDefinitionBuilder getAuditHandlerBeanDefinitionBuilder(AuditingConfiguration configuration) {
+
+		Assert.notNull(configuration, "AuditingConfiguration must not be null!");
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(IsNewAwareAuditingHandler.class);
+
+		BeanDefinitionBuilder persistentEntities = BeanDefinitionBuilder
+			.genericBeanDefinition(PersistentEntities.class)
+			.setFactoryMethod("of");
+		persistentEntities.addConstructorArgReference(MAPPING_CONTEXT_BEAN_NAME);
+
+		builder.addConstructorArgValue(persistentEntities.getBeanDefinition());
+		return configureDefaultAuditHandlerAttributes(configuration, builder);
+	}
+
+	private void registerReactiveAuditingEntityCallback(BeanDefinitionRegistry registry, Object source) {
+
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder
+			.rootBeanDefinition(ReactiveAuditingBeforeBindCallback.class);
+
+		builder.addConstructorArgValue(
+			ParsingUtils.getObjectFactoryBeanDefinition(getAuditingHandlerBeanName(), registry));
+		builder.getRawBeanDefinition().setSource(source);
+
+		registerInfrastructureBeanWithId(builder.getBeanDefinition(),
+			ReactiveAuditingBeforeBindCallback.class.getName(), registry);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManager.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManager.java
@@ -70,7 +70,7 @@ public class ReactiveNeo4jTransactionManager extends AbstractReactiveTransaction
 
 	public static Mono<RxTransaction> retrieveReactiveTransaction(final Driver driver, final String targetDatabase) {
 
-		return TransactionSynchronizationManager.currentTransaction() // Do we have a Transaction context?
+		return TransactionSynchronizationManager.forCurrentTransaction() // Do we have a Transaction context?
 			// Bail out early if synchronization between transaction managers is not active
 			.filter(TransactionSynchronizationManager::isSynchronizationActive)
 			.flatMap(tsm -> {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallback.java
@@ -36,6 +36,8 @@ import org.springframework.util.Assert;
 @API(status = API.Status.INTERNAL, since = "1.0")
 public final class AuditingBeforeBindCallback implements BeforeBindCallback<Object>, Ordered {
 
+	public static final int NEO4J_AUDITING_ORDER = 100;
+
 	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
 
 	/**
@@ -65,6 +67,6 @@ public final class AuditingBeforeBindCallback implements BeforeBindCallback<Obje
 	 */
 	@Override
 	public int getOrder() {
-		return 100;
+		return NEO4J_AUDITING_ORDER;
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallback.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.apiguardian.api.API;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.core.Ordered;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.util.Assert;
+
+/**
+ * {@link EntityCallback} to populate auditing related fields on an entity about to be bound to a record.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Iron Maiden
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class AuditingBeforeBindCallback implements BeforeBindCallback<Object>, Ordered {
+
+	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
+
+	/**
+	 * Creates a new {@link AuditingBeforeBindCallback} using the given {@link AuditingHandler}
+	 * provided by the given {@link ObjectFactory}.
+	 *
+	 * @param auditingHandlerFactory must not be {@literal null}.
+	 */
+	public AuditingBeforeBindCallback(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
+
+		Assert.notNull(auditingHandlerFactory, "IsNewAwareAuditingHandler must not be null!");
+		this.auditingHandlerFactory = auditingHandlerFactory;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.neo4j.springframework.data.repository.event.BeforeBindCallback#onBeforeBind(java.lang.Object)
+	 */
+	@Override
+	public Object onBeforeBind(Object entity) {
+		return auditingHandlerFactory.getObject().markAudited(entity);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.core.Ordered#getOrder()
+	 */
+	@Override
+	public int getOrder() {
+		return 100;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/BeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/BeforeBindCallback.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.apiguardian.api.API;
+import org.springframework.data.mapping.callback.EntityCallback;
+
+/**
+ * Entity callback triggered before an Entity is bound to a record (represented by a {@link java.util.Map java.util.Map&lt;String, Object&gt;}).
+ *
+ * @author Michael J. Simons
+ * @param <T> The type of the entity.
+ * @since 1.0
+ * @soundtrack Bon Jovi - Slippery When Wet
+ */
+@FunctionalInterface
+@API(status = API.Status.STABLE, since = "1.0")
+public interface BeforeBindCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is saved. Can return either the same or a modified instance
+	 * of the domain object. This method is called before converting the {@code entity} to a {@link java.util.Map},
+	 * so the outcome of this callback is used to create the record for the domain object.
+	 *
+	 * @param entity the domain object to save.
+	 * @return the domain object to be persisted.
+	 */
+	T onBeforeBind(T entity);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
@@ -40,6 +40,8 @@ import org.springframework.util.Assert;
 @API(status = API.Status.INTERNAL, since = "1.0")
 public final class ReactiveAuditingBeforeBindCallback implements ReactiveBeforeBindCallback<Object>, Ordered {
 
+	public static final int NEO4J_REACTIVE_AUDITING_ORDER = 100;
+
 	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
 
 	/**
@@ -69,6 +71,6 @@ public final class ReactiveAuditingBeforeBindCallback implements ReactiveBeforeB
 	 */
 	@Override
 	public int getOrder() {
-		return 100;
+		return NEO4J_REACTIVE_AUDITING_ORDER;
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import reactor.core.publisher.Mono;
+
+import org.apiguardian.api.API;
+import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.core.Ordered;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.util.Assert;
+
+/**
+ * Reactive {@link EntityCallback} to populate auditing related fields on an entity about to be bound to a record.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - The Number Of The Beast
+ * @see AuditingBeforeBindCallback
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class ReactiveAuditingBeforeBindCallback implements ReactiveBeforeBindCallback<Object>, Ordered {
+
+	private final ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory;
+
+	/**
+	 * Creates a new {@link ReactiveAuditingBeforeBindCallback} using the {@link AuditingHandler} provided by the
+	 * given {@link ObjectFactory}.
+	 *
+	 * @param auditingHandlerFactory must not be {@literal null}.
+	 */
+	public ReactiveAuditingBeforeBindCallback(ObjectFactory<IsNewAwareAuditingHandler> auditingHandlerFactory) {
+
+		Assert.notNull(auditingHandlerFactory, "IsNewAwareAuditingHandler must not be null!");
+		this.auditingHandlerFactory = auditingHandlerFactory;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.neo4j.springframework.data.repository.event.ReactiveBeforeBindCallback#onBeforeBind(java.lang.Object)
+	 */
+	@Override
+	public Publisher<Object> onBeforeBind(Object entity) {
+		return Mono.just(auditingHandlerFactory.getObject().markAudited(entity));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.core.Ordered#getOrder()
+	 */
+	@Override
+	public int getOrder() {
+		return 100;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveBeforeBindCallback.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.apiguardian.api.API;
+import org.reactivestreams.Publisher;
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+
+/**
+ * Entity callback triggered before an Entity is bound to a record (represented by a {@link java.util.Map java.util.Map&lt;String, Object&gt;}).
+ *
+ * @param <T> The type of the entity.
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Killers
+ * @see ReactiveEntityCallbacks
+ * @since 1.0
+ */
+@FunctionalInterface
+@API(status = API.Status.STABLE, since = "1.0")
+public interface ReactiveBeforeBindCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is saved. Can return either the same or a modified instance
+	 * of the domain object. This method is called before converting the {@code entity} to a {@link java.util.Map},
+	 * so the outcome of this callback is used to create the record for the domain object.
+	 *
+	 * @param entity the domain object to save.
+	 * @return the domain object to be persisted.
+	 */
+	Publisher<T> onBeforeBind(T entity);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/package-info.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Contains the infrastructure for the event system. The event system comes in two flavours: Events that are based
+ * on Spring's application event system and callbacks that are based on Spring Data's callback system. Application
+ * events can be configured to run asynchronously, which make them a bad fit in transactional workloads.
+ * <p>
+ * As a rule of thumb, use Entity callbacks for modifying entities before persisting and application events otherwise.
+ * The best option however to react in a transactional way to changes of an entity is to implement
+ * {@link org.springframework.data.domain.DomainEvents} on an aggregate root.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ * @soundtrack Bon Jovi - Slippery When Wet
+ */
+@NonNullApi
+package org.neo4j.springframework.data.repository.event;
+
+import org.springframework.lang.NonNullApi;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEntityInformation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEntityInformation.java
@@ -43,7 +43,7 @@ public interface Neo4jEntityInformation<T, ID> extends EntityInformation<T, ID> 
 	 * Retrieves an expression to be used in Cypher statements to retrieve the generated or internal id for a node
 	 * fitting the given {@code nodeDescription} under a symbolic name of {@code 'n'}.
 	 *
-	 * @return An expression to address nodes corresponding to entities of the given typoe by id.
+	 * @return An expression to address nodes corresponding to entities of the given type by id.
 	 */
 	Expression getIdExpression();
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEvents.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEvents.java
@@ -19,12 +19,11 @@
 package org.neo4j.springframework.data.repository.support;
 
 import org.neo4j.springframework.data.repository.event.BeforeBindCallback;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.lang.Nullable;
 
 /**
- * Utility class that orchestrates both an {@link ApplicationEventPublisher} and {@link EntityCallbacks}.
+ * Utility class that orchestrates {@link EntityCallbacks}.
  * All the methods provided here check for their availability and do nothing when an event cannot be published.
  *
  * @author Michael J. Simons
@@ -32,16 +31,13 @@ import org.springframework.lang.Nullable;
  */
 final class Neo4jEvents {
 
-	private final @Nullable ApplicationEventPublisher eventPublisher;
 	private final @Nullable EntityCallbacks entityCallbacks;
 
-	Neo4jEvents(@Nullable ApplicationEventPublisher eventPublisher,
-		@Nullable EntityCallbacks entityCallbacks) {
-		this.eventPublisher = eventPublisher;
+	Neo4jEvents(@Nullable EntityCallbacks entityCallbacks) {
 		this.entityCallbacks = entityCallbacks;
 	}
 
-	protected <T> T maybeCallBeforeBind(T object) {
+	<T> T maybeCallBeforeBind(T object) {
 		if (entityCallbacks != null) {
 			return entityCallbacks.callback(BeforeBindCallback.class, object);
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEvents.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jEvents.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.support;
+
+import org.neo4j.springframework.data.repository.event.BeforeBindCallback;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.mapping.callback.EntityCallbacks;
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility class that orchestrates both an {@link ApplicationEventPublisher} and {@link EntityCallbacks}.
+ * All the methods provided here check for their availability and do nothing when an event cannot be published.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+final class Neo4jEvents {
+
+	private final @Nullable ApplicationEventPublisher eventPublisher;
+	private final @Nullable EntityCallbacks entityCallbacks;
+
+	Neo4jEvents(@Nullable ApplicationEventPublisher eventPublisher,
+		@Nullable EntityCallbacks entityCallbacks) {
+		this.eventPublisher = eventPublisher;
+		this.entityCallbacks = entityCallbacks;
+	}
+
+	protected <T> T maybeCallBeforeBind(T object) {
+		if (entityCallbacks != null) {
+			return entityCallbacks.callback(BeforeBindCallback.class, object);
+		}
+
+		return object;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactory.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactory.java
@@ -57,9 +57,12 @@ final class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 
 	private final SchemaBasedStatementBuilder schemaBasedStatementBuilder;
 
-	Neo4jRepositoryFactory(Neo4jClient neo4jClient, Neo4jMappingContext mappingContext) {
+	private final Neo4jEvents eventSupport;
+
+	Neo4jRepositoryFactory(Neo4jClient neo4jClient, Neo4jMappingContext mappingContext, Neo4jEvents eventSupport) {
 		this.neo4jClient = neo4jClient;
 		this.mappingContext = mappingContext;
+		this.eventSupport = eventSupport;
 
 		this.schemaBasedStatementBuilder = CypherAdapterUtils.createSchemaBasedStatementBuilder(this.mappingContext);
 	}
@@ -79,8 +82,7 @@ final class Neo4jRepositoryFactory extends RepositoryFactorySupport {
 
 		Neo4jEntityInformation<?, Object> entityInformation = getEntityInformation(metadata.getDomainType());
 		return getTargetRepositoryViaReflection(metadata,
-			neo4jClient, entityInformation, schemaBasedStatementBuilder
-		);
+			neo4jClient, entityInformation, schemaBasedStatementBuilder, eventSupport);
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactoryBean.java
@@ -24,9 +24,13 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport;
+import org.springframework.lang.Nullable;
 
 /**
  * Special adapter for Springs {@link org.springframework.beans.factory.FactoryBean} interface to allow easy setup of
@@ -46,6 +50,9 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 	private Neo4jClient neo4jClient;
 
 	private Neo4jMappingContext neo4jMappingContext;
+
+	private @Nullable ApplicationEventPublisher eventPublisher;
+	private @Nullable EntityCallbacks entityCallbacks;
 
 	/**
 	 * Creates a new {@link TransactionalRepositoryFactoryBeanSupport} for the given repository interface.
@@ -67,7 +74,20 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new Neo4jRepositoryFactory(neo4jClient, neo4jMappingContext);
+		return new Neo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new Neo4jEvents(eventPublisher, entityCallbacks));
 	}
 
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
+
+		this.entityCallbacks = EntityCallbacks.create(beanFactory);
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		super.setApplicationEventPublisher(publisher);
+
+		this.eventPublisher = publisher;
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Neo4jRepositoryFactoryBean.java
@@ -25,7 +25,6 @@ import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -51,7 +50,6 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 
 	private Neo4jMappingContext neo4jMappingContext;
 
-	private @Nullable ApplicationEventPublisher eventPublisher;
 	private @Nullable EntityCallbacks entityCallbacks;
 
 	/**
@@ -74,7 +72,7 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new Neo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new Neo4jEvents(eventPublisher, entityCallbacks));
+		return new Neo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new Neo4jEvents(entityCallbacks));
 	}
 
 	@Override
@@ -82,12 +80,5 @@ public final class Neo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID
 		super.setBeanFactory(beanFactory);
 
 		this.entityCallbacks = EntityCallbacks.create(beanFactory);
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		super.setApplicationEventPublisher(publisher);
-
-		this.eventPublisher = publisher;
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jEvents.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jEvents.java
@@ -21,30 +21,26 @@ package org.neo4j.springframework.data.repository.support;
 import reactor.core.publisher.Mono;
 
 import org.neo4j.springframework.data.repository.event.ReactiveBeforeBindCallback;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.lang.Nullable;
 
 /**
- * Utility class that orchestrates both an {@link ApplicationEventPublisher} and {@link ReactiveEntityCallbacks}.
+ * Utility class that orchestrates {@link ReactiveEntityCallbacks}.
  * All the methods provided here check for their availability and do nothing when an event cannot be published.
  *
  * @author Michael J. Simons
  * @soundtrack Iron Maiden - Killers
  * @since 1.0
  */
-class ReactiveNeo4jEvents {
+final class ReactiveNeo4jEvents {
 
-	private final @Nullable ApplicationEventPublisher eventPublisher;
 	private final @Nullable ReactiveEntityCallbacks entityCallbacks;
 
-	ReactiveNeo4jEvents(@Nullable ApplicationEventPublisher eventPublisher,
-		@Nullable ReactiveEntityCallbacks entityCallbacks) {
-		this.eventPublisher = eventPublisher;
+	ReactiveNeo4jEvents(@Nullable ReactiveEntityCallbacks entityCallbacks) {
 		this.entityCallbacks = entityCallbacks;
 	}
 
-	protected <T> Mono<T> maybeCallBeforeBind(T object) {
+	<T> Mono<T> maybeCallBeforeBind(T object) {
 
 		if (entityCallbacks != null) {
 			return entityCallbacks.callback(ReactiveBeforeBindCallback.class, object);

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jEvents.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jEvents.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.support;
+
+import reactor.core.publisher.Mono;
+
+import org.neo4j.springframework.data.repository.event.ReactiveBeforeBindCallback;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility class that orchestrates both an {@link ApplicationEventPublisher} and {@link ReactiveEntityCallbacks}.
+ * All the methods provided here check for their availability and do nothing when an event cannot be published.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Killers
+ * @since 1.0
+ */
+class ReactiveNeo4jEvents {
+
+	private final @Nullable ApplicationEventPublisher eventPublisher;
+	private final @Nullable ReactiveEntityCallbacks entityCallbacks;
+
+	ReactiveNeo4jEvents(@Nullable ApplicationEventPublisher eventPublisher,
+		@Nullable ReactiveEntityCallbacks entityCallbacks) {
+		this.eventPublisher = eventPublisher;
+		this.entityCallbacks = entityCallbacks;
+	}
+
+	protected <T> Mono<T> maybeCallBeforeBind(T object) {
+
+		if (entityCallbacks != null) {
+			return entityCallbacks.callback(ReactiveBeforeBindCallback.class, object);
+		}
+
+		return Mono.just(object);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -56,9 +56,12 @@ final class ReactiveNeo4jRepositoryFactory extends RepositoryFactorySupport {
 
 	private final SchemaBasedStatementBuilder schemaBasedStatementBuilder;
 
-	ReactiveNeo4jRepositoryFactory(ReactiveNeo4jClient neo4jClient, Neo4jMappingContext mappingContext) {
+	private final ReactiveNeo4jEvents eventSupport;
+
+	ReactiveNeo4jRepositoryFactory(ReactiveNeo4jClient neo4jClient, Neo4jMappingContext mappingContext, ReactiveNeo4jEvents eventSupport) {
 		this.neo4jClient = neo4jClient;
 		this.mappingContext = mappingContext;
+		this.eventSupport = eventSupport;
 
 		this.schemaBasedStatementBuilder = CypherAdapterUtils.createSchemaBasedStatementBuilder(this.mappingContext);
 	}
@@ -78,7 +81,7 @@ final class ReactiveNeo4jRepositoryFactory extends RepositoryFactorySupport {
 
 		Neo4jEntityInformation<?, Object> entityInformation = getEntityInformation(metadata.getDomainType());
 		return getTargetRepositoryViaReflection(metadata,
-			neo4jClient, entityInformation, schemaBasedStatementBuilder
+			neo4jClient, entityInformation, schemaBasedStatementBuilder, eventSupport
 		);
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -24,9 +24,13 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport;
+import org.springframework.lang.Nullable;
 
 /**
  * Special adapter for Springs {@link org.springframework.beans.factory.FactoryBean} interface to allow easy setup of
@@ -46,6 +50,9 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 	private ReactiveNeo4jClient neo4jClient;
 
 	private Neo4jMappingContext neo4jMappingContext;
+
+	private @Nullable ApplicationEventPublisher eventPublisher;
+	private @Nullable ReactiveEntityCallbacks entityCallbacks;
 
 	/**
 	 * Creates a new {@link TransactionalRepositoryFactoryBeanSupport} for the given repository interface.
@@ -67,7 +74,20 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new ReactiveNeo4jRepositoryFactory(neo4jClient, neo4jMappingContext);
+		return new ReactiveNeo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new ReactiveNeo4jEvents(eventPublisher, entityCallbacks));
 	}
 
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
+
+		this.entityCallbacks = ReactiveEntityCallbacks.create(beanFactory);
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		super.setApplicationEventPublisher(publisher);
+
+		this.eventPublisher = publisher;
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -25,7 +25,6 @@ import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -51,7 +50,6 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 
 	private Neo4jMappingContext neo4jMappingContext;
 
-	private @Nullable ApplicationEventPublisher eventPublisher;
 	private @Nullable ReactiveEntityCallbacks entityCallbacks;
 
 	/**
@@ -74,7 +72,7 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 
 	@Override
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
-		return new ReactiveNeo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new ReactiveNeo4jEvents(eventPublisher, entityCallbacks));
+		return new ReactiveNeo4jRepositoryFactory(neo4jClient, neo4jMappingContext, new ReactiveNeo4jEvents(entityCallbacks));
 	}
 
 	@Override
@@ -82,12 +80,5 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 		super.setBeanFactory(beanFactory);
 
 		this.entityCallbacks = ReactiveEntityCallbacks.create(beanFactory);
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		super.setApplicationEventPublisher(publisher);
-
-		this.eventPublisher = publisher;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/config/Neo4jAuditingRegistrarTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/config/Neo4jAuditingRegistrarTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.AnnotationMetadata;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(MockitoExtension.class)
+class Neo4jAuditingRegistrarTest {
+
+	@Mock AnnotationMetadata metadata;
+	@Mock BeanDefinitionRegistry registry;
+
+	Neo4jAuditingRegistrar registrar = new Neo4jAuditingRegistrar();
+
+	@Test
+	public void rejectsNullAnnotationMetadata() {
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> registrar.registerBeanDefinitions(null, registry));
+	}
+
+	@Test
+	public void rejectsNullBeanDefinitionRegistry() {
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> registrar.registerBeanDefinitions(metadata, null));
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManagerTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManagerTest.java
@@ -97,7 +97,7 @@ class ReactiveNeo4jTransactionManagerTest {
 
 			transactionalOperator
 				.execute(transactionStatus -> TransactionSynchronizationManager
-					.currentTransaction().doOnNext(tsm -> {
+					.forCurrentTransaction().doOnNext(tsm -> {
 						assertThat(tsm.hasResource(driver)).isTrue();
 						transactionStatus.setRollbackOnly();
 					}).then(retrieveReactiveTransaction(driver, databaseName))
@@ -155,9 +155,9 @@ class ReactiveNeo4jTransactionManagerTest {
 
 			transactionalOperator
 				.execute(transactionStatus -> TransactionSynchronizationManager
-					.currentTransaction().doOnNext(tsm -> assertThat(tsm.hasResource(driver)).isFalse())
+					.forCurrentTransaction().doOnNext(tsm -> assertThat(tsm.hasResource(driver)).isFalse())
 					.then(retrieveReactiveTransaction(driver, databaseName))
-					.flatMap(ignoredNativeTx -> TransactionSynchronizationManager.currentTransaction()
+					.flatMap(ignoredNativeTx -> TransactionSynchronizationManager.forCurrentTransaction()
 						.doOnNext(tsm -> assertThat(tsm.hasResource(driver)).isTrue()))
 				)
 				.as(StepVerifier::create)
@@ -182,13 +182,13 @@ class ReactiveNeo4jTransactionManagerTest {
 
 			transactionalOperator
 				.execute(transactionStatus -> TransactionSynchronizationManager
-					.currentTransaction()
+					.forCurrentTransaction()
 					.doOnNext(tsm -> {
 						assertThat(tsm.hasResource(driver)).isFalse();
 						transactionStatus.setRollbackOnly();
 					})
 					.then(retrieveReactiveTransaction(driver, databaseName))
-					.flatMap(ignoredNativeTx -> TransactionSynchronizationManager.currentTransaction()
+					.flatMap(ignoredNativeTx -> TransactionSynchronizationManager.forCurrentTransaction()
 						.doOnNext(tsm -> assertThat(tsm.hasResource(driver)).isTrue()))
 				)
 				.as(StepVerifier::create)

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
+import org.neo4j.springframework.data.integration.shared.AuditingITBase;
+import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+@ContextConfiguration(classes = AuditingIT.Config.class)
+class AuditingIT extends AuditingITBase {
+
+	private final TestRepository thingRepository;
+
+	@Autowired
+	AuditingIT(TestRepository thingRepository, Driver driver) {
+		super(driver);
+		this.thingRepository = thingRepository;
+	}
+
+	@Test
+	void auditingOfCreationShouldWork() {
+
+		ImmutableAuditableThing thing = new ImmutableAuditableThing("A thing");
+		thing = thingRepository.save(thing);
+
+		assertThat(thing.getCreatedAt()).isEqualTo(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+		assertThat(thing.getCreatedBy()).isEqualTo("A user");
+
+		assertThat(thing.getModifiedAt()).isNull();
+		assertThat(thing.getModifiedBy()).isNull();
+
+		verifyDatabase(thing.getId(), thing);
+	}
+
+	@Test
+	void auditingOfModificationShouldWork() {
+
+		ImmutableAuditableThing thing = thingRepository.findById(idOfExistingThing).get();
+		thing = thing.withName("A new name");
+		thing = thingRepository.save(thing);
+
+		assertThat(thing.getCreatedAt()).isEqualTo(EXISTING_THING_CREATED_AT);
+		assertThat(thing.getCreatedBy()).isEqualTo(EXISTING_THING_CREATED_BY);
+
+		assertThat(thing.getModifiedAt()).isEqualTo(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+		assertThat(thing.getModifiedBy()).isEqualTo("A user");
+
+		assertThat(thing.getName()).isEqualTo("A new name");
+
+		verifyDatabase(idOfExistingThing, thing);
+	}
+
+	public interface TestRepository extends CrudRepository<ImmutableAuditableThing, Long> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	@EnableNeo4jAuditing(modifyOnCreate = false, auditorAwareRef = "auditorProvider", dateTimeProviderRef = "fixedDateTimeProvider")
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ImmutableAuditableThing.class.getPackage().getName());
+		}
+
+		@Bean
+		public AuditorAware<String> auditorProvider() {
+			return () -> Optional.of("A user");
+		}
+
+		@Bean
+		public DateTimeProvider fixedDateTimeProvider() {
+			return () -> Optional.of(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
@@ -25,14 +25,12 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.driver.Driver;
 import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
 import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
 import org.neo4j.springframework.data.integration.shared.AuditingITBase;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
-import org.neo4j.springframework.data.test.Neo4jExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,14 +38,11 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
  * @author Michael J. Simons
  */
-@ExtendWith(SpringExtension.class)
-@ExtendWith(Neo4jExtension.class)
 @ContextConfiguration(classes = AuditingIT.Config.class)
 class AuditingIT extends AuditingITBase {
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/CallbacksIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/CallbacksIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Node;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.ThingWithAssignedId;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.repository.event.BeforeBindCallback;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.neo4j.springframework.data.test.Neo4jExtension.Neo4jConnectionSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+@ContextConfiguration(classes = CallbacksIT.Config.class)
+class CallbacksIT {
+
+	private static Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final ThingRepository thingRepository;
+	private final Driver driver;
+
+	@Autowired CallbacksIT(ThingRepository thingRepository, Driver driver) {
+
+		this.thingRepository = thingRepository;
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	void setupData() {
+
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			transaction.success();
+		}
+	}
+
+	@Test
+	void onBeforeBindShouldBeCalledForSingleEntity() {
+
+		ThingWithAssignedId thing = new ThingWithAssignedId("aaBB");
+		thing.setName("A name");
+		thing = thingRepository.save(thing);
+
+		assertThat(thing.getName()).isEqualTo("A name (Edited)");
+
+		try (Session session = driver.session()) {
+			Record record = session
+				.run("MATCH (n:Thing) WHERE n.theId = $id RETURN n", Values.parameters("id", thing.getTheId()))
+				.single();
+
+			assertThat(record.containsKey("n")).isTrue();
+			Node node = record.get("n").asNode();
+			assertThat(node.get("theId").asString()).isEqualTo(thing.getTheId());
+			assertThat(node.get("name").asString()).isEqualTo("A name (Edited)");
+		}
+	}
+
+	@Test
+	void onBeforeBindShouldBeCalledForAllEntities() {
+
+		ThingWithAssignedId thing1 = new ThingWithAssignedId("id1");
+		thing1.setName("A name");
+		ThingWithAssignedId thing2 = new ThingWithAssignedId("id2");
+		thing2.setName("Another name");
+		Iterable<ThingWithAssignedId> savedThings = thingRepository.saveAll(Arrays.asList(thing1, thing2));
+
+		assertThat(savedThings).extracting(ThingWithAssignedId::getName)
+			.containsExactlyInAnyOrder("A name (Edited)", "Another name (Edited)");
+
+		try (Session session = driver.session()) {
+			Record record = session
+				.run("MATCH (n:Thing) WHERE n.theId in $ids RETURN COLLECT(n.name) as names",
+					Values.parameters("ids", Arrays.asList("id1", "id2")))
+				.single();
+
+			List<String> names = record.get("names").asList(Value::asString);
+			assertThat(names)
+				.hasSize(2)
+				.containsExactlyInAnyOrder("A name (Edited)", "Another name (Edited)");
+		}
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		BeforeBindCallback<ThingWithAssignedId> nameChanger() {
+			return entity -> {
+				ThingWithAssignedId updatedThing = new ThingWithAssignedId(entity.getTheId());
+				updatedThing.setName(entity.getName() + " (Edited)");
+				return updatedThing;
+			};
+		}
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ThingWithAssignedId.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
+import org.neo4j.springframework.data.integration.shared.AuditingITBase;
+import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+@ContextConfiguration(classes = ReactiveAuditingIT.Config.class)
+class ReactiveAuditingIT extends AuditingITBase {
+
+	private final ReactiveTransactionManager transactionManager;
+	private final ReactiveTestRepository thingRepository;
+
+	@Autowired
+	ReactiveAuditingIT(ReactiveTransactionManager transactionManager, ReactiveTestRepository thingRepository,
+		Driver driver) {
+		super(driver);
+		this.thingRepository = thingRepository;
+		this.transactionManager = transactionManager;
+	}
+
+	@Test
+	void auditingOfCreationShouldWork() {
+
+		List<ImmutableAuditableThing> newThings = new ArrayList<>();
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> thingRepository.save(new ImmutableAuditableThing("A thing")))
+			.as(StepVerifier::create)
+			.recordWith(() -> newThings)
+			.expectNextCount(1L)
+			.verifyComplete();
+
+		ImmutableAuditableThing savedThing = newThings.get(0);
+		assertThat(savedThing.getCreatedAt()).isEqualTo(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+		assertThat(savedThing.getCreatedBy()).isEqualTo("A user");
+
+		assertThat(savedThing.getModifiedAt()).isNull();
+		assertThat(savedThing.getModifiedBy()).isNull();
+
+		verifyDatabase(savedThing.getId(), savedThing);
+	}
+
+	@Test
+	void auditingOfModificationShouldWork() {
+
+		Mono<ImmutableAuditableThing> findAndUpdateAThing = thingRepository.findById(idOfExistingThing)
+			.flatMap(thing -> thingRepository.save(thing.withName("A new name")));
+
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> findAndUpdateAThing)
+			.as(StepVerifier::create)
+			.consumeNextWith(savedThing -> {
+
+				assertThat(savedThing.getCreatedAt()).isEqualTo(EXISTING_THING_CREATED_AT);
+				assertThat(savedThing.getCreatedBy()).isEqualTo(EXISTING_THING_CREATED_BY);
+
+				assertThat(savedThing.getModifiedAt()).isEqualTo(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+				assertThat(savedThing.getModifiedBy()).isEqualTo("A user");
+
+				assertThat(savedThing.getName()).isEqualTo("A new name");
+			})
+			.verifyComplete();
+
+		// Need to happen outside the reactive flow, as we use the blocking session to verify the database
+		verifyDatabase(idOfExistingThing,
+			new ImmutableAuditableThing(null, EXISTING_THING_CREATED_AT, EXISTING_THING_CREATED_BY,
+				DEFAULT_CREATION_AND_MODIFICATION_DATE, "A user", "A new name"));
+	}
+
+	public interface ReactiveTestRepository extends ReactiveCrudRepository<ImmutableAuditableThing, Long> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	@EnableNeo4jAuditing(modifyOnCreate = false, auditorAwareRef = "auditorProvider", dateTimeProviderRef = "fixedDateTimeProvider")
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ImmutableAuditableThing.class.getPackage().getName());
+		}
+
+		@Bean
+		public AuditorAware<String> auditorProvider() {
+			return () -> Optional.of("A user");
+		}
+
+		@Bean
+		public DateTimeProvider fixedDateTimeProvider() {
+			return () -> Optional.of(DEFAULT_CREATION_AND_MODIFICATION_DATE);
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
@@ -30,14 +30,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.driver.Driver;
 import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
 import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
 import org.neo4j.springframework.data.integration.shared.AuditingITBase;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
 import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
-import org.neo4j.springframework.data.test.Neo4jExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +43,6 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -53,8 +50,6 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 /**
  * @author Michael J. Simons
  */
-@ExtendWith(SpringExtension.class)
-@ExtendWith(Neo4jExtension.class)
 @ContextConfiguration(classes = ReactiveAuditingIT.Config.class)
 class ReactiveAuditingIT extends AuditingITBase {
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveCallbacksIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveCallbacksIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static org.neo4j.driver.Values.*;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.ThingWithAssignedId;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.neo4j.springframework.data.repository.event.ReactiveBeforeBindCallback;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+@ContextConfiguration(classes = ReactiveCallbacksIT.Config.class)
+class ReactiveCallbacksIT {
+
+	private static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final ReactiveTransactionManager transactionManager;
+	private final ReactiveThingRepository thingRepository;
+	private final Driver driver;
+
+	@Autowired
+	ReactiveCallbacksIT(ReactiveTransactionManager transactionManager,
+		ReactiveThingRepository thingRepository, Driver driver) {
+
+		this.transactionManager = transactionManager;
+		this.thingRepository = thingRepository;
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	void setupData() {
+
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			transaction.success();
+		}
+	}
+
+	@Test
+	void onBeforeBindShouldBeCalledForSingleEntity() {
+
+		ThingWithAssignedId thing = new ThingWithAssignedId("aaBB");
+		thing.setName("A name");
+
+		Mono<ThingWithAssignedId> operationUnderTest = Mono.just(thing).flatMap(thingRepository::save);
+
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> operationUnderTest)
+			.map(ThingWithAssignedId::getName)
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.verifyComplete();
+
+		Flux
+			.usingWhen(
+				Mono.fromSupplier(() -> driver.rxSession()),
+				s -> s.run("MATCH (n:Thing) WHERE n.theId = $id RETURN n", parameters("id", "aaBB")).records(),
+				RxSession::close
+			)
+			.map(r -> r.get("n").asNode().get("name").asString())
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.verifyComplete();
+	}
+
+	@Test
+	void onBeforeBindShouldBeCalledForAllEntitiesUsingIterable() {
+
+		ThingWithAssignedId thing1 = new ThingWithAssignedId("id1");
+		thing1.setName("A name");
+		ThingWithAssignedId thing2 = new ThingWithAssignedId("id2");
+		thing2.setName("Another name");
+		thingRepository.saveAll(Arrays.asList(thing1, thing2));
+
+		Flux<ThingWithAssignedId> operationUnderTest = thingRepository.saveAll(Arrays.asList(thing1, thing2));
+
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> operationUnderTest)
+			.map(ThingWithAssignedId::getName)
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.expectNext("Another name (Edited)")
+			.verifyComplete();
+
+		Flux
+			.usingWhen(
+				Mono.fromSupplier(() -> driver.rxSession()),
+				s -> {
+					Value parameters = parameters("ids", Arrays.asList("id1", "id2"));
+					return s.run("MATCH (n:Thing) WHERE n.theId IN ($ids) RETURN n.name as name ORDER BY n.name ASC",
+						parameters)
+						.records();
+				},
+				RxSession::close
+			)
+			.map(r -> r.get("name").asString())
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.expectNext("Another name (Edited)")
+			.verifyComplete();
+	}
+
+	@Test
+	void onBeforeBindShouldBeCalledForAllEntitiesUsingPublisher() {
+
+		ThingWithAssignedId thing1 = new ThingWithAssignedId("id1");
+		thing1.setName("A name");
+		ThingWithAssignedId thing2 = new ThingWithAssignedId("id2");
+		thing2.setName("Another name");
+		thingRepository.saveAll(Arrays.asList(thing1, thing2));
+
+		Flux<ThingWithAssignedId> operationUnderTest = thingRepository.saveAll(Flux.just(thing1, thing2));
+
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> operationUnderTest)
+			.map(ThingWithAssignedId::getName)
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.expectNext("Another name (Edited)")
+			.verifyComplete();
+
+		Flux
+			.usingWhen(
+				Mono.fromSupplier(() -> driver.rxSession()),
+				s -> {
+					Value parameters = parameters("ids", Arrays.asList("id1", "id2"));
+					return s.run("MATCH (n:Thing) WHERE n.theId IN ($ids) RETURN n.name as name ORDER BY n.name ASC",
+						parameters)
+						.records();
+				},
+				RxSession::close
+			)
+			.map(r -> r.get("name").asString())
+			.as(StepVerifier::create)
+			.expectNext("A name (Edited)")
+			.expectNext("Another name (Edited)")
+			.verifyComplete();
+	}
+
+	@Configuration
+	@EnableReactiveNeo4jRepositories
+	@EnableTransactionManagement
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		ReactiveBeforeBindCallback<ThingWithAssignedId> nameChanger() {
+			return entity -> {
+				ThingWithAssignedId updatedThing = new ThingWithAssignedId(entity.getTheId());
+				updatedThing.setName(entity.getName() + " (Edited)");
+				return Mono.just(updatedThing);
+			};
+		}
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ThingWithAssignedId.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditingITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditingITBase.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
@@ -30,12 +31,15 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.Node;
 import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Shared information for both imperative and reactive auditing tests.
  *
  * @author Michael J. Simons
  */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
 public abstract class AuditingITBase {
 	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
 
@@ -48,7 +52,7 @@ public abstract class AuditingITBase {
 
 	protected Long idOfExistingThing;
 
-	public AuditingITBase(Driver driver) {
+	protected AuditingITBase(Driver driver) {
 		this.driver = driver;
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditingITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditingITBase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Node;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+
+/**
+ * Shared information for both imperative and reactive auditing tests.
+ *
+ * @author Michael J. Simons
+ */
+public abstract class AuditingITBase {
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	protected static final String EXISTING_THING_NAME = "An old name";
+	protected static final String EXISTING_THING_CREATED_BY = "The creator";
+	protected static final LocalDateTime EXISTING_THING_CREATED_AT = LocalDateTime.of(2013, 5, 6, 8, 0);
+	protected static final LocalDateTime DEFAULT_CREATION_AND_MODIFICATION_DATE = LocalDateTime.of(2018, 7, 1, 8, 0);
+
+	private final Driver driver;
+
+	protected Long idOfExistingThing;
+
+	public AuditingITBase(Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	protected void setupData() {
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			idOfExistingThing = transaction
+				.run(
+					"CREATE (t:ImmutableAuditableThing {name: $name, createdBy: $createdBy, createdAt: $createdAt}) RETURN id(t) as id",
+					Values.parameters("name", EXISTING_THING_NAME, "createdBy", EXISTING_THING_CREATED_BY, "createdAt",
+						EXISTING_THING_CREATED_AT))
+				.single().get("id").asLong();
+
+			transaction.success();
+		}
+	}
+
+	protected void verifyDatabase(long id, ImmutableAuditableThing expectedValues) {
+
+		try (Session session = driver.session()) {
+			Node node = session
+				.run("MATCH (t:ImmutableAuditableThing) WHERE id(t) = $id RETURN t", Values.parameters("id", id))
+				.single().get("t").asNode();
+
+			assertThat(node.get("name").asString()).isEqualTo(expectedValues.getName());
+			assertThat(node.get("createdAt").asLocalDateTime()).isEqualTo(expectedValues.getCreatedAt());
+			assertThat(node.get("createdBy").asString()).isEqualTo(expectedValues.getCreatedBy());
+
+			Value modifiedAt = node.get("modifiedAt");
+			Value modifiedBy = node.get("modifiedBy");
+
+			if (expectedValues.getModifiedAt() == null) {
+				assertThat(modifiedAt.isNull()).isTrue();
+			} else {
+				assertThat(modifiedAt.asLocalDateTime()).isEqualTo(expectedValues.getModifiedAt());
+			}
+
+			if (expectedValues.getModifiedBy() == null) {
+				assertThat(modifiedBy.isNull()).isTrue();
+			} else {
+				assertThat(modifiedBy.asString()).isEqualTo(expectedValues.getModifiedBy());
+			}
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/CallbacksITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/CallbacksITBase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import static java.util.stream.Collectors.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Node;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Shared information for both imperative and reactive callbacks tests.
+ *
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+public abstract class CallbacksITBase {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	private final Driver driver;
+
+	protected CallbacksITBase(Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	protected void setupData() {
+
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			transaction.success();
+		}
+	}
+
+	protected void verifyDatabase(Iterable<ThingWithAssignedId> expectedValues) {
+
+		List<String> ids = StreamSupport.stream(expectedValues.spliterator(), false)
+			.map(ThingWithAssignedId::getTheId).collect(toList());
+		List<String> names = StreamSupport.stream(expectedValues.spliterator(), false)
+			.map(ThingWithAssignedId::getName).collect(toList());
+		try (Session session = driver.session()) {
+			Record record = session
+				.run("MATCH (n:Thing) WHERE n.theId in $ids RETURN COLLECT(n) as things", Values.parameters("ids", ids))
+				.single();
+
+			List<Node> nodes = record.get("things").asList(Value::asNode);
+			assertThat(nodes).extracting(n -> n.get("theId").asString()).containsAll(ids);
+			assertThat(nodes).extracting(n -> n.get("name").asString())
+				.containsAll(names);
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Wither;
+
+import java.time.LocalDateTime;
+
+import org.neo4j.springframework.data.core.schema.Node;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.PersistenceConstructor;
+
+/**
+ * @author Michael J. Simons
+ */
+@Value
+@Wither
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@Node
+public class ImmutableAuditableThing {
+
+	@Id Long id;
+	@CreatedDate LocalDateTime createdAt;
+	@CreatedBy String createdBy;
+	@LastModifiedDate LocalDateTime modifiedAt;
+	@LastModifiedBy String modifiedBy;
+
+	String name;
+
+	public ImmutableAuditableThing(String name) {
+		this(null, null, null, null, null, name);
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallbackTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/AuditingBeforeBindCallbackTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.springframework.core.Ordered;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.context.PersistentEntities;
+
+/**
+ * @author Michael J. Simons
+ */
+class AuditingBeforeBindCallbackTest {
+
+	IsNewAwareAuditingHandler spyOnHandler;
+
+	AuditingBeforeBindCallback callback;
+
+	@BeforeEach
+	public void setUp() {
+
+		Neo4jMappingContext mappingContext = new Neo4jMappingContext();
+		mappingContext.setInitialEntitySet(new HashSet<>(Arrays.asList(Sample.class, ImmutableSample.class)));
+		mappingContext.initialize();
+
+		IsNewAwareAuditingHandler originalHandler = new IsNewAwareAuditingHandler(
+			new PersistentEntities(Arrays.asList(mappingContext)));
+		spyOnHandler = spy(originalHandler);
+		callback = new AuditingBeforeBindCallback(() -> spyOnHandler);
+	}
+
+	@Test
+	void rejectsNullAuditingHandler() {
+
+		assertThatIllegalArgumentException().isThrownBy(() -> new AuditingBeforeBindCallback(null));
+	}
+
+	@Test
+	void triggersCreationMarkForObjectWithEmptyId() {
+
+		Sample sample = new Sample();
+		sample = (Sample) callback.onBeforeBind(sample);
+		assertThat(sample.created).isNotNull();
+		assertThat(sample.modified).isNotNull();
+
+		verify(spyOnHandler, times(1)).markCreated(sample);
+		verify(spyOnHandler, times(0)).markModified(any());
+	}
+
+	@Test
+	void triggersModificationMarkForObjectWithSetId() {
+
+		Sample sample = new Sample();
+		sample.id = "id";
+		sample.version = 1L;
+		sample = (Sample) callback.onBeforeBind(sample);
+		assertThat(sample.created).isNull();
+		assertThat(sample.modified).isNotNull();
+
+		verify(spyOnHandler, times(0)).markCreated(any());
+		verify(spyOnHandler, times(1)).markModified(sample);
+	}
+
+	@Test
+	void hasExplicitOrder() {
+
+		assertThat(callback).isInstanceOf(Ordered.class);
+		assertThat(callback.getOrder()).isEqualTo(100);
+	}
+
+	@Test
+	void propagatesChangedInstanceToEvent() {
+
+		ImmutableSample sample = new ImmutableSample();
+
+		ImmutableSample newSample = new ImmutableSample();
+		IsNewAwareAuditingHandler handler = mock(IsNewAwareAuditingHandler.class);
+		doReturn(newSample).when(handler).markAudited(eq(sample));
+
+		Object result = new AuditingBeforeBindCallback(() -> handler).onBeforeBind(sample);
+
+		assertThat(result).isSameAs(newSample);
+	}
+
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import static org.neo4j.springframework.data.core.schema.Id.Strategy.*;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Wither;
+
+import java.util.Date;
+
+import org.neo4j.springframework.data.core.schema.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+/**
+ * @author Michael J. Simons
+ */
+@Value
+@Wither
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class ImmutableSample {
+
+	@Id(strategy = ASSIGNED) String id;
+	@CreatedDate Date created;
+	@LastModifiedDate Date modified;
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallbackTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallbackTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.springframework.core.Ordered;
+import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.mapping.context.PersistentEntities;
+
+/**
+ * @author Michael J. Simons
+ */
+class ReactiveAuditingBeforeBindCallbackTest {
+
+	IsNewAwareAuditingHandler spyOnHandler;
+
+	ReactiveAuditingBeforeBindCallback callback;
+
+	@BeforeEach
+	public void setUp() {
+
+		Neo4jMappingContext mappingContext = new Neo4jMappingContext();
+		mappingContext.setInitialEntitySet(new HashSet<>(Arrays.asList(Sample.class, ImmutableSample.class)));
+		mappingContext.initialize();
+
+		IsNewAwareAuditingHandler originalHandler = new IsNewAwareAuditingHandler(
+			new PersistentEntities(Arrays.asList(mappingContext)));
+		spyOnHandler = spy(originalHandler);
+		callback = new ReactiveAuditingBeforeBindCallback(() -> spyOnHandler);
+	}
+
+	@Test
+	void rejectsNullAuditingHandler() {
+
+		assertThatIllegalArgumentException().isThrownBy(() -> new ReactiveAuditingBeforeBindCallback(null));
+	}
+
+	@Test
+	void triggersCreationMarkForObjectWithEmptyId() {
+
+		Sample sample = new Sample();
+		StepVerifier
+			.create(callback.onBeforeBind(sample))
+			.expectNextMatches(s -> {
+				Sample auditedObject = (Sample) s;
+				return auditedObject.created != null && auditedObject.modified != null;
+			});
+
+		verify(spyOnHandler, times(1)).markCreated(sample);
+		verify(spyOnHandler, times(0)).markModified(any());
+	}
+
+	@Test
+	void triggersModificationMarkForObjectWithSetId() {
+
+		Sample sample = new Sample();
+		sample.id = "id";
+		sample.version = 1L;
+
+		StepVerifier
+			.create(callback.onBeforeBind(sample))
+			.expectNextMatches(s -> {
+				Sample auditedObject = (Sample) s;
+				return auditedObject.created == null && auditedObject.modified != null;
+			});
+
+		verify(spyOnHandler, times(0)).markCreated(any());
+		verify(spyOnHandler, times(1)).markModified(sample);
+	}
+
+	@Test
+	void hasExplicitOrder() {
+
+		assertThat(callback).isInstanceOf(Ordered.class);
+		assertThat(callback.getOrder()).isEqualTo(100);
+	}
+
+	@Test
+	void propagatesChangedInstanceToEvent() {
+
+		ImmutableSample sample = new ImmutableSample();
+
+		ImmutableSample newSample = new ImmutableSample();
+		IsNewAwareAuditingHandler handler = mock(IsNewAwareAuditingHandler.class);
+		doReturn(newSample).when(handler).markAudited(eq(sample));
+
+		ReactiveAuditingBeforeBindCallback localCallback = new ReactiveAuditingBeforeBindCallback(() -> handler);
+		StepVerifier.create(localCallback.onBeforeBind(sample)).expectNext(newSample);
+	}
+
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/Sample.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/Sample.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import static org.neo4j.springframework.data.core.schema.Id.Strategy.*;
+
+import java.util.Date;
+
+import org.neo4j.springframework.data.core.schema.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Version;
+
+/**
+ * @author Michael J. Simons
+ */
+class Sample {
+
+	@Id(strategy = ASSIGNED) String id;
+	@Version Long version;
+	@CreatedDate Date created;
+	@LastModifiedDate Date modified;
+}


### PR DESCRIPTION
As usual, I tried to find some coherent commits of what I have done.

I have introduced new helper classes to call callbacks in case there are any, one basic callback interface to be called before an entity get's bound to a map (record) and first usage of it in form of the auditing support.

Update to 2.2.0 is necessary to support callbacks (in contrast to the event system, which doesn't work with reactive infrastructure).

The auditing support contains the necessary annotation and config registrar. 

I'm looking forward to your polishing :)