### PR TITLE
Improved Id-Annotation and add support for externally generated ids.

### DIFF
--- a/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/Author.java
+++ b/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/Author.java
@@ -18,13 +18,14 @@
  */
 package org.neo4j.springframework.data.examples.references_and_aggregates.books;
 
-import org.springframework.data.annotation.Id;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
 
 /**
  * @author Michael J. Simons
  */
 public class Author {
-	@Id
+	@Id @GeneratedValue
 	private Long id;
 	private final String name;
 

--- a/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/Book.java
+++ b/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/Book.java
@@ -21,14 +21,15 @@ package org.neo4j.springframework.data.examples.references_and_aggregates.books;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.springframework.data.annotation.Id;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
 import org.springframework.util.Assert;
 
 /**
  * @author Michael J. Simons
  */
 public class Book {
-	@Id
+	@Id @GeneratedValue
 	private Long id;
 
 	private final String title;

--- a/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/PurchaseOrder.java
+++ b/examples/mapping/src/main/java/org/neo4j/springframework/data/examples/references_and_aggregates/books/PurchaseOrder.java
@@ -21,13 +21,14 @@ package org.neo4j.springframework.data.examples.references_and_aggregates.books;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.springframework.data.annotation.Id;
 
 /**
  * @author Michael J. Simons
  */
 public class PurchaseOrder {
-	@Id
+	@Id @GeneratedValue
 	private Long id;
 	private final String shippingAddress;
 	private final Set<OrderItem> items = new HashSet<>();

--- a/examples/reactive-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieEntity.java
+++ b/examples/reactive-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieEntity.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.examples.spring_boot.domain;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.Property;
@@ -28,7 +29,7 @@ import org.neo4j.springframework.data.core.schema.Property;
 @Node("Movie")
 public class MovieEntity {
 
-	@Id
+	@Id @GeneratedValue
 	private final Long id;
 
 	private final String title;

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j_rx/bikes/BikeNode.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j_rx/bikes/BikeNode.java
@@ -18,7 +18,8 @@
  */
 package org.springframework.boot.autoconfigure.data.neo4j_rx.bikes;
 
-import org.springframework.data.annotation.Id;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 
 /**
@@ -27,7 +28,7 @@ import org.neo4j.springframework.data.core.schema.Node;
 @Node
 public class BikeNode {
 
-	@Id
+	@Id @GeneratedValue
 	private Long id;
 
 	private String name;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategy.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategy.java
@@ -20,7 +20,7 @@ package org.neo4j.springframework.data.core.mapping;
 
 import java.util.function.Function;
 
-import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.support.IsNewStrategy;
@@ -54,17 +54,17 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 
 		Assert.notNull(entityMetaData, "Entity meta data must not be null.");
 
-		Id.Strategy idStrategy = entityMetaData.getIdDescription().getIdStrategy();
+		IdDescription idDescription = entityMetaData.getIdDescription();
 		Class<?> valueType = entityMetaData.getRequiredIdProperty().getType();
 
-		if (idStrategy == Id.Strategy.EXTERNALLY_GENERATED && valueType.isPrimitive()) {
+		if (idDescription.idIsGeneratedExternally() && valueType.isPrimitive()) {
 			throw new IllegalArgumentException(String.format("Cannot use %s with externally generated, primitive ids.",
 				DefaultNeo4jIsNewStrategy.class.getName()));
 		}
 
 		Function<Object, Object> valueLookup;
 		Neo4jPersistentProperty versionProperty = entityMetaData.getVersionProperty();
-		if (idStrategy == Id.Strategy.ASSIGNED) {
+		if (idDescription.idIsAssigned()) {
 			if (versionProperty == null) {
 				log.warn("Instances of " + entityMetaData.getType()
 					+ " with an assigned id will always be treated as new without version property!");
@@ -78,17 +78,18 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 			valueLookup = source -> entityMetaData.getIdentifierAccessor(source).getIdentifier();
 		}
 
-		return new DefaultNeo4jIsNewStrategy(idStrategy, valueType, valueLookup);
+		return new DefaultNeo4jIsNewStrategy(idDescription, valueType, valueLookup);
 	}
 
-	private final Id.Strategy strategy;
+	private final IdDescription idDescription;
 
 	private final Class<?> valueType;
 
 	private @Nullable final Function<Object, Object> valueLookup;
 
-	private DefaultNeo4jIsNewStrategy(Id.Strategy strategy, Class<?> valueType, Function<Object, Object> valueLookup) {
-		this.strategy = strategy;
+	private DefaultNeo4jIsNewStrategy(IdDescription idDescription, Class<?> valueType,
+		Function<Object, Object> valueLookup) {
+		this.idDescription = idDescription;
 		this.valueType = valueType;
 		this.valueLookup = valueLookup;
 	}
@@ -101,7 +102,7 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 	public boolean isNew(Object entity) {
 
 		Object value = valueLookup.apply(entity);
-		if (strategy.isInternal()) {
+		if (idDescription.idIsGeneratedInternally()) {
 
 			boolean isNew = false;
 			if (value != null && valueType.isPrimitive() && Number.class.isInstance(value)) {
@@ -111,9 +112,9 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 			}
 
 			return isNew;
-		} else if (strategy == Id.Strategy.EXTERNALLY_GENERATED) {
+		} else if (idDescription.idIsGeneratedExternally()) {
 			return value == null;
-		} else if (strategy == Id.Strategy.ASSIGNED) {
+		} else if (idDescription.idIsAssigned()) {
 			if (valueType != null && !valueType.isPrimitive()) {
 				return value == null;
 			}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategy.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategy.java
@@ -57,14 +57,14 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 		IdDescription idDescription = entityMetaData.getIdDescription();
 		Class<?> valueType = entityMetaData.getRequiredIdProperty().getType();
 
-		if (idDescription.idIsGeneratedExternally() && valueType.isPrimitive()) {
+		if (idDescription.isExternallyGeneratedId() && valueType.isPrimitive()) {
 			throw new IllegalArgumentException(String.format("Cannot use %s with externally generated, primitive ids.",
 				DefaultNeo4jIsNewStrategy.class.getName()));
 		}
 
 		Function<Object, Object> valueLookup;
 		Neo4jPersistentProperty versionProperty = entityMetaData.getVersionProperty();
-		if (idDescription.idIsAssigned()) {
+		if (idDescription.isAssignedId()) {
 			if (versionProperty == null) {
 				log.warn("Instances of " + entityMetaData.getType()
 					+ " with an assigned id will always be treated as new without version property!");
@@ -102,7 +102,7 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 	public boolean isNew(Object entity) {
 
 		Object value = valueLookup.apply(entity);
-		if (idDescription.idIsGeneratedInternally()) {
+		if (idDescription.isInternallyGeneratedId()) {
 
 			boolean isNew = false;
 			if (value != null && valueType.isPrimitive() && Number.class.isInstance(value)) {
@@ -112,9 +112,9 @@ class DefaultNeo4jIsNewStrategy implements IsNewStrategy {
 			}
 
 			return isNew;
-		} else if (idDescription.idIsGeneratedExternally()) {
+		} else if (idDescription.isExternallyGeneratedId()) {
 			return value == null;
-		} else if (idDescription.idIsAssigned()) {
+		} else if (idDescription.isAssignedId()) {
 			if (valueType != null && !valueType.isPrimitive()) {
 				return value == null;
 			}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -128,7 +128,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		Assert.notNull(this.getIdDescription(), "An entity is required to describe its id property.");
 	}
 
-	String computePrimaryLabel() {
+	private String computePrimaryLabel() {
 
 		Node nodeAnnotation = this.findAnnotation(Node.class);
 		if (nodeAnnotation == null || nodeAnnotation.labels().length != 1) {
@@ -138,7 +138,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		}
 	}
 
-	IdDescription computeIdDescription() {
+	private IdDescription computeIdDescription() {
 
 		Neo4jPersistentProperty idProperty = this.getRequiredIdProperty();
 		GeneratedValue generatedValueAnnotation = idProperty.findAnnotation(GeneratedValue.class);
@@ -169,7 +169,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 				generatedValueAnnotation.generatorRef(), idProperty.getPropertyName());
 	}
 
-	Collection<GraphPropertyDescription> computeGraphProperties() {
+	private Collection<GraphPropertyDescription> computeGraphProperties() {
 
 		final List<GraphPropertyDescription> computedGraphProperties = new ArrayList<>();
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -149,7 +149,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		}
 
 		// Internally generated ids.
-		if (generatedValueAnnotation.generatorClass() == GeneratedValue.InternalIdGenerator.class) {
+		if (generatedValueAnnotation.generatorClass() == GeneratedValue.InternalIdGenerator.class && generatedValueAnnotation.generatorRef().isEmpty()) {
 			if (idProperty.findAnnotation(Property.class) != null) {
 				throw new IllegalArgumentException(
 					"Cannot use internal id strategy with custom property " + idProperty.getPropertyName()
@@ -165,7 +165,8 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 
 		// Externally generated ids.
 		return IdDescription
-			.forExternallyGeneratedIds(generatedValueAnnotation.generatorClass(), idProperty.getPropertyName());
+			.forExternallyGeneratedIds(generatedValueAnnotation.generatorClass(),
+				generatedValueAnnotation.generatorRef(), idProperty.getPropertyName());
 	}
 
 	Collection<GraphPropertyDescription> computeGraphProperties() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.springframework.core.annotation.AnnotatedElementUtils;
-import org.springframework.data.mapping.model.BasicPersistentEntity;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
-import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.Property;
+import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.support.IsNewStrategy;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.TypeInformation;
@@ -141,28 +140,32 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 
 	IdDescription computeIdDescription() {
 
-		final Neo4jPersistentProperty idProperty = this.getRequiredIdProperty();
-		final Optional<Id> optionalIdAnnotation = Optional
-			.ofNullable(AnnotatedElementUtils.findMergedAnnotation(idProperty.getField(), Id.class));
-		return optionalIdAnnotation
-			.map(idAnnotation -> {
+		Neo4jPersistentProperty idProperty = this.getRequiredIdProperty();
+		GeneratedValue generatedValueAnnotation = idProperty.findAnnotation(GeneratedValue.class);
 
-				if (idAnnotation.strategy() == Id.Strategy.INTERNALLY_GENERATED) {
-					if (idProperty.findAnnotation(Property.class) != null) {
-						throw new IllegalArgumentException(
-							"Cannot use internal id strategy with custom property " + idProperty.getPropertyName()
-								+ " on entity class " + this.getUnderlyingClass().getName());
-					}
+		// Assigned ids
+		if (generatedValueAnnotation == null) {
+			return IdDescription.forAssignedIds(idProperty.getPropertyName());
+		}
 
-					if (!VALID_GENERATED_ID_TYPES.contains(idProperty.getActualType())) {
-						throw new IllegalArgumentException("Internally generated ids can only be assigned to one of " + VALID_GENERATED_ID_TYPES);
-					}
-				}
+		// Internally generated ids.
+		if (generatedValueAnnotation.generatorClass() == GeneratedValue.InternalIdGenerator.class) {
+			if (idProperty.findAnnotation(Property.class) != null) {
+				throw new IllegalArgumentException(
+					"Cannot use internal id strategy with custom property " + idProperty.getPropertyName()
+						+ " on entity class " + this.getUnderlyingClass().getName());
+			}
 
-				return new IdDescription(idAnnotation.strategy(), idAnnotation.generator(),
-					idAnnotation.strategy() == Id.Strategy.INTERNALLY_GENERATED ? null : idProperty.getPropertyName());
-			})
-			.orElseGet(() -> new IdDescription());
+			if (!VALID_GENERATED_ID_TYPES.contains(idProperty.getActualType())) {
+				throw new IllegalArgumentException("Internally generated ids can only be assigned to one of " + VALID_GENERATED_ID_TYPES);
+			}
+
+			return IdDescription.forInternallyGeneratedIds();
+		}
+
+		// Externally generated ids.
+		return IdDescription
+			.forExternallyGeneratedIds(generatedValueAnnotation.generatorClass(), idProperty.getPropertyName());
 	}
 
 	Collection<GraphPropertyDescription> computeGraphProperties() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -32,10 +32,12 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.types.TypeSystem;
+import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.IdGenerator;
 import org.neo4j.springframework.data.core.schema.Neo4jSimpleTypes;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
@@ -43,6 +45,15 @@ import org.neo4j.springframework.data.core.schema.Relationship;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.neo4j.springframework.data.core.schema.Schema;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
@@ -50,6 +61,7 @@ import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
 
 /**
  * An implementation of both a {@link Schema} as well as a Neo4j version of Spring Datas
@@ -61,7 +73,8 @@ import org.springframework.data.util.TypeInformation;
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
 public final class Neo4jMappingContext
-	extends AbstractMappingContext<Neo4jPersistentEntity<?>, Neo4jPersistentProperty> implements Schema {
+	extends AbstractMappingContext<Neo4jPersistentEntity<?>, Neo4jPersistentProperty> implements Schema,
+	BeanDefinitionRegistryPostProcessor {
 
 	/**
 	 * The shared entity instantiators of this context. Those should not be recreated for each entity or even not for
@@ -79,9 +92,11 @@ public final class Neo4jMappingContext
 	private final ConcurrentMap<String, Collection<RelationshipDescription>> relationshipsByPrimaryLabel = new ConcurrentHashMap<>();
 
 	/**
-	 * The known and loaded ID generators.
+	 * A map of fallback id generators, that have not been added to the application context
 	 */
-	private final Map<Class<? extends IdGenerator>, IdGenerator> idGenerators = new HashMap<>();
+	private final Map<Class<? extends IdGenerator<?>>, IdGenerator<?>> fallbackIdGenerators = new ConcurrentHashMap<>();
+
+	private @Nullable ListableBeanFactory beanFactory;
 
 	public Neo4jMappingContext() {
 		super.setSimpleTypeHolder(Neo4jSimpleTypes.SIMPLE_TYPE_HOLDER);
@@ -214,7 +229,56 @@ public final class Neo4jMappingContext
 	}
 
 	@Override
-	public IdGenerator<?> getOrCreateIdGeneratorOfType(Class<? extends IdGenerator<?>> idGeneratorType) {
-		return this.idGenerators.computeIfAbsent(idGeneratorType, BeanUtils::instantiateClass);
+	public <T extends IdGenerator<?>> T getOrCreateIdGeneratorOfType(Class<T> idGeneratorType) {
+		Supplier<T> fallbackSupplier = () -> (T) this.fallbackIdGenerators
+			.computeIfAbsent(idGeneratorType, BeanUtils::instantiateClass);
+
+		if (this.beanFactory == null) {
+			return fallbackSupplier.get();
+		} else {
+			return this.beanFactory
+				.getBeanProvider(idGeneratorType)
+				.getIfUnique(fallbackSupplier);
+		}
+	}
+
+	@Override
+	public <T extends IdGenerator<?>> Optional<T> getIdGenerator(String reference) {
+		try {
+			return Optional.of((T) this.beanFactory.getBean(reference));
+		} catch (NoSuchBeanDefinitionException e) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		super.setApplicationContext(applicationContext);
+
+		this.beanFactory = applicationContext;
+	}
+
+	@Override
+	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+
+		// Register all the known id generators
+		this.getPersistentEntities().stream()
+			.map(Neo4jPersistentEntity::getIdDescription)
+			.filter(IdDescription::idIsGeneratedExternally).map(IdDescription::getIdGeneratorClass)
+			.filter(Optional::isPresent).map(Optional::get)
+			.distinct()
+			.map(generatorClass -> {
+				RootBeanDefinition definition = new RootBeanDefinition(generatorClass);
+				definition.setRole(RootBeanDefinition.ROLE_INFRASTRUCTURE);
+				return definition;
+			})
+			.forEach(definition -> {
+				String beanName = BeanDefinitionReaderUtils.generateBeanName(definition, registry);
+				registry.registerBeanDefinition(beanName, definition);
+			});
+	}
+
+	@Override
+	public void postProcessBeanFactory(@SuppressWarnings({ "HiddenField" }) ConfigurableListableBeanFactory beanFactory) throws BeansException {
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -264,7 +264,7 @@ public final class Neo4jMappingContext
 		// Register all the known id generators
 		this.getPersistentEntities().stream()
 			.map(Neo4jPersistentEntity::getIdDescription)
-			.filter(IdDescription::idIsGeneratedExternally).map(IdDescription::getIdGeneratorClass)
+			.filter(IdDescription::isExternallyGeneratedId).map(IdDescription::getIdGeneratorClass)
 			.filter(Optional::isPresent).map(Optional::get)
 			.distinct()
 			.map(generatorClass -> {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -36,17 +36,19 @@ import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.types.TypeSystem;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
+import org.neo4j.springframework.data.core.schema.Neo4jSimpleTypes;
+import org.neo4j.springframework.data.core.schema.NodeDescription;
+import org.neo4j.springframework.data.core.schema.Relationship;
+import org.neo4j.springframework.data.core.schema.RelationshipDescription;
+import org.neo4j.springframework.data.core.schema.Schema;
+import org.springframework.beans.BeanUtils;
 import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
-import org.neo4j.springframework.data.core.schema.Neo4jSimpleTypes;
-import org.neo4j.springframework.data.core.schema.NodeDescription;
-import org.neo4j.springframework.data.core.schema.Relationship;
-import org.neo4j.springframework.data.core.schema.RelationshipDescription;
-import org.neo4j.springframework.data.core.schema.Schema;
 import org.springframework.data.util.TypeInformation;
 
 /**
@@ -75,6 +77,11 @@ public final class Neo4jMappingContext
 	private final Map<String, NodeDescription<?>> nodeDescriptionsByPrimaryLabel = new HashMap<>();
 
 	private final ConcurrentMap<String, Collection<RelationshipDescription>> relationshipsByPrimaryLabel = new ConcurrentHashMap<>();
+
+	/**
+	 * The known and loaded ID generators.
+	 */
+	private final Map<Class<? extends IdGenerator>, IdGenerator> idGenerators = new HashMap<>();
 
 	public Neo4jMappingContext() {
 		super.setSimpleTypeHolder(Neo4jSimpleTypes.SIMPLE_TYPE_HOLDER);
@@ -204,5 +211,10 @@ public final class Neo4jMappingContext
 		});
 
 		return Collections.unmodifiableCollection(relationships);
+	}
+
+	@Override
+	public IdGenerator<?> getOrCreateIdGeneratorOfType(Class<? extends IdGenerator<?>> idGeneratorType) {
+		return this.idGenerators.computeIfAbsent(idGeneratorType, BeanUtils::instantiateClass);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.schema;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Indicates a generated id. Ids can be generated internally. by the database itself or by an external generator. This annotation
+ * defaults to the internally generated ids.
+ * <p>
+ * An internal id has no corresponding property on a node. It can only retrieved via the built-in Cypher function {@code id()}.
+ * <p>
+ * To use an external id generator, specify on the
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+@Inherited
+@API(status = API.Status.STABLE, since = "1.0")
+public @interface GeneratedValue {
+
+	/**
+	 * @return The generator to use.
+	 * @see #generatorClass()
+	 */
+	@AliasFor("generatorClass")
+	Class<? extends IdGenerator<?>> value() default GeneratedValue.InternalIdGenerator.class;
+
+	/**
+	 * @return The generator to use. Defaults to {@link InternalIdGenerator}, which indicates database generated values.
+	 */
+	@AliasFor("value")
+	Class<? extends IdGenerator<?>> generatorClass() default GeneratedValue.InternalIdGenerator.class;
+
+	/**
+	 * This {@link IdGenerator} does nothing. It is used for relying on the internal, database-side created id.
+	 */
+	class InternalIdGenerator implements IdGenerator<Void> {
+
+		@Override
+		public Void generateId(String primaryLabel, Object entity) {
+			return null;
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
@@ -60,6 +60,11 @@ public @interface GeneratedValue {
 	Class<? extends IdGenerator<?>> generatorClass() default GeneratedValue.InternalIdGenerator.class;
 
 	/**
+	 * @return An optional reference to a bean to be used as ID generator.
+	 */
+	String generatorRef() default "";
+
+	/**
 	 * This {@link IdGenerator} does nothing. It is used for relying on the internal, database-side created id.
 	 */
 	class InternalIdGenerator implements IdGenerator<Void> {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
@@ -67,7 +67,7 @@ public @interface GeneratedValue {
 	/**
 	 * This {@link IdGenerator} does nothing. It is used for relying on the internal, database-side created id.
 	 */
-	class InternalIdGenerator implements IdGenerator<Void> {
+	final class InternalIdGenerator implements IdGenerator<Void> {
 
 		@Override
 		public Void generateId(String primaryLabel, Object entity) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Id.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Id.java
@@ -24,12 +24,57 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.EnumSet;
 
 import org.apiguardian.api.API;
 
 /**
- * Annotation to configure assigment of ids.
+ * This annotation is included here for completeness. It marks an attribute as the primary id of a node entity. It can
+ * be used as an alternative to {@link org.springframework.data.annotation.Id} and it may provide additional features
+ * in the future.
+ *
+ * <p>
+ *
+ * To use assigned ids, annotate an arbitrary attribute of your domain class with {@link org.springframework.data.annotation.Id}
+ * or this annotation:
+ * <pre>
+ * &#64;Node
+ * public class MyEntity {
+ *     &#64;Id
+ *     String theId;
+ * }
+ * </pre>
+ * You can combine {@code @Id} with {@code @Property} with assigned ids to rename the node property in which the assigned id is stored.
+ *
+ * <p>
+ *
+ * To use internally generated ids, annotate an arbitrary attribute of type {@code java.lang.long} or {@code java.lang.Long}
+ * with {@code @Id} and {@link GeneratedValue @GeneratedValue}.
+ * <pre>
+ * &#64;Node
+ * public class MyEntity {
+ *     &#64;Id &#64;GeneratedValue
+ *     Long id;
+ * }
+ * </pre>
+ *
+ * It does not need to be named {@code id}, but most people chose this as the attribute in the class. As the attribute
+ * does not correspond to a node property, it cannot be renamed via {@code @Property}.
+ *
+ * <p>
+ *
+ * To use externally generated ids, annotate an arbitrary attribute with a type that your generated returns
+ * with {@code @Id} and {@link GeneratedValue @GeneratedValue} and specify the generator class.
+ *
+ * <pre>
+ * &#64;Node
+ * public class MyEntity {
+ *     &#64;Id &#64;GeneratedValue(UUIDStringGenerator.class)
+ *     String theId;
+ * }
+ * </pre>
+ *
+ * Externally generated ids are indistinguishable to assigned ids from the database perspective and thus can be arbitrarily
+ * named via {@code @Property}.
  *
  * @author Michael J. Simons
  * @since 1.0
@@ -41,66 +86,4 @@ import org.apiguardian.api.API;
 @org.springframework.data.annotation.Id
 @API(status = API.Status.STABLE, since = "1.0")
 public @interface Id {
-
-	/**
-	 * Enumerating available strategies for providing ids for new entities.
-	 * @since 1.0
-	 */
-	enum Strategy {
-
-		/**
-		 * The default, use Neo4js internal ids.
-		 */
-		INTERNALLY_GENERATED,
-
-		/**
-		 * Use assigned values.
-		 */
-		ASSIGNED,
-
-		/**
-		 * Use externally generated values, a generator class is required.
-		 */
-		EXTERNALLY_GENERATED;
-
-		/**
-		 * @return True, if the database generated the ID.
-		 */
-		public boolean isInternal() {
-			return this == INTERNALLY_GENERATED;
-		}
-
-		/**
-		 * @return True, if the ID is assigned to the entity before the entity hits the database
-		 */
-		public boolean isExternal() {
-			return EnumSet.of(ASSIGNED, EXTERNALLY_GENERATED).contains(this);
-		}
-	}
-
-	/**
-	 * Configure the strategy for generating ids. Some strategies require a {@link #generator()}.
-	 *
-	 * @return The strategy applied for generating ids for new entities. Defaults to use Neo4j internal database identifiers.
-	 */
-	Strategy strategy() default Strategy.INTERNALLY_GENERATED;
-
-	/**
-	 *
-	 * @return The generator that fits the selected {@link #strategy()}. Defaults to a Noop generator.
-	 */
-	Class<? extends IdGenerator> generator() default NoopIdGenerator.class;
-
-	/**
-	 * This {@link IdGenerator} does nothing. It is used for relying on the internal, database-side created id.
-	 * @since 1.0
-	 */
-	// Needed to make the generator attribute defaultable (null is not a constant)
-	class NoopIdGenerator implements IdGenerator {
-
-		@Override
-		public Object generateId(Object entity) {
-			return null;
-		}
-	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
@@ -96,23 +96,23 @@ public final class IdDescription {
 	}
 
 	/**
-	 * @return True, if the database generated the ID.
+	 * @return True, if the ID is assigned to the entity before the entity hits the database, either manually or through a generator.
 	 */
-	public boolean idIsGeneratedInternally() {
-		return this.idGeneratorClass == GeneratedValue.InternalIdGenerator.class;
+	public boolean isAssignedId() {
+		return this.idGeneratorClass == null && this.idGeneratorRef == null;
 	}
 
 	/**
-	 * @return True, if the ID is assigned to the entity before the entity hits the database, either manually or through a generator.
+	 * @return True, if the database generated the ID.
 	 */
-	public boolean idIsAssigned() {
-		return this.idGeneratorClass == null && this.idGeneratorRef == null;
+	public boolean isInternallyGeneratedId() {
+		return this.idGeneratorClass == GeneratedValue.InternalIdGenerator.class;
 	}
 
 	/**
 	 * @return True, if the ID is externally generated.
 	 */
-	public boolean idIsGeneratedExternally() {
+	public boolean isExternallyGeneratedId() {
 		return (this.idGeneratorClass != null && this.idGeneratorClass != GeneratedValue.InternalIdGenerator.class)
 			|| this.idGeneratorRef != null;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Node.java
@@ -38,6 +38,7 @@ import org.springframework.core.annotation.AliasFor;
 @Target(ElementType.TYPE)
 @Documented
 @Inherited
+@org.springframework.data.annotation.Persistent
 @API(status = API.Status.STABLE, since = "1.0")
 public @interface Node {
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
@@ -73,6 +73,6 @@ public interface NodeDescription<T> {
 	 * @return True if entities for this node use Neo4j internal ids.
 	 */
 	default boolean isUsingInternalIds() {
-		return this.getIdDescription().idIsGeneratedInternally();
+		return this.getIdDescription().isInternallyGeneratedId();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
@@ -73,6 +73,6 @@ public interface NodeDescription<T> {
 	 * @return True if entities for this node use Neo4j internal ids.
 	 */
 	default boolean isUsingInternalIds() {
-		return this.getIdDescription().getIdStrategy() == Id.Strategy.INTERNALLY_GENERATED;
+		return this.getIdDescription().idIsGeneratedInternally();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Schema.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Schema.java
@@ -118,4 +118,13 @@ public interface Schema {
 
 		return getBinderFunctionFor(sourceClass).orElseThrow(() -> new UnknownEntityException(sourceClass));
 	}
+
+	/**
+	 * Creates or retrieves an instance of the given id generator class. During the lifetime of the schema,
+	 * this method returns the same instance of reoccurring requests of the same type.
+	 *
+	 * @param idGeneratorType The type of the ID generator to return
+	 * @return The id generator.
+	 */
+	IdGenerator<?> getOrCreateIdGeneratorOfType(Class<? extends IdGenerator<?>> idGeneratorType);
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Schema.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Schema.java
@@ -126,5 +126,7 @@ public interface Schema {
 	 * @param idGeneratorType The type of the ID generator to return
 	 * @return The id generator.
 	 */
-	IdGenerator<?> getOrCreateIdGeneratorOfType(Class<? extends IdGenerator<?>> idGeneratorType);
+	<T extends IdGenerator<?>> T getOrCreateIdGeneratorOfType(Class<T> idGeneratorType);
+
+	<T extends IdGenerator<?>> Optional<T> getIdGenerator(String reference);
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/UUIDStringGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/UUIDStringGenerator.java
@@ -16,26 +16,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.springframework.data.core.schema;
+package org.neo4j.springframework.data.core.support;
+
+import java.util.UUID;
 
 import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
 
 /**
- * Interface for generating ids for entities.
+ * A generator providing UUIDs.
  *
- * @param <T> Type of the id to generate
  * @author Michael J. Simons
+ * @soundtrack Various - Kung Fury (Original Motion Picture Soundtrack)
  * @since 1.0
  */
-@FunctionalInterface
 @API(status = API.Status.STABLE, since = "1.0")
-public interface IdGenerator<T> {
+public final class UUIDStringGenerator implements IdGenerator<String> {
 
-	/**
-	 * Generates a new id for given entity.
-	 *
-	 * @param entity the entity to be saved
-	 * @return id to be assigned to the entity
-	 */
-	T generateId(String primaryLabel, Object entity);
+	@Override
+	public String generateId(String primaryLabel, Object entity) {
+		return UUID.randomUUID().toString();
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -111,7 +111,7 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
 	}
 
-	/**
+	/*
 	 * (non-Javadoc)
 	 *
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -25,9 +25,14 @@ import java.util.Collections;
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.event.IdGeneratingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -104,5 +109,21 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 			source.getAttribute("neo4jClientRef").orElse(DEFAULT_NEO4J_CLIENT_BEAN_NAME));
 		builder.addPropertyReference("neo4jMappingContext",
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
+	}
+
+	/**
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)
+	 */
+	@Override
+	public void registerBeansForRoot(BeanDefinitionRegistry registry,
+		RepositoryConfigurationSource configurationSource) {
+
+		RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(IdGeneratingBeforeBindCallback.class);
+		rootBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+
+		String beanName = BeanDefinitionReaderUtils.generateBeanName(rootBeanDefinition, registry);
+		registry.registerBeanDefinition(beanName, rootBeanDefinition);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -110,7 +110,7 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
 	}
 
-	/**
+	/*
 	 * (non-Javadoc)
 	 *
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -25,9 +25,14 @@ import java.util.Collections;
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.event.ReactiveIdGeneratingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -103,5 +108,21 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 			source.getAttribute("neo4jClientRef").orElse(DEFAULT_NEO4J_CLIENT_BEAN_NAME));
 		builder.addPropertyReference("neo4jMappingContext",
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
+	}
+
+	/**
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)
+	 */
+	@Override
+	public void registerBeansForRoot(BeanDefinitionRegistry registry,
+		RepositoryConfigurationSource configurationSource) {
+
+		RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(ReactiveIdGeneratingBeforeBindCallback.class);
+		rootBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+
+		String beanName = BeanDefinitionReaderUtils.generateBeanName(rootBeanDefinition, registry);
+		registry.registerBeanDefinition(beanName, rootBeanDefinition);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdGeneratingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdGeneratingBeforeBindCallback.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.springframework.core.Ordered;
+
+/**
+ * Callback used to call the ID generator configured for an entity just before binding.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Various - Kung Fury (Original Motion Picture Soundtrack)
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class IdGeneratingBeforeBindCallback implements BeforeBindCallback<Object>, Ordered {
+
+	private final IdPopulator idPopulator;
+
+	public IdGeneratingBeforeBindCallback(Neo4jMappingContext neo4jMappingContext) {
+		this.idPopulator = new IdPopulator(neo4jMappingContext);
+	}
+
+	@Override
+	public Object onBeforeBind(Object entity) {
+
+		return idPopulator.populateIfNecessary(entity);
+	}
+
+	@Override
+	public int getOrder() {
+		return AuditingBeforeBindCallback.NEO4J_AUDITING_ORDER - 10;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdPopulator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdPopulator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.neo4j.springframework.data.core.schema.IdDescription;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.util.Assert;
+
+/**
+ * Support for populating id properties with user specified id generators.
+ *
+ * @author Michael J. Simons
+ */
+final class IdPopulator {
+
+	private final Neo4jMappingContext neo4jMappingContext;
+
+	IdPopulator(Neo4jMappingContext neo4jMappingContext) {
+
+		Assert.notNull(neo4jMappingContext, "A mapping context is required.");
+
+		this.neo4jMappingContext = neo4jMappingContext;
+	}
+
+	Object populateIfNecessary(Object entity) {
+
+		Assert.notNull(entity, "Entity may not be null!");
+
+		Neo4jPersistentEntity<?> nodeDescription = neo4jMappingContext.getRequiredPersistentEntity(entity.getClass());
+		IdDescription idDescription = nodeDescription.getIdDescription();
+
+		// Filter in two steps to avoid unnecessary object creation.
+		if (!idDescription.idIsGeneratedExternally()) {
+			return entity;
+		}
+
+		PersistentPropertyAccessor propertyAccessor = nodeDescription.getPropertyAccessor(entity);
+		Neo4jPersistentProperty idProperty = nodeDescription.getRequiredIdProperty();
+
+		// Check existing ID
+		if (propertyAccessor.getProperty(idProperty) != null) {
+			return entity;
+		}
+
+		// Get or create the shared generator
+		IdGenerator<?> idGenerator = neo4jMappingContext
+			.getOrCreateIdGeneratorOfType(idDescription.getIdGeneratorClass().get());
+		propertyAccessor.setProperty(idProperty, idGenerator.generateId(nodeDescription.getPrimaryLabel(), entity));
+		return propertyAccessor.getBean();
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdPopulator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdPopulator.java
@@ -52,7 +52,7 @@ final class IdPopulator {
 		IdDescription idDescription = nodeDescription.getIdDescription();
 
 		// Filter in two steps to avoid unnecessary object creation.
-		if (!idDescription.idIsGeneratedExternally()) {
+		if (!idDescription.isExternallyGeneratedId()) {
 			return entity;
 		}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallback.java
@@ -62,7 +62,8 @@ public final class ReactiveAuditingBeforeBindCallback implements ReactiveBeforeB
 	 */
 	@Override
 	public Publisher<Object> onBeforeBind(Object entity) {
-		return Mono.just(auditingHandlerFactory.getObject().markAudited(entity));
+
+		return Mono.fromSupplier(() -> auditingHandlerFactory.getObject().markAudited(entity));
 	}
 
 	/*

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveIdGeneratingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveIdGeneratingBeforeBindCallback.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import reactor.core.publisher.Mono;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.reactivestreams.Publisher;
+import org.springframework.core.Ordered;
+
+/**
+ * Callback used to call the ID generator configured for an entity just before binding.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Various - Kung Fury (Original Motion Picture Soundtrack)
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class ReactiveIdGeneratingBeforeBindCallback implements ReactiveBeforeBindCallback<Object>, Ordered {
+
+	private final IdPopulator idPopulator;
+
+	public ReactiveIdGeneratingBeforeBindCallback(Neo4jMappingContext neo4jMappingContext) {
+		this.idPopulator = new IdPopulator(neo4jMappingContext);
+	}
+
+	@Override
+	public Publisher<Object> onBeforeBind(Object entity) {
+
+		return Mono.fromSupplier(() -> idPopulator.populateIfNecessary(entity));
+	}
+
+	@Override
+	public int getOrder() {
+		return ReactiveAuditingBeforeBindCallback.NEO4J_REACTIVE_AUDITING_ORDER - 10;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
@@ -31,7 +31,6 @@ import org.neo4j.springframework.data.core.cypher.*;
 import org.neo4j.springframework.data.core.cypher.StatementBuilder.BuildableStatement;
 import org.neo4j.springframework.data.core.cypher.StatementBuilder.OngoingReadingAndWith;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
-import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
 import org.neo4j.springframework.data.core.schema.Schema;
@@ -140,7 +139,7 @@ public final class CypherAdapterUtils {
 
 			List<Expression> expressions = new ArrayList<>();
 			expressions.add(rootNode);
-			if (idDescription.getIdStrategy() == Id.Strategy.INTERNALLY_GENERATED) {
+			if (idDescription.idIsGeneratedInternally()) {
 				expressions.add(Functions.id(rootNode).as(NAME_OF_INTERNAL_ID));
 			}
 			return Cypher.match(rootNode).where(condition.orElse(Conditions.noCondition()))
@@ -159,7 +158,7 @@ public final class CypherAdapterUtils {
 			Node rootNode = node(nodeDescription.getPrimaryLabel()).named(NAME_OF_ROOT_NODE);
 			IdDescription idDescription = nodeDescription.getIdDescription();
 			Parameter idParameter = parameter(NAME_OF_ID_PARAM);
-			if (idDescription.getIdStrategy().isExternal()) {
+			if (!idDescription.idIsGeneratedInternally()) {
 				String nameOfIdProperty = idDescription.getOptionalGraphPropertyName()
 					.orElseThrow(() -> new MappingException("External id does not correspond to a graph property!"));
 
@@ -235,17 +234,11 @@ public final class CypherAdapterUtils {
 		final SymbolicName rootNode = Cypher.name(NAME_OF_ROOT_NODE);
 		final IdDescription idDescription = nodeDescription.getIdDescription();
 		Expression idExpression;
-		switch (idDescription.getIdStrategy()) {
-			case INTERNALLY_GENERATED:
-				idExpression = Functions.id(rootNode);
-				break;
-			case ASSIGNED:
-			case EXTERNALLY_GENERATED:
-				idExpression = idDescription.getOptionalGraphPropertyName()
-					.map(propertyName -> property(rootNode.getName(), propertyName)).get();
-				break;
-			default:
-				throw new IllegalStateException("Unsupported ID strategy: %s" + idDescription.getIdStrategy());
+		if (idDescription.idIsGeneratedInternally()) {
+			idExpression = Functions.id(rootNode);
+		} else {
+			idExpression = idDescription.getOptionalGraphPropertyName()
+				.map(propertyName -> property(rootNode.getName(), propertyName)).get();
 		}
 
 		return idExpression;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
@@ -139,7 +139,7 @@ public final class CypherAdapterUtils {
 
 			List<Expression> expressions = new ArrayList<>();
 			expressions.add(rootNode);
-			if (idDescription.idIsGeneratedInternally()) {
+			if (idDescription.isInternallyGeneratedId()) {
 				expressions.add(Functions.id(rootNode).as(NAME_OF_INTERNAL_ID));
 			}
 			return Cypher.match(rootNode).where(condition.orElse(Conditions.noCondition()))
@@ -158,7 +158,7 @@ public final class CypherAdapterUtils {
 			Node rootNode = node(nodeDescription.getPrimaryLabel()).named(NAME_OF_ROOT_NODE);
 			IdDescription idDescription = nodeDescription.getIdDescription();
 			Parameter idParameter = parameter(NAME_OF_ID_PARAM);
-			if (!idDescription.idIsGeneratedInternally()) {
+			if (!idDescription.isInternallyGeneratedId()) {
 				String nameOfIdProperty = idDescription.getOptionalGraphPropertyName()
 					.orElseThrow(() -> new MappingException("External id does not correspond to a graph property!"));
 
@@ -234,7 +234,7 @@ public final class CypherAdapterUtils {
 		final SymbolicName rootNode = Cypher.name(NAME_OF_ROOT_NODE);
 		final IdDescription idDescription = nodeDescription.getIdDescription();
 		Expression idExpression;
-		if (idDescription.idIsGeneratedInternally()) {
+		if (idDescription.isInternallyGeneratedId()) {
 			idExpression = Functions.id(rootNode);
 		} else {
 			idExpression = idDescription.getOptionalGraphPropertyName()

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategyTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategyTest.java
@@ -94,7 +94,7 @@ class DefaultNeo4jIsNewStrategyTest {
 
 			Object a = new Object();
 			Object b = new Object();
-			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "na");
+			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "na");
 			doReturn(String.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -109,7 +109,7 @@ class DefaultNeo4jIsNewStrategyTest {
 		@Test
 		void doesntNeedToDealWithPrimitives() {
 
-			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "na");
+			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "na");
 			doReturn(long.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategyTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jIsNewStrategyTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.neo4j.springframework.data.core.schema.IdDescription;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
 import org.springframework.data.mapping.IdentifierAccessor;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.neo4j.springframework.data.core.schema.Id;
-import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.springframework.data.support.IsNewStrategy;
 
 /**
@@ -54,7 +54,7 @@ class DefaultNeo4jIsNewStrategyTest {
 			Object a = new Object();
 			Object b = new Object();
 
-			IdDescription idDescription = new IdDescription();
+			IdDescription idDescription = IdDescription.forInternallyGeneratedIds();
 			doReturn(Long.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -72,7 +72,7 @@ class DefaultNeo4jIsNewStrategyTest {
 			Object b = new Object();
 			Object c = new Object();
 
-			IdDescription idDescription = new IdDescription();
+			IdDescription idDescription = IdDescription.forInternallyGeneratedIds();
 			doReturn(long.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -94,7 +94,7 @@ class DefaultNeo4jIsNewStrategyTest {
 
 			Object a = new Object();
 			Object b = new Object();
-			IdDescription idDescription = new IdDescription(Id.Strategy.EXTERNALLY_GENERATED, null, null);
+			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "na");
 			doReturn(String.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -109,7 +109,7 @@ class DefaultNeo4jIsNewStrategyTest {
 		@Test
 		void doesntNeedToDealWithPrimitives() {
 
-			IdDescription idDescription = new IdDescription(Id.Strategy.EXTERNALLY_GENERATED, null, null);
+			IdDescription idDescription = IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "na");
 			doReturn(long.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -126,7 +126,7 @@ class DefaultNeo4jIsNewStrategyTest {
 		@Test
 		void shouldAlwaysTreatEntitiesAsNewWithoutVersion() {
 			Object a = new Object();
-			IdDescription idDescription = new IdDescription(Id.Strategy.ASSIGNED, null, null);
+			IdDescription idDescription = IdDescription.forAssignedIds("na");
 			doReturn(String.class).when(idProperty).getType();
 			doReturn(idDescription).when(entityMetaData).getIdDescription();
 			doReturn(idProperty).when(entityMetaData).getRequiredIdProperty();
@@ -139,7 +139,7 @@ class DefaultNeo4jIsNewStrategyTest {
 		void shouldDealWithVersion() {
 			Object a = new Object();
 			Object b = new Object();
-			IdDescription idDescription = new IdDescription(Id.Strategy.ASSIGNED, null, null);
+			IdDescription idDescription = IdDescription.forAssignedIds("na");
 
 			doReturn(String.class).when(idProperty).getType();
 			doReturn(String.class).when(versionProperty).getType();
@@ -166,7 +166,7 @@ class DefaultNeo4jIsNewStrategyTest {
 		void shouldDealWithPrimitiveVersion() {
 			Object a = new Object();
 			Object b = new Object();
-			IdDescription idDescription = new IdDescription(Id.Strategy.ASSIGNED, null, null);
+			IdDescription idDescription = IdDescription.forAssignedIds("na");
 
 			doReturn(String.class).when(idProperty).getType();
 			doReturn(int.class).when(versionProperty).getType();
@@ -187,6 +187,14 @@ class DefaultNeo4jIsNewStrategyTest {
 
 			assertThat(strategy.isNew(a)).isTrue();
 			assertThat(strategy.isNew(b)).isFalse();
+		}
+	}
+
+	static class DummyIdGenerator implements IdGenerator<Void> {
+
+		@Override
+		public Void generateId(String primaryLabel, Object entity) {
+			return null;
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -57,7 +57,7 @@ public class Neo4jMappingContextTest {
 			.hasValueSatisfying(description -> {
 				assertThat(description.getUnderlyingClass()).isEqualTo(UserNode.class);
 
-				assertThat(description.getIdDescription().idIsGeneratedInternally()).isTrue();
+				assertThat(description.getIdDescription().isInternallyGeneratedId()).isTrue();
 
 				assertThat(description.getGraphProperties())
 					.extracting(GraphPropertyDescription::getFieldName)
@@ -74,7 +74,7 @@ public class Neo4jMappingContextTest {
 			.hasValueSatisfying(description -> {
 				assertThat(description.getUnderlyingClass()).isEqualTo(BikeNode.class);
 
-				assertThat(description.getIdDescription().idIsAssigned()).isTrue();
+				assertThat(description.getIdDescription().isAssignedId()).isTrue();
 
 				Collection<String> expectedRelationships = Arrays
 					.asList("[:owner] -> (:User)", "[:renter] -> (:User)", "[:dynamicRelationships] -> (:User)");

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -28,8 +28,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
 import org.neo4j.springframework.data.core.schema.Property;
@@ -55,8 +57,7 @@ public class Neo4jMappingContextTest {
 			.hasValueSatisfying(description -> {
 				assertThat(description.getUnderlyingClass()).isEqualTo(UserNode.class);
 
-				assertThat(description.getIdDescription().getIdStrategy())
-					.isEqualTo(Id.Strategy.INTERNALLY_GENERATED);
+				assertThat(description.getIdDescription().idIsGeneratedInternally()).isTrue();
 
 				assertThat(description.getGraphProperties())
 					.extracting(GraphPropertyDescription::getFieldName)
@@ -73,8 +74,7 @@ public class Neo4jMappingContextTest {
 			.hasValueSatisfying(description -> {
 				assertThat(description.getUnderlyingClass()).isEqualTo(BikeNode.class);
 
-				assertThat(description.getIdDescription().getIdStrategy())
-					.isEqualTo(Id.Strategy.ASSIGNED);
+				assertThat(description.getIdDescription().idIsAssigned()).isTrue();
 
 				Collection<String> expectedRelationships = Arrays
 					.asList("[:owner] -> (:User)", "[:renter] -> (:User)", "[:dynamicRelationships] -> (:User)");
@@ -136,7 +136,7 @@ public class Neo4jMappingContextTest {
 	@Node("User")
 	static class UserNode {
 
-		@org.springframework.data.annotation.Id
+		@org.springframework.data.annotation.Id @GeneratedValue
 		private long id;
 
 		@Relationship(type = "OWNS", inverse = "owner")
@@ -150,7 +150,7 @@ public class Neo4jMappingContextTest {
 
 	static class BikeNode {
 
-		@Id(strategy = Id.Strategy.ASSIGNED)
+		@Id
 		private String id;
 
 		UserNode owner;
@@ -167,7 +167,7 @@ public class Neo4jMappingContextTest {
 
 	static class TripNode {
 
-		@Id(strategy = Id.Strategy.ASSIGNED)
+		@Id
 		private String id;
 
 		String name;
@@ -175,13 +175,15 @@ public class Neo4jMappingContextTest {
 
 	static class InvalidId {
 
-		@Id @Property("getMappingFunctionFor")
+		@Id
+		@GeneratedValue
+		@Property("getMappingFunctionFor")
 		private String id;
 	}
 
 	static class InvalidIdType {
 
-		@Id
+		@Id @GeneratedValue
 		private String id;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -133,6 +133,24 @@ public class Neo4jMappingContextTest {
 			assertThat(schema.getMappingFunctionFor(association.getInverse().getAssociationTargetType())).isPresent());
 	}
 
+	@Test
+	void shouldCacheIdGenerators() {
+
+		Neo4jMappingContext schema = new Neo4jMappingContext();
+		IdGenerator<?> dummyIdGenerator1 = schema.getOrCreateIdGeneratorOfType(DummyIdGenerator.class);
+		IdGenerator<?> dummyIdGenerator2 = schema.getOrCreateIdGeneratorOfType(DummyIdGenerator.class);
+
+		assertThat(dummyIdGenerator1).isSameAs(dummyIdGenerator2);
+	}
+
+	static class DummyIdGenerator implements IdGenerator<Void> {
+
+		@Override
+		public Void generateId(String primaryLabel, Object entity) {
+			return null;
+		}
+	}
+
 	@Node("User")
 	static class UserNode {
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.schema;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class IdDescriptionTest {
+
+	@Test
+	void isAssignedShouldWork() {
+
+		assertThat(IdDescription.forAssignedIds("foobar").idIsAssigned()).isTrue();
+		assertThat(IdDescription.forAssignedIds("foobar").idIsGeneratedExternally()).isFalse();
+		assertThat(IdDescription.forAssignedIds("foobar").idIsGeneratedInternally()).isFalse();
+	}
+
+	@Test
+	void idIsGeneratedInternallyShouldWork() {
+
+		assertThat(IdDescription.forInternallyGeneratedIds().idIsAssigned()).isFalse();
+		assertThat(IdDescription.forInternallyGeneratedIds().idIsGeneratedExternally()).isFalse();
+		assertThat(IdDescription.forInternallyGeneratedIds().idIsGeneratedInternally()).isTrue();
+	}
+
+	@Test
+	void idIsGeneratedExternally() {
+
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsAssigned()).isFalse();
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsGeneratedExternally())
+			.isTrue();
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsGeneratedInternally())
+			.isFalse();
+	}
+
+	private static class DummyIdGenerator implements IdGenerator<Void> {
+
+		@Override
+		public Void generateId(String primaryLabel, Object entity) {
+			return null;
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
@@ -46,10 +46,16 @@ class IdDescriptionTest {
 	@Test
 	void idIsGeneratedExternally() {
 
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsAssigned()).isFalse();
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsGeneratedExternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsAssigned()).isFalse();
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsGeneratedExternally())
 			.isTrue();
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, "foobar").idIsGeneratedInternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsGeneratedInternally())
+			.isFalse();
+
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsAssigned()).isFalse();
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsGeneratedExternally())
+			.isTrue();
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsGeneratedInternally())
 			.isFalse();
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/schema/IdDescriptionTest.java
@@ -30,32 +30,32 @@ class IdDescriptionTest {
 	@Test
 	void isAssignedShouldWork() {
 
-		assertThat(IdDescription.forAssignedIds("foobar").idIsAssigned()).isTrue();
-		assertThat(IdDescription.forAssignedIds("foobar").idIsGeneratedExternally()).isFalse();
-		assertThat(IdDescription.forAssignedIds("foobar").idIsGeneratedInternally()).isFalse();
+		assertThat(IdDescription.forAssignedIds("foobar").isAssignedId()).isTrue();
+		assertThat(IdDescription.forAssignedIds("foobar").isExternallyGeneratedId()).isFalse();
+		assertThat(IdDescription.forAssignedIds("foobar").isInternallyGeneratedId()).isFalse();
 	}
 
 	@Test
 	void idIsGeneratedInternallyShouldWork() {
 
-		assertThat(IdDescription.forInternallyGeneratedIds().idIsAssigned()).isFalse();
-		assertThat(IdDescription.forInternallyGeneratedIds().idIsGeneratedExternally()).isFalse();
-		assertThat(IdDescription.forInternallyGeneratedIds().idIsGeneratedInternally()).isTrue();
+		assertThat(IdDescription.forInternallyGeneratedIds().isAssignedId()).isFalse();
+		assertThat(IdDescription.forInternallyGeneratedIds().isExternallyGeneratedId()).isFalse();
+		assertThat(IdDescription.forInternallyGeneratedIds().isInternallyGeneratedId()).isTrue();
 	}
 
 	@Test
 	void idIsGeneratedExternally() {
 
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsAssigned()).isFalse();
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsGeneratedExternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").isAssignedId()).isFalse();
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").isExternallyGeneratedId())
 			.isTrue();
-		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").idIsGeneratedInternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(DummyIdGenerator.class, null, "foobar").isInternallyGeneratedId())
 			.isFalse();
 
-		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsAssigned()).isFalse();
-		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsGeneratedExternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").isAssignedId()).isFalse();
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").isExternallyGeneratedId())
 			.isTrue();
-		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").idIsGeneratedInternally())
+		assertThat(IdDescription.forExternallyGeneratedIds(null, "someId", "foobar").isInternallyGeneratedId())
 			.isFalse();
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/IdGeneratorsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/IdGeneratorsIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static java.util.stream.Collectors.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.IdGeneratorsITBase;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ */
+@ContextConfiguration(classes = IdGeneratorsIT.Config.class)
+class IdGeneratorsIT extends IdGeneratorsITBase {
+
+	private final TestRepository testRepository;
+
+	@Autowired IdGeneratorsIT(TestRepository testRepository, Driver driver) {
+		super(driver);
+		this.testRepository = testRepository;
+	}
+
+	@Test
+	void idGenerationWithNewEntityShouldWork() {
+
+		ThingWithGeneratedId t = new ThingWithGeneratedId("Foobar");
+		t.setName("Foobar");
+		t = testRepository.save(t);
+		assertThat(t.getTheId())
+			.isNotBlank()
+			.matches("thingWithGeneratedId-\\d+");
+
+		verifyDatabase(t);
+	}
+
+	@Test
+	void idGenerationWithNewEntitiesShouldWork() {
+
+		List<ThingWithGeneratedId> things = IntStream.rangeClosed(1, 10)
+			.mapToObj(i -> new ThingWithGeneratedId("name" + i))
+			.collect(toList());
+
+		Iterable<ThingWithGeneratedId> savedThings = testRepository.saveAll(things);
+		assertThat(savedThings)
+			.hasSize(things.size())
+			.extracting(ThingWithGeneratedId::getTheId)
+			.allMatch(s -> s.matches("thingWithGeneratedId-\\d+"));
+
+		Set<String> distinctIds = StreamSupport.stream(savedThings.spliterator(), false)
+			.map(ThingWithGeneratedId::getTheId).collect(toSet());
+
+		assertThat(distinctIds).hasSize(things.size());
+	}
+
+	@Test
+	void shouldNotOverwriteExistingId() {
+
+		ThingWithGeneratedId t = testRepository.findById(ID_OF_EXISTING_THING).get();
+		t.setName("changed");
+		t = testRepository.save(t);
+
+		assertThat(t.getTheId())
+			.isNotBlank()
+			.isEqualTo(ID_OF_EXISTING_THING);
+
+		verifyDatabase(t);
+	}
+
+	public interface TestRepository extends CrudRepository<ThingWithGeneratedId, String> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ThingWithGeneratedId.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveIdGeneratorsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveIdGeneratorsIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static java.util.stream.Collectors.*;
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.IdGeneratorsITBase;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+/**
+ * @author Michael J. Simons
+ */
+@ContextConfiguration(classes = ReactiveIdGeneratorsIT.Config.class)
+class ReactiveIdGeneratorsIT extends IdGeneratorsITBase {
+
+	private final ReactiveTransactionManager transactionManager;
+	private final TestRepository testRepository;
+
+	@Autowired ReactiveIdGeneratorsIT(ReactiveTransactionManager transactionManager, TestRepository testRepository,
+		Driver driver) {
+		super(driver);
+		this.transactionManager = transactionManager;
+		this.testRepository = testRepository;
+	}
+
+	@Test
+	void idGenerationWithNewEntityShouldWork() {
+
+		List<ThingWithGeneratedId> savedThings = new ArrayList<>();
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> testRepository.save(new ThingWithGeneratedId("Foobar")))
+			.as(StepVerifier::create)
+			.recordWith(() -> savedThings)
+			.consumeNextWith(savedThing -> {
+
+				assertThat(savedThing.getName()).isEqualTo("Foobar");
+				assertThat(savedThing.getTheId())
+					.isNotBlank()
+					.matches("thingWithGeneratedId-\\d+");
+			})
+			.verifyComplete();
+
+		verifyDatabase(savedThings.get(0));
+	}
+
+	@Test
+	void idGenerationWithNewEntitiesShouldWork() {
+
+		List<ThingWithGeneratedId> things = IntStream.rangeClosed(1, 10)
+			.mapToObj(i -> new ThingWithGeneratedId("name" + i))
+			.collect(toList());
+
+		Set<String> generatedIds = new HashSet<>();
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> testRepository.saveAll(things))
+			.map(ThingWithGeneratedId::getTheId)
+			.as(StepVerifier::create)
+			.recordWith(() -> generatedIds)
+			.expectNextCount(things.size())
+			.expectRecordedMatches(recorded -> {
+				assertThat(recorded)
+					.hasSize(things.size())
+					.allMatch(generatedId -> generatedId.matches("thingWithGeneratedId-\\d+"));
+				return true;
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void shouldNotOverwriteExistingId() {
+
+		Mono<ThingWithGeneratedId> findAndUpdateAThing = testRepository.findById(ID_OF_EXISTING_THING)
+			.flatMap(thing -> {
+				thing.setName("changed");
+				return testRepository.save(thing);
+			});
+
+		List<ThingWithGeneratedId> savedThings = new ArrayList<>();
+		TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+		transactionalOperator
+			.execute(t -> findAndUpdateAThing)
+			.as(StepVerifier::create)
+			.recordWith(() -> savedThings)
+			.consumeNextWith(savedThing -> {
+
+				assertThat(savedThing.getName()).isEqualTo("changed");
+				assertThat(savedThing.getTheId()).isEqualTo(ID_OF_EXISTING_THING);
+			})
+			.verifyComplete();
+
+		verifyDatabase(savedThings.get(0));
+	}
+
+	public interface TestRepository extends ReactiveCrudRepository<ThingWithGeneratedId, String> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.openConnection();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(ThingWithGeneratedId.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AbstractNamedThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AbstractNamedThing.java
@@ -18,25 +18,18 @@
  */
 package org.neo4j.springframework.data.integration.shared;
 
-import org.neo4j.springframework.data.core.schema.Id;
-import org.neo4j.springframework.data.core.schema.Node;
-
 /**
- * Has an assigned id.
- *
  * @author Michael J. Simons
  */
-@Node("Thing")
-public class ThingWithAssignedId extends AbstractNamedThing {
+abstract class AbstractNamedThing {
 
-	@Id
-	private final String theId;
+	private String name;
 
-	public ThingWithAssignedId(String theId) {
-		this.theId = theId;
+	public String getName() {
+		return name;
 	}
 
-	public String getTheId() {
-		return theId;
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/IdGeneratorsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/IdGeneratorsITBase.java
@@ -59,16 +59,16 @@ public abstract class IdGeneratorsITBase {
 		}
 	}
 
-	protected void verifyDatabase(ThingWithGeneratedId expectedValues) {
+	protected void verifyDatabase(String id, String name) {
 
 		try (Session session = driver.session()) {
 			Node node = session
-				.run("MATCH (t:ThingWithGeneratedId {theId: $theId}) RETURN t",
-					Values.parameters("theId", expectedValues.getTheId()))
+				.run("MATCH (t) WHERE t.theId = $theId RETURN t",
+					Values.parameters("theId", id))
 				.single().get("t").asNode();
 
-			assertThat(node.get("name").asString()).isEqualTo(expectedValues.getName());
-			assertThat(node.get("theId").asString()).isEqualTo(expectedValues.getTheId());
+			assertThat(node.get("name").asString()).isEqualTo(name);
+			assertThat(node.get("theId").asString()).isEqualTo(id);
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/IdGeneratorsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/IdGeneratorsITBase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Node;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Michael J. Simons
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(Neo4jExtension.class)
+public abstract class IdGeneratorsITBase {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	protected static final String EXISTING_THING_NAME = "An old name";
+
+	protected static final String ID_OF_EXISTING_THING = "not-generated.";
+
+	private final Driver driver;
+
+	protected IdGeneratorsITBase(Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	protected void setupData() {
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			transaction.run("CREATE (t:ThingWithGeneratedId {name: $name, theId: $theId}) RETURN id(t) as id",
+				Values.parameters("name", EXISTING_THING_NAME, "theId", ID_OF_EXISTING_THING));
+			transaction.success();
+		}
+	}
+
+	protected void verifyDatabase(ThingWithGeneratedId expectedValues) {
+
+		try (Session session = driver.session()) {
+			Node node = session
+				.run("MATCH (t:ThingWithGeneratedId {theId: $theId}) RETURN t",
+					Values.parameters("theId", expectedValues.getTheId()))
+				.single().get("t").asNode();
+
+			assertThat(node.get("name").asString()).isEqualTo(expectedValues.getName());
+			assertThat(node.get("theId").asString()).isEqualTo(expectedValues.getTheId());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
@@ -25,13 +25,13 @@ import lombok.experimental.Wither;
 import java.time.LocalDateTime;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
-import org.neo4j.springframework.data.core.schema.Node;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.Persistent;
 
 /**
  * @author Michael J. Simons
@@ -39,7 +39,7 @@ import org.springframework.data.annotation.PersistenceConstructor;
 @Value
 @Wither
 @AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
-@Node
+@Persistent
 public class ImmutableAuditableThing {
 
 	@Id @GeneratedValue Long id;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
@@ -24,6 +24,7 @@ import lombok.experimental.Wither;
 
 import java.time.LocalDateTime;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -41,7 +42,7 @@ import org.springframework.data.annotation.PersistenceConstructor;
 @Node
 public class ImmutableAuditableThing {
 
-	@Id Long id;
+	@Id @GeneratedValue Long id;
 	@CreatedDate LocalDateTime createdAt;
 	@CreatedBy String createdBy;
 	@LastModifiedDate LocalDateTime modifiedAt;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithAllConstructor.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithAllConstructor.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.neo4j.driver.types.Point;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.Property;
@@ -45,7 +46,7 @@ import org.neo4j.springframework.data.core.schema.Property;
 @EqualsAndHashCode
 public class PersonWithAllConstructor {
 
-	@Id
+	@Id @GeneratedValue
 	@Wither
 	private final Long id;
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithNoConstructor.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithNoConstructor.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.Property;
@@ -35,7 +36,8 @@ import org.neo4j.springframework.data.core.schema.Property;
 @ToString
 public class PersonWithNoConstructor {
 
-	@Id private Long id;
+	@Id @GeneratedValue
+	private Long id;
 
 	private String name;
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithWither.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithWither.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 
@@ -35,7 +36,8 @@ import org.neo4j.springframework.data.core.schema.Node;
 @ToString
 public class PersonWithWither {
 
-	@Id private final Long id;
+	@Id @GeneratedValue
+	private final Long id;
 
 	private final String name;
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/TestSequenceGenerator.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/TestSequenceGenerator.java
@@ -16,26 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.springframework.data.core.schema;
+package org.neo4j.springframework.data.integration.shared;
 
-import org.apiguardian.api.API;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.springframework.data.core.schema.IdGenerator;
+import org.springframework.util.StringUtils;
 
 /**
- * Interface for generating ids for entities.
+ * This is a naive sequence generator which must not be used in production.
  *
- * @param <T> Type of the id to generate
  * @author Michael J. Simons
- * @since 1.0
  */
-@FunctionalInterface
-@API(status = API.Status.STABLE, since = "1.0")
-public interface IdGenerator<T> {
+public class TestSequenceGenerator implements IdGenerator<String> {
 
-	/**
-	 * Generates a new id for given entity.
-	 *
-	 * @param entity the entity to be saved
-	 * @return id to be assigned to the entity
-	 */
-	T generateId(String primaryLabel, Object entity);
+	private final AtomicInteger sequence = new AtomicInteger(0);
+
+	@Override
+	public String generateId(String primaryLabel, Object entity) {
+		return StringUtils.uncapitalize(primaryLabel) + "-" + sequence.incrementAndGet();
+	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAssignedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAssignedId.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.springframework.data.integration.shared;
 
-import static org.neo4j.springframework.data.core.schema.Id.Strategy.*;
-
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 
@@ -31,7 +29,7 @@ import org.neo4j.springframework.data.core.schema.Node;
 @Node("Thing")
 public class ThingWithAssignedId {
 
-	@Id(strategy = ASSIGNED)
+	@Id
 	private final String theId;
 
 	private String name;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithGeneratedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithGeneratedId.java
@@ -26,26 +26,16 @@ import org.neo4j.springframework.data.core.schema.Node;
  * @author Michael J. Simons
  */
 @Node
-public class ThingWithGeneratedId {
+public class ThingWithGeneratedId extends AbstractNamedThing {
 
 	@Id @GeneratedValue(TestSequenceGenerator.class)
 	private String theId;
 
-	private String name;
-
 	public ThingWithGeneratedId(String name) {
-		this.name = name;
+		super.setName(name);
 	}
 
 	public String getTheId() {
 		return theId;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithGeneratedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithGeneratedId.java
@@ -16,26 +16,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.springframework.data.core.schema;
+package org.neo4j.springframework.data.integration.shared;
 
-import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
 
 /**
- * Interface for generating ids for entities.
- *
- * @param <T> Type of the id to generate
  * @author Michael J. Simons
- * @since 1.0
  */
-@FunctionalInterface
-@API(status = API.Status.STABLE, since = "1.0")
-public interface IdGenerator<T> {
+@Node
+public class ThingWithGeneratedId {
 
-	/**
-	 * Generates a new id for given entity.
-	 *
-	 * @param entity the entity to be saved
-	 * @return id to be assigned to the entity
-	 */
-	T generateId(String primaryLabel, Object entity);
+	@Id @GeneratedValue(TestSequenceGenerator.class)
+	private String theId;
+
+	private String name;
+
+	public ThingWithGeneratedId(String name) {
+		this.name = name;
+	}
+
+	public String getTheId() {
+		return theId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithIdGeneratedByBean.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithIdGeneratedByBean.java
@@ -18,22 +18,21 @@
  */
 package org.neo4j.springframework.data.integration.shared;
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
 import org.neo4j.springframework.data.core.schema.Node;
 
 /**
- * Has an assigned id.
- *
  * @author Michael J. Simons
  */
-@Node("Thing")
-public class ThingWithAssignedId extends AbstractNamedThing {
+@Node
+public class ThingWithIdGeneratedByBean extends AbstractNamedThing {
 
-	@Id
-	private final String theId;
+	@Id @GeneratedValue(generatorRef = "aFancyIdGenerator")
+	private String theId;
 
-	public ThingWithAssignedId(String theId) {
-		this.theId = theId;
+	public ThingWithIdGeneratedByBean(String name) {
+		this.setName(name);
 	}
 
 	public String getTheId() {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/IdPopulatorTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/IdPopulatorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.IdDescription;
+import org.neo4j.springframework.data.core.schema.IdGenerator;
+import org.neo4j.springframework.data.core.schema.Node;
+
+@ExtendWith(MockitoExtension.class)
+class IdPopulatorTest {
+
+	@Mock
+	private Neo4jMappingContext neo4jMappingContext;
+
+	@Mock
+	private Neo4jPersistentEntity<?> nodeDescription;
+
+	@Test
+	void shouldRejectNullMappingContext() {
+		Assertions.assertThatIllegalArgumentException().isThrownBy(() -> new IdPopulator(null))
+			.withMessage("A mapping context is required.");
+	}
+
+	@Test
+	void shouldRejectNullEntity() {
+		IdPopulator idPopulator = new IdPopulator(neo4jMappingContext);
+		Assertions.assertThatIllegalArgumentException().isThrownBy(() -> idPopulator.populateIfNecessary(null))
+			.withMessage("Entity may not be null!");
+	}
+
+	@Test
+	void shouldIgnoreInternalIdGenerator() {
+
+		IdDescription toBeReturned = IdDescription.forInternallyGeneratedIds();
+		doReturn(toBeReturned).when(nodeDescription).getIdDescription();
+		doReturn(nodeDescription).when(neo4jMappingContext).getRequiredPersistentEntity(Sample.class);
+
+		IdPopulator idPopulator = new IdPopulator(neo4jMappingContext);
+		Sample sample = new Sample();
+
+		assertThat(idPopulator.populateIfNecessary(sample)).isSameAs(sample);
+
+		verify(nodeDescription).getIdDescription();
+		verify(neo4jMappingContext).getRequiredPersistentEntity(Sample.class);
+
+		verifyNoMoreInteractions(nodeDescription, neo4jMappingContext);
+	}
+
+	@Test
+	void shouldNotActOnAssignedProperty() {
+
+		IdPopulator idPopulator = new IdPopulator(new Neo4jMappingContext());
+		Sample sample = new Sample();
+		sample.theId = "something";
+
+		Sample populatedSample = (Sample) idPopulator.populateIfNecessary(sample);
+		assertThat(populatedSample).isSameAs(sample);
+		assertThat(populatedSample.theId).isEqualTo("something");
+	}
+
+	@Test
+	void shouldInvokeGenerator() {
+
+		IdPopulator idPopulator = new IdPopulator(new Neo4jMappingContext());
+		Sample sample = new Sample();
+
+		Sample populatedSample = (Sample) idPopulator.populateIfNecessary(sample);
+		assertThat(populatedSample).isSameAs(sample);
+		assertThat(populatedSample.theId).isEqualTo("Not necessary unique.");
+	}
+
+	@Node
+	static class Sample {
+
+		@Id @GeneratedValue(DummyIdGenerator.class)
+		private String theId;
+	}
+
+	static class DummyIdGenerator implements IdGenerator<String> {
+
+		@Override
+		public String generateId(String primaryLabel, Object entity) {
+			return "Not necessary unique.";
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.springframework.data.repository.event;
 
-import static org.neo4j.springframework.data.core.schema.Id.Strategy.*;
-
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
@@ -27,8 +25,8 @@ import lombok.experimental.Wither;
 
 import java.util.Date;
 
-import org.neo4j.springframework.data.core.schema.Id;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 
 /**
@@ -40,7 +38,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 @NoArgsConstructor(force = true)
 public class ImmutableSample {
 
-	@Id(strategy = ASSIGNED) String id;
+	@Id String id;
 	@CreatedDate Date created;
 	@LastModifiedDate Date modified;
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallbackTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ReactiveAuditingBeforeBindCallbackTest.java
@@ -71,7 +71,8 @@ class ReactiveAuditingBeforeBindCallbackTest {
 			.expectNextMatches(s -> {
 				Sample auditedObject = (Sample) s;
 				return auditedObject.created != null && auditedObject.modified != null;
-			});
+			})
+			.verifyComplete();
 
 		verify(spyOnHandler, times(1)).markCreated(sample);
 		verify(spyOnHandler, times(0)).markModified(any());
@@ -89,7 +90,8 @@ class ReactiveAuditingBeforeBindCallbackTest {
 			.expectNextMatches(s -> {
 				Sample auditedObject = (Sample) s;
 				return auditedObject.created == null && auditedObject.modified != null;
-			});
+			})
+			.verifyComplete();
 
 		verify(spyOnHandler, times(0)).markCreated(any());
 		verify(spyOnHandler, times(1)).markModified(sample);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/Sample.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/Sample.java
@@ -18,12 +18,10 @@
  */
 package org.neo4j.springframework.data.repository.event;
 
-import static org.neo4j.springframework.data.core.schema.Id.Strategy.*;
-
 import java.util.Date;
 
-import org.neo4j.springframework.data.core.schema.Id;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
 
@@ -32,7 +30,7 @@ import org.springframework.data.annotation.Version;
  */
 class Sample {
 
-	@Id(strategy = ASSIGNED) String id;
+	@Id String id;
 	@Version Long version;
 	@CreatedDate Date created;
 	@LastModifiedDate Date modified;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/RepositoryQueryTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/RepositoryQueryTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.Point;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.MappingException;
 import org.neo4j.springframework.data.core.Neo4jClient;
@@ -243,7 +244,7 @@ final class RepositoryQueryTest {
 	}
 
 	static class TestEntity {
-		@Id
+		@Id @GeneratedValue
 		private Long id;
 	}
 

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/shared/KotlinPerson.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/shared/KotlinPerson.kt
@@ -19,6 +19,7 @@
 
 package org.neo4j.springframework.data.integration.shared
 
+import org.neo4j.springframework.data.core.schema.GeneratedValue
 import org.neo4j.springframework.data.core.schema.Id
 import org.neo4j.springframework.data.core.schema.Node
 
@@ -26,4 +27,4 @@ import org.neo4j.springframework.data.core.schema.Node
  * @author Gerrit Meier
  */
 @Node
-data class KotlinPerson(@Id val id: Long, val name: String)
+data class KotlinPerson(@Id @GeneratedValue val id: Long, val name: String)


### PR DESCRIPTION
Please see the comment of the first commit and the JavaDoc of `org.neo4j.springframework.data.core.schema.Id` and `org.neo4j.springframework.data.core.schema.GeneratedValue` for usage of the new, allowed combinations:

```
@Id @GeneratedValue Long id;

@Id SomeSupportedType id;

@Id @Property("anotherName") SomeSupportedType id;

@Id  @GeneratedValue(SomeGenerator.class) SomeSupportedType id;

@Id @Property("anotherName") @GeneratedValue(SomeGenerator.class) SomeSupportedType id;
```

Second commit is the actual feature of generating external ids. The feature is also based on the callbacks mechanism of Spring Data.