### PR TITLE
GH-38 - Add support for Kotlins Coroutines to the ReactiveNeo4jClient.

### DIFF
--- a/spring-data-neo4j-rx/pom.xml
+++ b/spring-data-neo4j-rx/pom.xml
@@ -134,6 +134,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.mockk</groupId>
 			<artifactId>mockk</artifactId>
 			<version>${mockk}</version>

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultNeo4jClient.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultNeo4jClient.java
@@ -148,11 +148,11 @@ class DefaultNeo4jClient implements Neo4jClient {
 	@Override
 	public <T> ExecutableQuery<T> toExecutableQuery(PreparedQuery<T> preparedQuery) {
 
-		Neo4jClient.MappingSpec<Optional<T>, Collection<T>, T> mappingSpec = this
+		Neo4jClient.MappingSpec<T> mappingSpec = this
 			.query(preparedQuery.getCypherQuery())
 			.bindAll(preparedQuery.getParameters())
 			.fetchAs(preparedQuery.getResultType());
-		Neo4jClient.RecordFetchSpec<Optional<T>, Collection<T>, T> fetchSpec = preparedQuery
+		Neo4jClient.RecordFetchSpec<T> fetchSpec = preparedQuery
 			.getOptionalMappingFunction()
 			.map(f -> mappingSpec.mappedBy(f))
 			.orElse(mappingSpec);
@@ -249,14 +249,14 @@ class DefaultNeo4jClient implements Neo4jClient {
 		}
 
 		@Override
-		public <T> MappingSpec<Optional<T>, Collection<T>, T> fetchAs(Class<T> targetClass) {
+		public <T> MappingSpec<T> fetchAs(Class<T> targetClass) {
 
 			return new DefaultRecordFetchSpec(this.targetDatabase, this.runnableStatement,
 				new SingleValueMappingFunction(conversionService, targetClass));
 		}
 
 		@Override
-		public RecordFetchSpec<Optional<Map<String, Object>>, Collection<Map<String, Object>>, Map<String, Object>> fetch() {
+		public RecordFetchSpec<Map<String, Object>> fetch() {
 
 			return new DefaultRecordFetchSpec<>(
 				this.targetDatabase,
@@ -273,8 +273,7 @@ class DefaultNeo4jClient implements Neo4jClient {
 		}
 	}
 
-	class DefaultRecordFetchSpec<T>
-		implements RecordFetchSpec<Optional<T>, Collection<T>, T>, MappingSpec<Optional<T>, Collection<T>, T> {
+	class DefaultRecordFetchSpec<T> implements RecordFetchSpec<T>, MappingSpec<T> {
 
 		private final String targetDatabase;
 
@@ -290,7 +289,7 @@ class DefaultNeo4jClient implements Neo4jClient {
 		}
 
 		@Override
-		public RecordFetchSpec<Optional<T>, Collection<T>, T> mappedBy(
+		public RecordFetchSpec<T> mappedBy(
 			@SuppressWarnings("HiddenField") BiFunction<TypeSystem, Record, T> mappingFunction) {
 
 			this.mappingFunction = new DelegatingMappingFunctionWithNullCheck<>(mappingFunction);
@@ -368,10 +367,9 @@ class DefaultNeo4jClient implements Neo4jClient {
 	final class DefaultExecutableQuery<T> implements ExecutableQuery<T> {
 
 		private final PreparedQuery<T> preparedQuery;
-		private final Neo4jClient.RecordFetchSpec<Optional<T>, Collection<T>, T> fetchSpec;
+		private final Neo4jClient.RecordFetchSpec<T> fetchSpec;
 
-		DefaultExecutableQuery(PreparedQuery<T> preparedQuery,
-			RecordFetchSpec<Optional<T>, Collection<T>, T> fetchSpec) {
+		DefaultExecutableQuery(PreparedQuery<T> preparedQuery, RecordFetchSpec<T> fetchSpec) {
 			this.preparedQuery = preparedQuery;
 			this.fetchSpec = fetchSpec;
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jClient.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jClient.java
@@ -124,14 +124,14 @@ public interface Neo4jClient {
 		 * @param <T>         The type of the class
 		 * @return A mapping spec that allows specifying a mapping function.
 		 */
-		<T> MappingSpec<Optional<T>, Collection<T>, T> fetchAs(Class<T> targetClass);
+		<T> MappingSpec<T> fetchAs(Class<T> targetClass);
 
 		/**
 		 * Fetch all records mapped into generic maps
 		 *
 		 * @return A fetch specification that maps into generic maps.
 		 */
-		RecordFetchSpec<Optional<Map<String, Object>>, Collection<Map<String, Object>>, Map<String, Object>> fetch();
+		RecordFetchSpec<Map<String, Object>> fetch();
 
 		/**
 		 * Execute the query and discard the results. It returns the drivers result summary, including various counters
@@ -186,12 +186,10 @@ public interface Neo4jClient {
 	}
 
 	/**
-	 * @param <S> The type of the class holding zero or one result element
-	 * @param <M> The type of the class holding zero or more result elements
 	 * @param <T> The resulting type of this mapping
 	 * @since 1.0
 	 */
-	interface MappingSpec<S, M, T> extends RecordFetchSpec<S, M, T> {
+	interface MappingSpec<T> extends RecordFetchSpec<T> {
 
 		/**
 		 * The mapping function is responsible to turn one record into one domain object. It will receive the record
@@ -200,37 +198,35 @@ public interface Neo4jClient {
 		 * @param mappingFunction The mapping function used to create new domain objects
 		 * @return A specification how to fetch one or more records.
 		 */
-		RecordFetchSpec<S, M, T> mappedBy(BiFunction<TypeSystem, Record, T> mappingFunction);
+		RecordFetchSpec<T> mappedBy(BiFunction<TypeSystem, Record, T> mappingFunction);
 	}
 
 	/**
-	 * @param <S> The type of the class holding zero or one result element
-	 * @param <M> The type of the class holding zero or more result elements
 	 * @param <T> The type to which the fetched records are eventually mapped
 	 * @since 1.0
 	 */
-	interface RecordFetchSpec<S, M, T> {
+	interface RecordFetchSpec<T> {
 
 		/**
 		 * Fetches exactly one record and throws an exception if there are more entries.
 		 *
 		 * @return The one and only record.
 		 */
-		S one();
+		Optional<T> one();
 
 		/**
 		 * Fetches only the first record. Returns an empty holder if there are no records.
 		 *
 		 * @return The first record if any.
 		 */
-		S first();
+		Optional<T> first();
 
 		/**
 		 * Fetches all records.
 		 *
 		 * @return All records.
 		 */
-		M all();
+		Collection<T> all();
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/kotlin/org/neo4j/springframework/data/core/Neo4jClientExtensions.kt
+++ b/spring-data-neo4j-rx/src/main/kotlin/org/neo4j/springframework/data/core/Neo4jClientExtensions.kt
@@ -42,30 +42,30 @@ fun <T : Any?> Neo4jClient.OngoingDelegation<T>.inDatabase(targetDatabase: Strin
 		`in`(targetDatabase)
 
 /**
- * An implementation of a fetch spec that replaces Java's Optional with a nullable.
+ * A fetch spec that replaces Java's Optional with a nullable.
  * @author Michael J. Simons
  */
-class DelegatingFetchSpec<T : Any>(private val delegate: Neo4jClient.RecordFetchSpec<Optional<T>, Collection<T>, T>) : Neo4jClient.RecordFetchSpec<T?, Collection<T>, T> {
-	override fun one(): T? = delegate.one().orElse(null)
+class KRecordFetchSpec<T : Any> (private val delegate: Neo4jClient.RecordFetchSpec<T>)  {
+	fun one(): T? = delegate.one().orElse(null)
 
-	override fun first(): T = delegate.first().orElse(null)
+	fun first(): T = delegate.first().orElse(null)
 
-	override fun all(): Collection<T> = delegate.all()
+	fun all(): Collection<T> = delegate.all()
 }
 
 /**
- * An implementation of a mapping spec that replaces Java's Optional with a nullable.
+ * A mapping spec that replaces Java's Optional with a nullable.
  * @author Michael J. Simons
  */
-class DelegatingMappingSpec<T : Any>(private val delegate: Neo4jClient.MappingSpec<Optional<T>, Collection<T>, T>) : Neo4jClient.MappingSpec<T?, Collection<T>, T> {
-	override fun mappedBy(mappingFunction: BiFunction<TypeSystem, Record, T>): Neo4jClient.RecordFetchSpec<T?, Collection<T>, T> =
-		DelegatingFetchSpec(delegate.mappedBy(mappingFunction))
+class KMappingSpec<T : Any>(private val delegate: Neo4jClient.MappingSpec<T>) {
+	fun mappedBy(mappingFunction: BiFunction<TypeSystem, Record, T>): KRecordFetchSpec<T> =
+		KRecordFetchSpec(delegate.mappedBy(mappingFunction))
 
-	override fun one(): T? = delegate.one().orElse(null)
+	fun one(): T? = delegate.one().orElse(null)
 
-	override fun first(): T = delegate.first().orElse(null)
+	fun first(): T = delegate.first().orElse(null)
 
-	override fun all(): Collection<T> = delegate.all()
+	fun all(): Collection<T> = delegate.all()
 }
 
 /**
@@ -73,8 +73,8 @@ class DelegatingMappingSpec<T : Any>(private val delegate: Neo4jClient.MappingSp
  * @author Michael J. Simons
  * @since 1.0
  */
-inline fun <reified T : Any> Neo4jClient.RunnableSpecTightToDatabase.fetchAs(): Neo4jClient.MappingSpec<T?, Collection<T>, T>
-		= DelegatingMappingSpec(fetchAs(T::class.java))
+inline fun <reified T : Any> Neo4jClient.RunnableSpecTightToDatabase.fetchAs(): KMappingSpec<T> =
+		KMappingSpec(fetchAs(T::class.java))
 
 /**
  * Extension for [Neo4jClient.RunnableSpecTightToDatabase.mappedBy] leveraging reified type parameters and removing
@@ -82,5 +82,5 @@ inline fun <reified T : Any> Neo4jClient.RunnableSpecTightToDatabase.fetchAs(): 
  * @author Michael J. Simons
  * @since 1.0
  */
-inline fun <reified T : Any> Neo4jClient.RunnableSpecTightToDatabase.mappedBy(noinline mappingFunction: (TypeSystem, Record) -> T): Neo4jClient.RecordFetchSpec<T?, Collection<T>, T>
-		= DelegatingFetchSpec(fetchAs(T::class.java).mappedBy(mappingFunction))
+inline fun <reified T : Any> Neo4jClient.RunnableSpecTightToDatabase.mappedBy(noinline mappingFunction: (TypeSystem, Record) -> T)
+		= KRecordFetchSpec(fetchAs(T::class.java).mappedBy(mappingFunction))

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/core/Neo4jClientExtensionsTest.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/core/Neo4jClientExtensionsTest.kt
@@ -52,8 +52,8 @@ class Neo4jClientExtensionsTest {
 
 		val runnableSpec = mockk<Neo4jClient.RunnableSpecTightToDatabase>(relaxed = true)
 
-		val mappingSpec: Neo4jClient.RecordFetchSpec<String?, Collection<String>, String> =
-				runnableSpec.mappedBy { _, record -> "Foo" };
+		val mappingSpec: KRecordFetchSpec<String> =
+				runnableSpec.mappedBy { _, _ -> "Foo" };
 
 		verify(exactly = 1) { runnableSpec.fetchAs(String::class.java) }
 	}


### PR DESCRIPTION
This adds either standard Coroutines support or the experimental Flow support of Kotlin 1.3 to ReactiveNeo4jClient where applicable and closes #38.