### PR TITLE
Introduce pragmatic relationship modification

### DIFF
--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationship.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationship.java
@@ -45,6 +45,10 @@ public class PersonWithRelationship {
 		return id;
 	}
 
+	public void setId(Long id) {
+		this.id = id;
+	}
+
 	public String getName() {
 		return name;
 	}


### PR DESCRIPTION
Remove all existing relationships and re-create them when saving an entity.
This sounds a little bit too much overhead but has the advantage of avoiding a cache or similar constructs to handle relationships.
Of course this might get revisited when relationship support gets more comples.