### PR TITLE
Replace string based projections and pattern comprehensions with Cypher DSL.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
@@ -108,10 +108,11 @@ public final class Cypher {
 	 * Creates a new symbolic name.
 	 *
 	 * @param value The value of the symbolic name
-	 * @return A new symoblic name
+	 * @return A new symbolic name
 	 */
 	public static SymbolicName name(String value) {
-		return new SymbolicName(value);
+
+		return SymbolicName.create(value);
 	}
 
 	/**
@@ -291,6 +292,7 @@ public final class Cypher {
 	public static PatternComprehension.OngoingDefinition listBasedOn(RelationshipChain pattern) {
 		return PatternComprehension.basedOn(pattern);
 	}
+
 	/**
 	 * Escapes and quotes the {@code unquotedString} for safe usage in Neo4j-Browser and Shell.
 	 *
@@ -324,6 +326,34 @@ public final class Cypher {
 		} else {
 			return existingUnionQuery.addAdditionalQueries(listOfQueries);
 		}
+	}
+
+	/**
+	 * This is a literal copy of {@link javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to
+	 * be not dependent on the compiler module.
+	 *
+	 * @param name A possible Java identifier
+	 * @return True, if {@code name} represents an identifier.
+	 */
+	static boolean isIdentifier(CharSequence name) {
+		String id = name.toString();
+
+		if (id.length() == 0) {
+			return false;
+		}
+		int cp = id.codePointAt(0);
+		if (!Character.isJavaIdentifierStart(cp)) {
+			return false;
+		}
+		for (int i = Character.charCount(cp);
+			 i < id.length();
+			 i += Character.charCount(cp)) {
+			cp = id.codePointAt(i);
+			if (!Character.isJavaIdentifierPart(cp)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
@@ -284,6 +284,13 @@ public final class Cypher {
 		return unionImpl(true, statement);
 	}
 
+	public static PatternComprehension.OngoingDefinition listBasedOn(Relationship pattern) {
+		return PatternComprehension.basedOn(pattern);
+	}
+
+	public static PatternComprehension.OngoingDefinition listBasedOn(RelationshipChain pattern) {
+		return PatternComprehension.basedOn(pattern);
+	}
 	/**
 	 * Escapes and quotes the {@code unquotedString} for safe usage in Neo4j-Browser and Shell.
 	 *

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expressions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expressions.java
@@ -45,7 +45,7 @@ public final class Expressions {
 	}
 
 	static Expression[] createSymbolicNames(String[] variables) {
-		return Arrays.stream(variables).map(SymbolicName::new).toArray(Expression[]::new);
+		return Arrays.stream(variables).map(SymbolicName::create).toArray(Expression[]::new);
 	}
 
 	private Expressions() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FunctionInvocation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FunctionInvocation.java
@@ -52,4 +52,10 @@ public final class FunctionInvocation implements Expression {
 		this.arguments.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override public String toString() {
+		return "FunctionInvocation{" +
+			"functionName='" + functionName + '\'' +
+			'}';
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/HasLabelCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/HasLabelCondition.java
@@ -18,32 +18,50 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
+import org.springframework.util.Assert;
 
 /**
- * A negated version of the condition passed during construction of this condition.
+ * A condition checking for the presence of labels on nodes.
  *
  * @author Michael J. Simons
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
-public final class NotCondition implements Condition {
+public final class HasLabelCondition implements Condition {
 
-	/**
-	 * The condition to which the visit is delegated to after entering this condition.
-	 */
-	private final Condition condition;
+	private final SymbolicName nodeName;
+	private final List<NodeLabel> nodeLabels;
 
-	NotCondition(Condition condition) {
-		this.condition = condition;
+	static HasLabelCondition create(SymbolicName nodeName, String... labels) {
+
+		Assert.notNull(nodeName, "A symbolic name for the node is required.");
+		Assert.notNull(labels, "Labels to query are required.");
+		Assert.notEmpty(labels, "At least one label to query is required.");
+
+		final List<NodeLabel> nodeLabels = new ArrayList<>(labels.length);
+		for (String label : labels) {
+			nodeLabels.add(new NodeLabel(label));
+		}
+
+		return new HasLabelCondition(nodeName, nodeLabels);
+	}
+
+	private HasLabelCondition(SymbolicName nodeName, List<NodeLabel> nodeLabels) {
+		this.nodeName = nodeName;
+		this.nodeLabels = nodeLabels;
 	}
 
 	@Override
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
-		condition.accept(visitor);
+		nodeName.accept(visitor);
+		this.nodeLabels.forEach(label -> label.accept(visitor));
 		visitor.leave(this);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/KeyValueMapEntry.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/KeyValueMapEntry.java
@@ -19,14 +19,37 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import org.apiguardian.api.API;
-import org.neo4j.springframework.data.core.cypher.support.Visitable;
+import org.neo4j.springframework.data.core.cypher.support.Visitor;
+import org.springframework.lang.Nullable;
 
 /**
- * A shared, internally used interface for {@link MapExpression map expressions}.
+ * Helper class, only for internal use.
  *
  * @author Michael J. Simons
+ * @soundtrack Rammstein - RAMMSTEIN
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
-public interface MapEntry extends Visitable {
+public final class KeyValueMapEntry implements MapEntry {
+
+	private @Nullable final String key;
+
+	private final Expression value;
+
+	KeyValueMapEntry(@Nullable String key, Expression value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public @Nullable String getKey() {
+		return key;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		value.accept(visitor);
+		visitor.leave(this);
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapExpression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapExpression.java
@@ -52,12 +52,16 @@ public final class MapExpression<S extends MapExpression<S>> extends TypedSubtre
 			Assert.isInstanceOf(Expression.class, input[i + 1], "Value needs to be of type Expression.");
 			Assert.isTrue(!knownKeys.contains(input[i]), "Duplicate key '" + input[i] + "'");
 
-			final MapEntry entry = new MapEntry((String) input[i], (Expression) input[i + 1]);
+			final KeyValueMapEntry entry = new KeyValueMapEntry((String) input[i], (Expression) input[i + 1]);
 			newContent.add(entry);
 			knownKeys.add(entry.getKey());
 		}
 
 		return new MapExpression<>(newContent);
+	}
+
+	static MapExpression<?> withEntries(List<MapEntry> entries) {
+		return new MapExpression<>(entries);
 	}
 
 	private MapExpression(List<MapEntry> children) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
@@ -37,6 +37,10 @@ public class MapProjection implements Expression {
 
 	private MapExpression<?> map;
 
+	static MapProjection create(SymbolicName name, List<Object> content) {
+		return create(name, content.toArray());
+	}
+
 	static MapProjection create(SymbolicName name, Object... content) {
 
 		final List<MapEntry> newContent = new ArrayList<>(content.length);

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.springframework.data.core.cypher.support.Visitor;
+import org.springframework.util.Assert;
+
+/**
+ * Represents a map projection as described <a href="https://medium.com/neo4j/loading-graph-data-for-an-object-graph-mapper-or-graphql-5103b1a8b66e">here</a>.
+ *
+ * @author Michael J. Simons
+ */
+public class MapProjection implements Expression {
+
+	private SymbolicName name;
+
+	private MapExpression<?> map;
+
+	static MapProjection create(SymbolicName name, Object... content) {
+
+		final List<MapEntry> newContent = new ArrayList<>(content.length);
+		final Set<String> knownKeys = new HashSet<>();
+
+		String lastKey = null;
+		Expression lastExpression = null;
+		int i = 0;
+		while (i < content.length) {
+
+			Object next;
+			if (i + 1 >= content.length) {
+				next = null;
+			} else {
+				next = content[i + 1];
+			}
+			Object current = content[i];
+
+			if (current instanceof String) {
+				if (next instanceof Expression) {
+					lastKey = (String) current;
+					lastExpression = (Expression) next;
+					i += 2;
+				} else {
+					lastKey = null;
+					lastExpression = new PropertyLookup((String) current);
+					i += 1;
+				}
+			} else if (current instanceof Expression) {
+				lastKey = null;
+				lastExpression = ((Expression) current);
+				i += 1;
+			}
+
+			if (lastExpression instanceof Property) {
+				lastExpression = ((Property) lastExpression).getName();
+			} else if (lastExpression instanceof Asterisk) {
+				lastExpression = new PropertyLookup("*");
+			}
+
+			final MapEntry entry;
+			if (lastKey != null) {
+				Assert.isTrue(!knownKeys.contains(lastKey), "Duplicate key '" + lastKey + "'");
+				entry = new KeyValueMapEntry(lastKey, lastExpression);
+				knownKeys.add(lastKey);
+			} else if (lastExpression instanceof PropertyLookup) {
+				entry = (PropertyLookup) lastExpression;
+			} else {
+				throw new IllegalArgumentException(lastExpression + " of type " + lastExpression.getClass()
+					+ " cannot be used with an implicit name as map entry.");
+			}
+
+			newContent.add(entry);
+			lastKey = null;
+			lastExpression = null;
+		}
+
+		return new MapProjection(name, MapExpression.withEntries(newContent));
+	}
+
+	public MapProjection(SymbolicName name, MapExpression<?> map) {
+		this.name = name;
+		this.map = map;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.enter(this);
+		this.name.accept(visitor);
+		this.map.accept(visitor);
+		visitor.leave(this);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -130,6 +130,22 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 		return properties(newProperties);
 	}
 
+	/**
+	 * Creates a map projection based on this node. The node needs a symbolic name for this to work.
+	 * <p>
+	 * Entries of type {@code String} in {@code entries} followed by an {@link Expression} will be treated as map keys
+	 * pointing to the expression in the projection, {@code String} entries alone will be treated as property lookups on the node.
+	 *
+	 * @param entries A list of entries for the projection
+	 * @return A map projection.
+	 */
+	public MapProjection project(Object... entries) {
+		return MapProjection.create(this.getSymbolicName().orElseThrow(() -> new IllegalStateException("Cannot project a node without a symbolic name.")), entries);
+	}
+
+	/**
+	 * @return The optional symbolic name of this node.
+	 */
 	public Optional<SymbolicName> getSymbolicName() {
 		return Optional.ofNullable(symbolicName);
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -99,7 +99,7 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 	public Node named(String newSymbolicName) {
 
 		Assert.hasText(newSymbolicName, "Symbolic name is required.");
-		return new Node(new SymbolicName(newSymbolicName), properties, labels);
+		return new Node(SymbolicName.create(newSymbolicName), properties, labels);
 	}
 
 	/**
@@ -128,6 +128,17 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 			newProperties = MapExpression.create(keysAndValues);
 		}
 		return properties(newProperties);
+	}
+
+	/**
+	 * A list will never be a valid entry for a map projection, so this convenient method prevents trying to create one
+	 * from a list of objects. It will delegate to {@link #project(Object...)} with the content of the list.
+	 *
+	 * @param entries A list of entries for the projection
+	 * @return A map projection.
+	 */
+	public MapProjection project(List<Object> entries) {
+		return project(entries.toArray());
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -183,6 +183,18 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 		return Relationship.create(this, Direction.UNI, other, types);
 	}
 
+	/**
+	 * A condition that checks for the presence of labels on a node.
+	 *
+	 * @param labelsToQuery A list of labels to query
+	 * @return A condition that checks whether this node has all of the labels to query
+	 */
+	public Condition hasLabels(String... labelsToQuery) {
+		return HasLabelCondition.create(this.getSymbolicName()
+				.orElseThrow(() -> new IllegalStateException("Cannot query a node without a symbolic name.")),
+			labelsToQuery);
+	}
+
 	@Override
 	public void accept(Visitor visitor) {
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
@@ -60,7 +60,7 @@ public final class PatternComprehension implements Expression {
 		 * @param listDefinition Defines the elements to be returned from the pattern
 		 * @return The final definition of the pattern comprehension
 		 */
-		PatternComprehension definedAs(Expression... listDefinition);
+		PatternComprehension returning(Expression... listDefinition);
 	}
 
 	/**
@@ -80,7 +80,7 @@ public final class PatternComprehension implements Expression {
 		}
 
 		@Override
-		public PatternComprehension definedAs(Expression... expressions) {
+		public PatternComprehension returning(Expression... expressions) {
 
 			Assert.notNull(expressions, "Expressions are required.");
 			Assert.notEmpty(expressions, "At least one expression is required.");

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.springframework.data.core.cypher.support.Visitable;
+import org.neo4j.springframework.data.core.cypher.support.Visitor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M14/railroad/PatternComprehension.html">PatternComprehension</a>
+ * and <a href="https://neo4j.com/docs/cypher-manual/current/syntax/lists/#cypher-pattern-comprehension">the corresponding cypher manual entry</a>.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+public final class PatternComprehension implements Expression {
+
+	private final RelationshipChain pattern;
+	private @Nullable final Where where;
+	private final Expression listDefinition;
+
+	static OngoingDefinition basedOn(Relationship pattern) {
+
+		Assert.notNull(pattern, "A pattern is required");
+		return new OngoingDefinition(RelationshipChain.create(pattern));
+	}
+
+	static OngoingDefinition basedOn(RelationshipChain pattern) {
+
+		Assert.notNull(pattern, "A pattern is required");
+		return new OngoingDefinition(pattern);
+	}
+
+	/**
+	 * Provides the final step of defining a pattern comprehension.
+	 */
+	public interface OngoingDefinitionWithPattern {
+
+		/**
+		 * @param listDefinition Defines the elements to be returned from the pattern
+		 * @return The final definition of the pattern comprehension
+		 */
+		PatternComprehension definedAs(Expression... listDefinition);
+	}
+
+	/**
+	 * Ongoing definition of a pattern comprehension. Can be defined without a where-clause now.
+	 */
+	public static class OngoingDefinition implements OngoingDefinitionWithPattern {
+		private final RelationshipChain pattern;
+		private Where where;
+
+		public OngoingDefinition(RelationshipChain pattern) {
+			this.pattern = pattern;
+		}
+
+		public OngoingDefinitionWithPattern where(Condition condition) {
+			this.where = new Where(condition);
+			return this;
+		}
+
+		@Override
+		public PatternComprehension definedAs(Expression... expressions) {
+
+			Assert.notNull(expressions, "Expressions are required.");
+			Assert.notEmpty(expressions, "At least one expression is required.");
+
+			List<Expression> expressionList = new ArrayList<>();
+			for (Expression expression : expressions) {
+				Expression newExpression = expression;
+				if (expression instanceof Named) {
+					newExpression = ((Named) expression)
+						.getSymbolicName()
+						.orElseThrow(() -> new IllegalArgumentException(
+							"A named expression must have a symbolic name inside a list definition."));
+				}
+				expressionList.add(newExpression);
+			}
+
+			Expression listDefinition;
+			if (expressions.length == 1) {
+				listDefinition = expressions[0];
+			} else {
+				listDefinition = ListExpression.create(expressions);
+			}
+			return new PatternComprehension(pattern, where, listDefinition);
+		}
+	}
+
+	private PatternComprehension(RelationshipChain pattern, @Nullable Where where, Expression listDefinition) {
+		this.pattern = pattern;
+		this.where = where;
+		this.listDefinition = listDefinition;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.enter(this);
+		this.pattern.accept(visitor);
+		Visitable.visitIfNotNull(this.where, visitor);
+		Pipe.INSTANCE.accept(visitor);
+		this.listDefinition.accept(visitor);
+		visitor.leave(this);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pipe.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pipe.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import org.apiguardian.api.API;
+
+/**
+ * The pipe ({@code |}) literal.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+final class Pipe extends Literal<String> {
+
+	public static final Pipe INSTANCE = new Pipe();
+
+	private Pipe() {
+		super("|");
+	}
+
+	@Override
+	public String asString() {
+		return super.getContent();
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
@@ -37,7 +37,7 @@ public final class Property implements Expression {
 			"A property derived from a node needs a parent with a symbolic name.");
 		Assert.hasText(name, "The properties name is required.");
 
-		return new Property(parentContainer.getSymbolicName().get(), name);
+		return new Property(parentContainer.getSymbolicName().get(), new PropertyLookup((name)));
 	}
 
 	static Property create(Expression container, String name) {
@@ -45,7 +45,7 @@ public final class Property implements Expression {
 		Assert.notNull(container, "The property container is required.");
 		Assert.hasText(name, "The properties name is required.");
 
-		return new Property(container, name);
+		return new Property(container, new PropertyLookup(name));
 
 	}
 
@@ -57,15 +57,15 @@ public final class Property implements Expression {
 	/**
 	 * The name of this property.
 	 */
-	private final String name;
+	private final PropertyLookup name;
 
-	Property(Expression container, String name) {
+	Property(Expression container, PropertyLookup name) {
 
 		this.container = container;
 		this.name = name;
 	}
 
-	public String getName() {
+	public PropertyLookup getName() {
 		return name;
 	}
 
@@ -84,6 +84,7 @@ public final class Property implements Expression {
 	public void accept(Visitor visitor) {
 		visitor.enter(this);
 		this.container.accept(visitor);
+		this.name.accept(visitor);
 		visitor.leave(this);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PropertyLookup.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PropertyLookup.java
@@ -19,14 +19,23 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import org.apiguardian.api.API;
-import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
 /**
- * A shared, internally used interface for {@link MapExpression map expressions}.
+ * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M14/railroad/PropertyLookup.html">PropertyLookup</a>
  *
  * @author Michael J. Simons
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
-public interface MapEntry extends Visitable {
+public final class PropertyLookup implements MapEntry, Expression {
+
+	private final String propertyKeyName;
+
+	PropertyLookup(String propertyKeyName) {
+		this.propertyKeyName = propertyKeyName;
+	}
+
+	public String getPropertyKeyName() {
+		return propertyKeyName;
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -121,6 +121,7 @@ public final class Relationship implements
 		return new Relationship(this.left, this.details.named(newSymbolicName), this.right);
 	}
 
+	@Override
 	public Optional<SymbolicName> getSymbolicName() {
 		return details.getSymbolicName();
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -157,4 +157,17 @@ public final class Relationship implements
 
 		visitor.leave(this);
 	}
+
+	/**
+	 * Creates a map projection based on this relationship. The relationship needs a symbolic name for this to work.
+	 * <p>
+	 * Entries of type {@code String} in {@code entries} followed by an {@link Expression} will be treated as map keys
+	 * pointing to the expression in the projection, {@code String} entries alone will be treated as property lookups on the node.
+	 *
+	 * @param entries A list of entries for the projection
+	 * @return A map projection.
+	 */
+	public MapProjection project(Object... entries) {
+		return MapProjection.create(this.getSymbolicName().orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")), entries);
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -67,7 +67,7 @@ public final class RelationshipDetail implements Visitable {
 	RelationshipDetail named(String newSymbolicName) {
 
 		Assert.hasText(newSymbolicName, "Symbolic name is required.");
-		return new RelationshipDetail(this.direction, new SymbolicName(newSymbolicName), this.types);
+		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types);
 	}
 
 	RelationshipDetail withType(String... newTypes) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
@@ -19,12 +19,16 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import org.apiguardian.api.API;
+import org.springframework.util.Assert;
 
 /**
  * A symbolic name to identify nodes and relationships.
  * <p>
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/SchemaName.html">SchemaName</a>
  * <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/SymbolicName.html">SymbolicName</a>
+ * <p>
+ * While OpenCypher extends the <a href="https://unicode.org/reports/tr31/">UNICODE IDENTIFIER AND PATTERN SYNTAX</a>
+ * with some characters, this DSL uses the same identifier Java itself uses for simplicity and until otherwise needed.
  *
  * @author Michael J. Simons
  * @since 1.0
@@ -34,7 +38,13 @@ public final class SymbolicName implements Expression {
 
 	private final String name;
 
-	SymbolicName(String name) {
+	static SymbolicName create(String name) {
+
+		Assert.isTrue(Cypher.isIdentifier(name), "Name must be a valid identifier.");
+		return new SymbolicName(name);
+	}
+
+	private SymbolicName(String name) {
 		this.name = name;
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Unwind.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Unwind.java
@@ -38,7 +38,7 @@ public final class Unwind implements ReadingClause {
 	Unwind(Expression expressionToUnwind, String variable) {
 
 		if (expressionToUnwind instanceof Aliased) {
-			this.expressionToUnwind = new SymbolicName(((Aliased) expressionToUnwind).getAlias());
+			this.expressionToUnwind = SymbolicName.create(((Aliased) expressionToUnwind).getAlias());
 		} else {
 			this.expressionToUnwind = expressionToUnwind;
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
@@ -220,10 +220,10 @@ class RenderingVisitor extends ReflectiveVisitor {
 			.append(direction.getSymbol());
 	}
 
-	void leave(Property property) {
+	void enter(PropertyLookup propertyLookup) {
 		builder
 			.append(".")
-			.append(property.getName());
+			.append(propertyLookup.getPropertyKeyName());
 	}
 
 	void enter(FunctionInvocation functionInvocation) {
@@ -346,7 +346,7 @@ class RenderingVisitor extends ReflectiveVisitor {
 		builder.append("{");
 	}
 
-	void enter(MapEntry map) {
+	void enter(KeyValueMapEntry map) {
 
 		builder.append(map.getKey()).append(": ");
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
@@ -403,6 +403,14 @@ class RenderingVisitor extends ReflectiveVisitor {
 		builder.append(" ");
 	}
 
+	void enter(PatternComprehension patternComprehension) {
+		builder.append("[");
+	}
+
+	void leave(PatternComprehension patternComprehension) {
+		builder.append("]");
+	}
+
 	public String getRenderedContent() {
 		return this.builder.toString();
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
@@ -328,7 +328,7 @@ public final class CypherAdapterUtils {
 
 				generatedLists.add(relationshipTargetName);
 				generatedLists.add(listBasedOn(relationship)
-					.definedAs(projectPropertiesAndRelationships(endNodeDescription, propertyName)));
+					.returning(projectPropertiesAndRelationships(endNodeDescription, propertyName)));
 			}
 
 			return generatedLists;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.NotNull;
@@ -101,6 +100,7 @@ public final class CypherAdapterUtils {
 	 * @return new {@link SchemaBasedStatementBuilder} instance based on the given {@link Schema}
 	 */
 	public static SchemaBasedStatementBuilder createSchemaBasedStatementBuilder(Schema schema) {
+
 		return new SchemaBasedStatementBuilder(schema);
 	}
 
@@ -266,35 +266,48 @@ public final class CypherAdapterUtils {
 
 		}
 
-		public String createReturnStatementForMatch(NodeDescription<?> nodeDescription) {
+		public Expression createReturnStatementForMatch(NodeDescription<?> nodeDescription) {
 
-			Collection<RelationshipDescription> relationshipDescriptions = schema.getRelationshipsOf(nodeDescription.getPrimaryLabel());
-
-			return NAME_OF_ROOT_NODE + "{"
-				+ getGraphPropertiesAsString(nodeDescription, NAME_OF_ROOT_NODE)
-				+ processRelationshipsForMatch(relationshipDescriptions, NAME_OF_ROOT_NODE)
-				+ "}";
+			return projectPropertiesAndRelationships(nodeDescription, NAME_OF_ROOT_NODE);
 		}
 
-		private String getGraphPropertiesAsString(NodeDescription<?> nodeDescription, String nodeName) {
+		private MapProjection projectPropertiesAndRelationships(NodeDescription<?> nodeDescription,
+			String propertyName) {
 
-			return nodeDescription.getGraphProperties().stream()
-				.map(property -> {
-					if (property.isInternalIdProperty()) {
-						return NAME_OF_INTERNAL_ID + ": id(" + nodeName + ")";
-					}
-					return "." + property.getPropertyName();
-				})
-				.collect(Collectors.joining(","));
+			Collection<RelationshipDescription> relationships = schema
+				.getRelationshipsOf(nodeDescription.getPrimaryLabel());
+
+			List<Object> contentOfProjection = new ArrayList<>();
+			contentOfProjection.addAll(projectNodeProperties(nodeDescription, propertyName));
+			contentOfProjection.addAll(generateListsOf(relationships, propertyName));
+
+			return Cypher.anyNode(propertyName).project(contentOfProjection);
 		}
 
-		private String processRelationshipsForMatch(Collection<RelationshipDescription> relationshipDescriptions, String nameOfStartNode) {
-			StringBuilder returnStatementBuilder = new StringBuilder();
-			for (RelationshipDescription relationshipDescription : relationshipDescriptions) {
+		private List<Object> projectNodeProperties(NodeDescription<?> nodeDescription, String nodeName) {
+
+			List<Object> nodePropertiesProjection = new ArrayList<>();
+			for (GraphPropertyDescription property : nodeDescription.getGraphProperties()) {
+				if (property.isInternalIdProperty()) {
+					nodePropertiesProjection.add(NAME_OF_INTERNAL_ID);
+					nodePropertiesProjection.add(Functions.id(Cypher.name(nodeName)));
+				} else {
+					nodePropertiesProjection.add(property.getPropertyName());
+				}
+			}
+
+			return nodePropertiesProjection;
+		}
+
+		private List<Object> generateListsOf(Collection<RelationshipDescription> relationships,
+			String nameOfStartNode) {
+
+			List<Object> generatedLists = new ArrayList<>();
+			for (RelationshipDescription relationshipDescription : relationships) {
 
 				String sourceLabel = relationshipDescription.getSource();
-				String relationshipType = relationshipDescription.getType();
 				String targetLabel = relationshipDescription.getTarget();
+
 				String propertyName = relationshipDescription.getPropertyName();
 
 				// do not follow self-references more than once
@@ -302,33 +315,24 @@ public final class CypherAdapterUtils {
 					continue;
 				}
 
+				String relationshipType = relationshipDescription.getType();
 				String relationshipTargetName = SchemaUtils.generateRelatedNodesCollectionName(relationshipDescription);
 
-				returnStatementBuilder
-					.append(", ") // next related element
-					.append(relationshipTargetName).append(":")
-					.append("[ (").append(nameOfStartNode).append(")")
-					.append(relationshipDescription.isOutgoing() ? "-" : "<-")
-					.append("[:").append(relationshipType).append("]")
-					.append(relationshipDescription.isOutgoing() ? "->" : "-")
-					.append("(").append(propertyName).append(":").append(targetLabel).append(")")
-					.append("| ").append(getReturnValueForRelationship(targetLabel, propertyName)).append("]");
+				Node startNode = anyNode(nameOfStartNode);
+				Node endNode = node(targetLabel).named(propertyName);
+				NodeDescription<?> endNodeDescription = schema.getNodeDescription(targetLabel);
+
+				Relationship relationship = relationshipDescription.isOutgoing()
+					? startNode.relationshipTo(endNode, relationshipType)
+					: startNode.relationshipFrom(endNode, relationshipType);
+
+				generatedLists.add(relationshipTargetName);
+				generatedLists.add(listBasedOn(relationship)
+					.definedAs(projectPropertiesAndRelationships(endNodeDescription, propertyName)));
 			}
 
-			return returnStatementBuilder.toString();
+			return generatedLists;
 		}
-
-		private String getReturnValueForRelationship(String targetLabel, String propertyName) {
-
-			Collection<RelationshipDescription> relationships = schema.getRelationshipsOf(targetLabel);
-			NodeDescription<?> nodeDescription = schema.getNodeDescription(targetLabel);
-
-			return propertyName + "{"
-				+ getGraphPropertiesAsString(nodeDescription, propertyName)
-				+ processRelationshipsForMatch(relationships, propertyName)
-				+ "}";
-		}
-
 	}
 
 	private static Condition conditionOrNoCondition(@Nullable Condition condition) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -125,7 +125,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 		SchemaBasedStatementBuilder statementBuilder = createSchemaBasedStatementBuilder(mappingContext);
 		Statement statement = statementBuilder
 			.prepareMatchOf(nodeDescription, condition)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(nodeDescription)))
+			.returning(statementBuilder.createReturnStatementForMatch(nodeDescription))
 			.orderBy(
 				Stream.concat(
 					sortItems.stream(),

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/SimpleNeo4jRepository.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/SimpleNeo4jRepository.java
@@ -40,7 +40,6 @@ import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.Neo4jClient.ExecutableQuery;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.cypher.Condition;
-import org.neo4j.springframework.data.core.cypher.Cypher;
 import org.neo4j.springframework.data.core.cypher.Functions;
 import org.neo4j.springframework.data.core.cypher.Statement;
 import org.neo4j.springframework.data.core.cypher.StatementBuilder;
@@ -105,7 +104,7 @@ class SimpleNeo4jRepository<T, ID> implements PagingAndSortingRepository<T, ID> 
 	public Iterable<T> findAll(Sort sort) {
 
 		Statement statement = statementBuilder.prepareMatchOf(entityMetaData)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.orderBy(toSortItems(entityMetaData, sort))
 			.build();
 
@@ -116,7 +115,7 @@ class SimpleNeo4jRepository<T, ID> implements PagingAndSortingRepository<T, ID> 
 	public Page<T> findAll(Pageable pageable) {
 
 		OngoingReadingAndReturn returning = statementBuilder.prepareMatchOf(entityMetaData)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)));
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData));
 
 		StatementBuilder.BuildableStatement returningWithPaging = addPagingParameter(entityMetaData, pageable,
 			returning);
@@ -255,7 +254,7 @@ class SimpleNeo4jRepository<T, ID> implements PagingAndSortingRepository<T, ID> 
 
 		Statement statement = statementBuilder
 			.prepareMatchOf(entityMetaData, entityInformation.getIdExpression().isEqualTo(literalOf(id)))
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.build();
 		return createExecutableQuery(statement).getSingleResult();
 	}
@@ -269,7 +268,7 @@ class SimpleNeo4jRepository<T, ID> implements PagingAndSortingRepository<T, ID> 
 	public Iterable<T> findAll() {
 
 		Statement statement = statementBuilder.prepareMatchOf(entityMetaData)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData))).build();
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData)).build();
 		return createExecutableQuery(statement).getResults();
 	}
 
@@ -278,7 +277,7 @@ class SimpleNeo4jRepository<T, ID> implements PagingAndSortingRepository<T, ID> 
 
 		Statement statement = statementBuilder
 			.prepareMatchOf(entityMetaData, entityInformation.getIdExpression().in((parameter("ids"))))
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.build();
 
 		return createExecutableQuery(statement, singletonMap("ids", ids)).getResults();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/SimpleReactiveNeo4jRepository.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/SimpleReactiveNeo4jRepository.java
@@ -42,7 +42,6 @@ import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient.ExecutableQuery;
 import org.neo4j.springframework.data.core.cypher.Condition;
-import org.neo4j.springframework.data.core.cypher.Cypher;
 import org.neo4j.springframework.data.core.cypher.Functions;
 import org.neo4j.springframework.data.core.cypher.Statement;
 import org.neo4j.springframework.data.core.cypher.renderer.Renderer;
@@ -103,7 +102,7 @@ class SimpleReactiveNeo4jRepository<T, ID> implements ReactiveSortingRepository<
 	public Mono<T> findById(ID id) {
 		Statement statement = statementBuilder
 			.prepareMatchOf(entityMetaData, entityInformation.getIdExpression().isEqualTo(literalOf(id)))
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.build();
 		return createExecutableQuery(statement).getSingleResult();
 	}
@@ -116,7 +115,7 @@ class SimpleReactiveNeo4jRepository<T, ID> implements ReactiveSortingRepository<
 	@Override
 	public Flux<T> findAll(Sort sort) {
 		Statement statement = statementBuilder.prepareMatchOf(entityMetaData)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.orderBy(toSortItems(entityMetaData, sort))
 			.build();
 
@@ -136,7 +135,7 @@ class SimpleReactiveNeo4jRepository<T, ID> implements ReactiveSortingRepository<
 	@Override
 	public Flux<T> findAll() {
 		Statement statement = statementBuilder.prepareMatchOf(entityMetaData)
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData))).build();
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData)).build();
 		return createExecutableQuery(statement).getResults();
 	}
 
@@ -144,7 +143,7 @@ class SimpleReactiveNeo4jRepository<T, ID> implements ReactiveSortingRepository<
 	public Flux<T> findAllById(Iterable<ID> ids) {
 		Statement statement = statementBuilder
 			.prepareMatchOf(entityMetaData, entityInformation.getIdExpression().in((parameter("ids"))))
-			.returning(Cypher.name(statementBuilder.createReturnStatementForMatch(entityMetaData)))
+			.returning(statementBuilder.createReturnStatementForMatch(entityMetaData))
 			.build();
 
 		return createExecutableQuery(statement, singletonMap("ids", ids)).getResults();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherIT.java
@@ -2013,7 +2013,7 @@ class CypherIT {
 			Node b = Cypher.anyNode("b");
 
 			statement = Cypher.match(a)
-				.returning(listBasedOn(a.relationshipBetween(b)).definedAs(b.property("released")).as("years"))
+				.returning(listBasedOn(a.relationshipBetween(b)).returning(b.property("released")).as("years"))
 				.build();
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo(
@@ -2029,7 +2029,7 @@ class CypherIT {
 
 			statement = Cypher.match(a)
 				.returning(
-					listBasedOn(a.relationshipBetween(b)).where(b.hasLabels("Movie")).definedAs(b.property("released"))
+					listBasedOn(a.relationshipBetween(b)).where(b.hasLabels("Movie")).returning(b.property("released"))
 						.as("years"))
 				.build();
 			assertThat(cypherRenderer.render(statement))
@@ -2055,14 +2055,14 @@ class CypherIT {
 			statement = Cypher.match(n)
 				.returning(n,
 					listOf(
-						listBasedOn(r_f1).definedAs(r_f1, o1),
-						listBasedOn(r_e1).definedAs(r_e1, o1),
-						listBasedOn(r_l1).definedAs(
+						listBasedOn(r_f1).returning(r_f1, o1),
+						listBasedOn(r_e1).returning(r_e1, o1),
+						listBasedOn(r_l1).returning(
 							r_l1, l1,
 							// The building of the statement works with and without the outer list,
 							// I'm not sure if it would be necessary for the result, but as I took the query from
 							// Neo4j-OGM, I'd like to keep it
-							listOf(listBasedOn(r_l2).definedAs(r_l2, p2))
+							listOf(listBasedOn(r_l2).returning(r_l2, p2))
 						)
 					)
 				)

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherTest.java
@@ -54,11 +54,13 @@ class CypherTest {
 		Property property = Cypher.property("a", "b");
 		property.accept(segment -> {
 			if (segment instanceof Property) {
-				assertThat(segment).extracting("name").containsOnly("b");
+				assertThat(segment).extracting(s -> ((Property) s).getName().getPropertyKeyName()).isEqualTo("b");
+			} else if (segment instanceof PropertyLookup) {
+				assertThat(segment).extracting(s -> ((PropertyLookup) s).getPropertyKeyName()).isEqualTo("b");
 			} else if (segment instanceof SymbolicName) {
 				assertThat(segment).extracting("name").containsOnly("a");
 			} else {
-				fail("Unexpected segment");
+				fail("Unexpected segment: " + segment.getClass());
 			}
 		});
 	}


### PR DESCRIPTION
This replaces the string based building of the map projections and pattern comprehensions for fetching relationships with new additions to the Cypher DSL.

Cypher DSL has now
* `project` on `Node` and `Relationship`
* `listBasedOn` on `Cypher`
* A new `HasLabelCondition` (needed during tests, but useful)
* Checks in `SymbolicName` to prevent misusage to get arbitrary strings into the tree