### PR TITLE
GH-55 - Implement dynamic relationships.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -162,8 +162,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 				Supplier<String> message = () ->
 					"Dynamic relationships cannot be used with a fixed type. Omit @Relationship or use @Relationship(direction = "
 						+ relationship.direction().name() + ").";
-				Assert.state(relationship == null || relationship.type() == null || relationship.type().isEmpty(),
-					message);
+				Assert.state(relationship == null || relationship.type().isEmpty(), message);
 			}
 		});
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
@@ -35,15 +36,19 @@ import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.core.schema.Property;
+import org.neo4j.springframework.data.core.schema.Relationship;
+import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.support.IsNewStrategy;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * @author Michael J. Simons
+ * @author Gerrit Meier
  * @since 1.0
  */
 class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPersistentProperty>
@@ -132,6 +137,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		super.verify();
 		this.idDescription = computeIdDescription();
 		verifyNoDuplicatedGraphProperties();
+		verifyDynamicAssociations();
 	}
 
 	private void verifyNoDuplicatedGraphProperties() {
@@ -142,10 +148,24 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 			.filter(entry -> entry.getValue().size() > 1)
 			.map(Map.Entry::getKey)
 			.collect(Collectors.toSet());
-		if (!duplicates.isEmpty()) {
-			throw new IllegalStateException(
+
+		Assert.state(duplicates.isEmpty(), () ->
 				String.format("Duplicate definition of propert%s %s in entity %s.", duplicates.size() == 1 ? "y" : "ies", duplicates, getUnderlyingClass()));
-		}
+	}
+
+	private void verifyDynamicAssociations() {
+
+		this.doWithAssociations((Association<Neo4jPersistentProperty> association) -> {
+			Neo4jPersistentProperty inverse = association.getInverse();
+			if (inverse.isMap()) {
+				Relationship relationship = inverse.findAnnotation(Relationship.class);
+				Supplier<String> message = () ->
+					"Dynamic relationships cannot be used with a fixed type. Omit @Relationship or use @Relationship(direction = "
+						+ relationship.direction().name() + ").";
+				Assert.state(relationship == null || relationship.type() == null || relationship.type().isEmpty(),
+					message);
+			}
+		});
 	}
 
 	private String computePrimaryLabel() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -157,7 +157,7 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 
 		this.doWithAssociations((Association<Neo4jPersistentProperty> association) -> {
 			Neo4jPersistentProperty inverse = association.getInverse();
-			if (inverse.isMap()) {
+			if (inverse.isDynamicAssociation()) {
 				Relationship relationship = inverse.findAnnotation(Relationship.class);
 				Supplier<String> message = () ->
 					"Dynamic relationships cannot be used with a fixed type. Omit @Relationship or use @Relationship(direction = "

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -54,6 +54,9 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 		this.isAssociation = Lazy.of(() -> {
 
 			Class<?> targetType = getActualType();
+			if (isMap()) {
+				return getComponentType() == String.class && !simpleTypeHolder.isSimpleType(targetType);
+			}
 			return !simpleTypeHolder.isSimpleType(targetType);
 		});
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -54,9 +54,6 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 		this.isAssociation = Lazy.of(() -> {
 
 			Class<?> targetType = getActualType();
-			if (isMap()) {
-				return getComponentType() == String.class && !simpleTypeHolder.isSimpleType(targetType);
-			}
 			return !simpleTypeHolder.isSimpleType(targetType);
 		});
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultRelationshipDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultRelationshipDescription.java
@@ -32,6 +32,8 @@ class DefaultRelationshipDescription implements RelationshipDescription {
 
 	private final String type;
 
+	private final boolean dynamic;
+
 	private final String source;
 
 	private final String target;
@@ -40,10 +42,11 @@ class DefaultRelationshipDescription implements RelationshipDescription {
 
 	private final Relationship.Direction direction;
 
-	DefaultRelationshipDescription(String type, String source, String target, String fieldName,
+	DefaultRelationshipDescription(String type, boolean dynamic, String source, String target, String fieldName,
 		Relationship.Direction direction) {
 
 		this.type = type;
+		this.dynamic = dynamic;
 		this.source = source;
 		this.target = target;
 		this.fieldName = fieldName;
@@ -53,6 +56,11 @@ class DefaultRelationshipDescription implements RelationshipDescription {
 	@Override
 	public String getType() {
 		return type;
+	}
+
+	@Override
+	public boolean isDynamic() {
+		return dynamic;
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -253,8 +253,8 @@ public final class Neo4jMappingContext
 			}
 
 			relationships
-				.add(new DefaultRelationshipDescription(type, primaryLabel, obverseOwner.getPrimaryLabel(),
-					inverse.getName(), direction));
+				.add(new DefaultRelationshipDescription(type, inverse.isMap(), primaryLabel,
+					obverseOwner.getPrimaryLabel(), inverse.getName(), direction));
 		});
 
 		return Collections.unmodifiableCollection(relationships);

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -253,7 +253,7 @@ public final class Neo4jMappingContext
 			}
 
 			relationships
-				.add(new DefaultRelationshipDescription(type, inverse.isMap(), primaryLabel,
+				.add(new DefaultRelationshipDescription(type, inverse.isDynamicAssociation(), primaryLabel,
 					obverseOwner.getPrimaryLabel(), inverse.getName(), direction));
 		});
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
@@ -19,8 +19,8 @@
 package org.neo4j.springframework.data.core.mapping;
 
 import org.apiguardian.api.API;
-import org.springframework.data.mapping.PersistentProperty;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
+import org.springframework.data.mapping.PersistentProperty;
 
 /**
  * A {@link org.springframework.data.mapping.PersistentProperty} interface with additional methods for metadata related to Neo4j.
@@ -31,4 +31,13 @@ import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 @API(status = API.Status.INTERNAL, since = "1.0")
 public interface Neo4jPersistentProperty
 	extends PersistentProperty<Neo4jPersistentProperty>, GraphPropertyDescription {
+
+	/**
+	 * Dynamic associations are associations to non-simple types stored in a map with a key type of {@literal java.lang.String}.
+	 *
+	 * @return True, if this association is a dynamic association.
+	 */
+	default boolean isDynamicAssociation() {
+		return isAssociation() && isMap() && getComponentType() == String.class;
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/RelationshipDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/RelationshipDescription.java
@@ -32,10 +32,21 @@ import org.neo4j.springframework.data.core.schema.Relationship.Direction;
 @API(status = API.Status.INTERNAL, since = "1.0")
 public interface RelationshipDescription {
 
+	String NAME_OF_RELATIONSHIP_TYPE = "__relationshipType__";
+
 	/**
+	 * If this relationship is dynamic, than this method always returns the name of the inverse property.
+	 *
 	 * @return The type of this relationship
 	 */
 	String getType();
+
+	/**
+	 * A relationship is dynamic when it's modelled as a {@code Map<String, ?>}.
+	 *
+	 * @return True, if this relationship is dynamic
+	 */
+	boolean isDynamic();
 
 	/**
 	 * The source of this relationship is described by the primary label of the node in question.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/DefaultNeo4jEntityInformation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/DefaultNeo4jEntityInformation.java
@@ -107,7 +107,7 @@ final class DefaultNeo4jEntityInformation<T, ID> extends PersistentEntityInforma
 	 */
 	static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
-		if (property.isMap()) {
+		if (property.isDynamicAssociation()) {
 			unifiedValue = ((Map<String, Object>) rawValue).entrySet();
 		} else if (property.isCollectionLike()) {
 			unifiedValue = (Collection<Object>) rawValue;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/DefaultNeo4jEntityInformation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/DefaultNeo4jEntityInformation.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.repository.support;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -26,6 +28,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.cypher.Expression;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.repository.query.CypherAdapterUtils;
 import org.springframework.data.repository.core.support.PersistentEntityInformation;
 
@@ -93,5 +96,24 @@ final class DefaultNeo4jEntityInformation<T, ID> extends PersistentEntityInforma
 	@Override
 	public Function<T, Map<String, Object>> getBinderFunction() {
 		return binderFunction;
+	}
+
+	/**
+	 * The value for a relationship can be a scalar object (1:1), a collection (1:n) or a map (1:n, but with dynamic
+	 * relationship types). This method unifies the type into something iterable, depending on the given inverse type.
+	 *
+	 * @param rawValue The raw value to unify
+	 * @return A unified collection (Either a collection of Map.Entry or a list of related values)
+	 */
+	static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
+		Collection<?> unifiedValue;
+		if (property.isMap()) {
+			unifiedValue = ((Map<String, Object>) rawValue).entrySet();
+		} else if (property.isCollectionLike()) {
+			unifiedValue = (Collection<Object>) rawValue;
+		} else {
+			unifiedValue = Collections.singleton(rawValue);
+		}
+		return unifiedValue;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DynamicRelationshipsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DynamicRelationshipsIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Values;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.DynamicRelationshipsITBase;
+import org.neo4j.springframework.data.integration.shared.Person;
+import org.neo4j.springframework.data.integration.shared.PersonWithRelatives;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ *
+ * @author Michael J. Simons
+ */
+class DynamicRelationshipsIT extends DynamicRelationshipsITBase {
+
+	private PersonWithRelativesRepository personsWithRelatives;
+
+	@Autowired
+	protected DynamicRelationshipsIT(PersonWithRelativesRepository personsWithRelatives, Driver driver) {
+		super(driver);
+		this.personsWithRelatives = personsWithRelatives;
+	}
+
+	@Test
+	public void shouldReadDynamicRelationships() {
+
+		PersonWithRelatives personWithRelatives = personsWithRelatives.findById(idOfExistingPerson).get();
+		assertThat(personWithRelatives).isNotNull();
+		assertThat(personWithRelatives.getName()).isEqualTo("A");
+
+		Map<String, Person> relatives = personWithRelatives.getRelatives();
+		assertThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
+		assertThat(relatives.get("HAS_WIFE").getFirstName()).isEqualTo("B");
+		assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C");
+	}
+
+	@Test
+	public void shouldUpdateDynamicRelationships() {
+
+		PersonWithRelatives personWithRelatives = personsWithRelatives.findById(idOfExistingPerson).get();
+		assumeThat(personWithRelatives).isNotNull();
+		assumeThat(personWithRelatives.getName()).isEqualTo("A");
+
+		Map<String, Person> relatives = personWithRelatives.getRelatives();
+		assumeThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
+
+		relatives.remove("HAS_WIFE");
+		Person d = new Person();
+		ReflectionTestUtils.setField(d, "firstName", "D");
+		relatives.put("HAS_SON", d);
+		ReflectionTestUtils.setField(relatives.get("HAS_DAUGHTER"), "firstName", "C2");
+
+		personWithRelatives = personsWithRelatives.save(personWithRelatives);
+		relatives = personWithRelatives.getRelatives();
+		assertThat(relatives).containsOnlyKeys("HAS_DAUGHTER", "HAS_SON");
+		assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C2");
+		assertThat(relatives.get("HAS_SON").getFirstName()).isEqualTo("D");
+	}
+
+	@Test
+	public void shouldWriteDynamicRelationships() {
+
+		PersonWithRelatives personWithRelatives = new PersonWithRelatives("Test");
+		Map<String, Person> relatives;
+		relatives = personWithRelatives.getRelatives();
+		Person d;
+		d = new Person();
+		ReflectionTestUtils.setField(d, "firstName", "R1");
+		relatives.put("RELATIVE_1", d);
+		d = new Person();
+		ReflectionTestUtils.setField(d, "firstName", "R2");
+		relatives.put("RELATIVE_2", d);
+
+		personWithRelatives = personsWithRelatives.save(personWithRelatives);
+		relatives = personWithRelatives.getRelatives();
+		assertThat(relatives).containsOnlyKeys("RELATIVE_1", "RELATIVE_2");
+
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			long numberOfRelations = transaction.run(""
+				+ "MATCH (t:PersonWithRelatives) WHERE id(t) = $id "
+				+ "RETURN size((t) --> (:Person)) as numberOfRelations", Values.parameters("id", personWithRelatives.getId()))
+				.single().get("numberOfRelations").asLong();
+			assertThat(numberOfRelations).isEqualTo(2L);
+		}
+	}
+
+	public interface PersonWithRelativesRepository extends CrudRepository<PersonWithRelatives, Long> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(PersonWithRelatives.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicRelationshipsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicRelationshipsIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
+
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Values;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.DynamicRelationshipsITBase;
+import org.neo4j.springframework.data.integration.shared.Person;
+import org.neo4j.springframework.data.integration.shared.PersonWithRelatives;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Michael J. Simons
+ */
+class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
+
+	private PersonWithRelativesRepository personsWithRelatives;
+
+	@Autowired
+	protected ReactiveDynamicRelationshipsIT(PersonWithRelativesRepository personsWithRelatives, Driver driver) {
+		super(driver);
+		this.personsWithRelatives = personsWithRelatives;
+	}
+
+	@Test
+	public void shouldReadDynamicRelationships() {
+
+		personsWithRelatives.findById(idOfExistingPerson)
+			.as(StepVerifier::create)
+			.consumeNextWith(personWithRelatives -> {
+				assertThat(personWithRelatives).isNotNull();
+				assertThat(personWithRelatives.getName()).isEqualTo("A");
+
+				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				assertThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
+				assertThat(relatives.get("HAS_WIFE").getFirstName()).isEqualTo("B");
+				assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C");
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	public void shouldUpdateDynamicRelationships() {
+
+		personsWithRelatives.findById(idOfExistingPerson)
+			.map(personWithRelatives -> {
+				assumeThat(personWithRelatives).isNotNull();
+				assumeThat(personWithRelatives.getName()).isEqualTo("A");
+
+				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				assumeThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
+
+				relatives.remove("HAS_WIFE");
+				Person d = new Person();
+				ReflectionTestUtils.setField(d, "firstName", "D");
+				relatives.put("HAS_SON", d);
+				ReflectionTestUtils.setField(relatives.get("HAS_DAUGHTER"), "firstName", "C2");
+				return personWithRelatives;
+			})
+			.flatMap(personsWithRelatives::save)
+			.as(StepVerifier::create)
+			.consumeNextWith(personWithRelatives -> {
+				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				assertThat(relatives).containsOnlyKeys("HAS_DAUGHTER", "HAS_SON");
+				assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C2");
+				assertThat(relatives.get("HAS_SON").getFirstName()).isEqualTo("D");
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	public void shouldWriteDynamicRelationships() {
+
+		PersonWithRelatives newPerson = new PersonWithRelatives("Test");
+		Person d;
+		d = new Person();
+		ReflectionTestUtils.setField(d, "firstName", "R1");
+		newPerson.getRelatives().put("RELATIVE_1", d);
+		d = new Person();
+		ReflectionTestUtils.setField(d, "firstName", "R2");
+		newPerson.getRelatives().put("RELATIVE_2", d);
+
+		List<PersonWithRelatives> recorded = new ArrayList<>();
+		personsWithRelatives.save(newPerson)
+			.as(StepVerifier::create)
+			.recordWith(() -> recorded)
+			.consumeNextWith(personWithRelatives -> {
+				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				assertThat(relatives).containsOnlyKeys("RELATIVE_1", "RELATIVE_2");
+			})
+			.verifyComplete();
+
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			long numberOfRelations = transaction.run(""
+					+ "MATCH (t:PersonWithRelatives) WHERE id(t) = $id "
+					+ "RETURN size((t) --> (:Person)) as numberOfRelations",
+				Values.parameters("id", recorded.iterator().next().getId()))
+				.single().get("numberOfRelations").asLong();
+			assertThat(numberOfRelations).isEqualTo(2L);
+		}
+	}
+
+	public interface PersonWithRelativesRepository extends ReactiveNeo4jRepository<PersonWithRelatives, Long> {
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return Collections.singletonList(PersonWithRelatives.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DynamicRelationshipsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DynamicRelationshipsITBase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Transaction;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+
+/**
+ * Make sure that dynamic relationships can be loaded and stored.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Helge Schneider - Live At The Grugahalle
+ */
+@Neo4jIntegrationTest
+public abstract class DynamicRelationshipsITBase {
+
+	protected static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+
+	protected final Driver driver;
+
+	protected long idOfExistingPerson;
+
+	protected DynamicRelationshipsITBase(Driver driver) {
+		this.driver = driver;
+	}
+
+	@BeforeEach
+	protected void setupData() {
+		try (Transaction transaction = driver.session().beginTransaction()) {
+			transaction.run("MATCH (n) detach delete n");
+			idOfExistingPerson = transaction.run(""
+				+ "CREATE (t:PersonWithRelatives {name: 'A'}) WITH t "
+				+ "CREATE (t) - [:HAS_WIFE] -> (w:Person {firstName: 'B'}) "
+				+ "CREATE (t) - [:HAS_DAUGHTER] -> (d:Person {firstName: 'C'}) "
+				+ " RETURN id(t) as id").single().get("id").asLong();
+			transaction.success();
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelatives.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelatives.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class PersonWithRelatives {
+
+	@Id @GeneratedValue
+	private long id;
+
+	private final String name;
+
+	private Map<String, Person> relatives = new HashMap<>();
+
+	public PersonWithRelatives(String name) {
+		this.name = name;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Map<String, Person> getRelatives() {
+		return relatives;
+	}
+}


### PR DESCRIPTION
We had tests in place that allowed using `Map<String, Object>` as definition of a dynamic relationship.
The key of the map represents the type of the relationship in that case.

The commit adds to the logic of writing, reading and deleting relationships: A relationship is dynamic, if the underlying property is a map.
In such case, no type is used to write, read and delete relationships.
While in theory one could handle all queries without a type, that would be slower than
necessary (Cypher / database wise), so we handled that locally.

The mapping function needs to be adapted to correctly extract added information to the query result.
When it works on a system generated query, it looks for an artifical property, if it works on a query
defined by the user, it expect the relationship to be contained in the result and uses `type()` on
the client.

This closes #55.