### PR TITLE
GH-54 - Derive default type for relationships if none is given.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultRelationshipDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultRelationshipDescription.java
@@ -22,13 +22,14 @@ import java.util.Objects;
 
 import org.neo4j.springframework.data.core.schema.Relationship;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
+import org.springframework.data.mapping.Association;
 
 /**
  * @author Michael J. Simons
  * @author Gerrit Meier
  * @since 1.0
  */
-class DefaultRelationshipDescription implements RelationshipDescription {
+class DefaultRelationshipDescription extends Association<Neo4jPersistentProperty> implements RelationshipDescription {
 
 	private final String type;
 
@@ -42,8 +43,12 @@ class DefaultRelationshipDescription implements RelationshipDescription {
 
 	private final Relationship.Direction direction;
 
-	DefaultRelationshipDescription(String type, boolean dynamic, String source, String target, String fieldName,
+	DefaultRelationshipDescription(Neo4jPersistentProperty inverse,
+		Neo4jPersistentProperty obverse,
+		String type, boolean dynamic, String source, String target, String fieldName,
 		Relationship.Direction direction) {
+
+		super(inverse, obverse);
 
 		this.type = type;
 		this.dynamic = dynamic;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentPropertyTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * @author Michael J. Simons
+ */
+class DefaultNeo4jPersistentPropertyTest {
+
+	@ParameterizedTest
+	@CsvSource({
+		"aName, A_NAME",
+		"ANumberedNam3, A_NUMBERED_NAM_3",
+		"Foo3Bar, FOO_3_BAR",
+		"Foo3BaR, FOO_3_BA_R",
+		"foo3BaR, FOO_3_BA_R",
+		"🖖someThing, 🖖_SOME_THING",
+		"$someThing, $_SOME_THING",
+		"$$some33Thing, $_$_SOME_3_3_THING",
+		"🧐someThing✋, 🧐_SOME_THING_✋",
+	})
+	void toUpperSnakeCaseShouldWork(String name, String expectedEscapedName) {
+
+		assertThat(DefaultNeo4jPersistentProperty.deriveRelationshipType(name)).isEqualTo(expectedEscapedName);
+	}
+
+	@Test
+	void toUpperSnakeCaseShouldDealWithNull() {
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> DefaultNeo4jPersistentProperty.deriveRelationshipType(null));
+	}
+
+	@Test
+	void toUpperSnakeCaseShouldDealWithEmptyString() {
+
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> DefaultNeo4jPersistentProperty.deriveRelationshipType(""));
+	}
+}


### PR DESCRIPTION
This introduces a method similar to toUpperSnakeCase from OGM, to derive
a type for relationship when none is given.

The computation of the relationship description has been moved to the
Neo4jPersistentProperty, as the contract already has a method for
computing an association.

The contract can be fulfilled by extending from the associciation und
thus removing some clutter from the mapping context.

This closes #54. 