### PR TITLE
GH-36 - Add DataNeo4jTest to simplify test for Neo4j.

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -137,7 +137,7 @@ WARNING: Don't choose Spring Data Neo4j here, as it will get you the previous ge
 
 ==== Maven
 
-You can issue a CURL request against the Spring Initializer to create a basic Maven project:
+You can issue a _curl_ request against the Spring Initializer to create a basic Maven project:
 
 [source,bash,subs="verbatim,attributes"]
 [[generate-maven-project]]

--- a/examples/imperative-web/README.adoc
+++ b/examples/imperative-web/README.adoc
@@ -48,7 +48,7 @@ java -jar examples/reactive-web/target/movie-api.jar \
 
 with parameters fitting to your needs.
 
-Here are some CURL commands, you can try out.
+Here are some _curl_ commands, you can try out.
 The same examples are also available in the file `movie-api-examples.http` that you can call from IDEA.
 
 [source,bash]

--- a/examples/imperative-web/README.adoc
+++ b/examples/imperative-web/README.adoc
@@ -1,0 +1,81 @@
+== Spring Boot / Imperative Web Example
+
+=== Building SDN/RX and Examples.
+
+NOTE: *You need to have JDK 12 installed.
+
+You can either built the complete project, including the examples.
+Thus, the examples will use your copy of SDN/RX, and any potential changes you made:
+
+[source,bash]
+----
+git clone git@github.com:neo4j/sdn-rx
+cd sdn-rx
+./mvnw -DskipTests -Drevision=1.0.0 -Dchangelist=-SNAPSHOT clean package
+----
+
+If you want to only try out the examples with the currently released version,
+pick out the example you like (for example the `imperative-web` example) and build it like this:
+
+[source,bash]
+----
+git clone git@github.com:neo4j/sdn-rx
+cd sdn-rx/examples/imperative-web
+mvn -DskipTests clean package
+cd ../..
+----
+
+=== Running the examples.
+
+You'll need a Neo4j 4 instance that has a user name `neo4j` with a password of `secret`.
+Please use `:play movies` in Neo4j browser to get some data in your graph.
+With from SDN/RX root folder run
+
+[source,bash]
+----
+java -jar examples/imperative-web/target/movie-api.jar
+----
+
+If your database has different credentials or is on a different host, run
+
+[source,bash]
+----
+java -jar examples/reactive-web/target/movie-api.jar \
+--org.neo4j.driver.uri=neo4j://yourhost:7687 \
+--org.neo4j.driver.authentication.username=youruser \
+--org.neo4j.driver.authentication.password=yourpassword
+----
+
+with parameters fitting to your needs.
+
+Here are some CURL commands, you can try out.
+The same examples are also available in the file `movie-api-examples.http` that you can call from IDEA.
+
+[source,bash]
+.Create a new movie
+----
+curl -X "PUT" "http://localhost:8080/movies" \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+  "title": "Aeon Flux",
+  "description": "Reactive is the new cool"
+}'
+----
+
+[source,bash]
+.List all movies.
+----
+curl http://localhost:8080/movies
+----
+
+[source,bash]
+.Query a movie by title.
+----
+curl http://localhost:8080/movies/by-title\?title\=Aeon%20Flux
+----
+
+[source,bash]
+.Delete a movie by id (use the one returned above for example)
+----
+curl -X DELETE http://localhost:8080/movies/847
+----

--- a/examples/imperative-web/movie-api-examples.http
+++ b/examples/imperative-web/movie-api-examples.http
@@ -1,0 +1,27 @@
+PUT http://localhost:8080/movies
+Content-Type: application/json
+
+{
+  "title": "Aeon Flux",
+  "description": "Reactive is the new cool"
+}
+
+###
+
+GET http://localhost:8080/movies
+Accept: */*
+Cache-Control: no-cache
+
+###
+
+GET http://localhost:8080/movies/by-title?title=Aeon Flux
+Accept: */*
+Cache-Control: no-cache
+
+###
+
+DELETE http://localhost:8080/movies/The Matrix
+Accept: */*
+Cache-Control: no-cache
+
+###

--- a/examples/imperative-web/pom.xml
+++ b/examples/imperative-web/pom.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+| Copyright (c) 2019 "Neo4j,"
+| Neo4j Sweden AB [https://neo4j.com]
+|
+| This file is part of Neo4j.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|     https://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<groupId>org.springframework.boot</groupId>
+		<version>2.2.0.RC1</version>
+		<relativePath></relativePath>
+		<!-- lookup parent from repository -->
+	</parent>
+
+	<groupId>org.neo4j.doc.springframework.data</groupId>
+	<artifactId>spring-data-neo4j-rx-examples-imperative-web</artifactId>
+	<version>999-SNAPSHOT</version>
+
+	<name>SDN⚡️RX Examples for Spring Boot</name>
+	<description>Demonstrating how to use SDN⚡️RX from within Spring Boot.</description>
+
+	<properties>
+		<java.version>12</java.version>
+		<maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+		<maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
+		<maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+		<maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+		<neo4j.version>3.5.11</neo4j.version>
+		<spring-data-neo4j-rx.version>${revision}${sha1}${changelist}</spring-data-neo4j-rx.version>
+		<testcontainers.version>1.10.7</testcontainers.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.neo4j.springframework.data</groupId>
+			<artifactId>spring-data-neo4j-rx-spring-boot-starter</artifactId>
+			<version>${spring-data-neo4j-rx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j.springframework.data</groupId>
+			<artifactId>spring-data-neo4j-rx-spring-boot-test-autoconfigure</artifactId>
+			<version>${spring-data-neo4j-rx.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j.test</groupId>
+			<artifactId>neo4j-harness</artifactId>
+			<version>${neo4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<finalName>movie-api</finalName>
+		<plugins>
+			<plugin>
+				<groupId>com.github.ekryd.sortpom</groupId>
+				<artifactId>sortpom-maven-plugin</artifactId>
+				<version>2.8.0</version>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>sort</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<keepBlankLines>true</keepBlankLines>
+					<nrOfIndentSpace>-1</nrOfIndentSpace>
+					<sortProperties>true</sortProperties>
+					<sortDependencies>groupId,artifactId</sortDependencies>
+					<createBackupFile>false</createBackupFile>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<!-- Those profiles are not relevant to the examples and are only needed for SDN/RX release chain. -->
+	<profiles>
+		<profile>
+			<id>revisionMissing</id>
+			<activation>
+				<property>
+					<name>!revision</name>
+				</property>
+			</activation>
+			<properties>
+				<revision>1.0.0</revision>
+			</properties>
+		</profile>
+		<profile>
+			<id>sha1Missing</id>
+			<activation>
+				<property>
+					<name>!sha</name>
+				</property>
+			</activation>
+			<properties>
+				<sha1></sha1>
+			</properties>
+		</profile>
+		<profile>
+			<id>changelistMissing</id>
+			<activation>
+				<property>
+					<name>!changelist</name>
+				</property>
+			</activation>
+			<properties>
+				<changelist>-SNAPSHOT</changelist>
+			</properties>
+		</profile>
+	</profiles>
+</project>

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/DemoApplication.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/DemoApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Michael J. Simons
+ */
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String... args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieEntity.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieEntity.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.domain;
+
+import static org.neo4j.springframework.data.core.schema.Relationship.Direction.*;
+
+import java.util.Set;
+
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.neo4j.springframework.data.core.schema.Property;
+import org.neo4j.springframework.data.core.schema.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node("Movie")
+public class MovieEntity {
+
+	@Id
+	private final String title;
+
+	@Property("tagline")
+	private final String description;
+
+	@Relationship(type = "ACTED_IN", direction = INCOMING)
+	private Set<PersonEntity> actors;
+
+	@Relationship(type = "DIRECTED", direction = INCOMING)
+	private Set<PersonEntity> directors;
+
+	public MovieEntity(String title, String description) {
+		this.title = title;
+		this.description = description;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public Set<PersonEntity> getActors() {
+		return actors;
+	}
+
+	public Set<PersonEntity> getDirectors() {
+		return directors;
+	}
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieRepository.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/MovieRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.domain;
+
+import java.util.Optional;
+
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+
+/**
+ * @author Michael J. Simons
+ */
+public interface MovieRepository extends Neo4jRepository<MovieEntity, String> {
+
+	Optional<MovieEntity> findOneByTitle(String title);
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/PersonEntity.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/PersonEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.domain;
+
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node("Person")
+public class PersonEntity {
+
+	@Id
+	private final String name;
+
+	private final Long born;
+
+	public PersonEntity(Long born, String name) {
+		this.born = born;
+		this.name = name;
+	}
+
+	public Long getBorn() {
+		return born;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/PersonRepository.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/domain/PersonRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.query.Query;
+
+/**
+ * @author Michael J. Simons
+ */
+public interface PersonRepository extends Neo4jRepository<PersonEntity, String> {
+
+	Optional<PersonEntity> findByName(String name);
+
+	@Query("MATCH (am:Movie)<-[ai:ACTED_IN]-(p:Person)-[d:DIRECTED]->(dm:Movie) return p, collect(ai), collect(d), collect(am), collect(dm)")
+	List<PersonEntity> getPersonsWhoActAndDirect();
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSGraphElement.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSGraphElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.support;
+
+/**
+ * Something that is part of a d3.js viz.
+ *
+ * @author Michael J. Simons
+ */
+public interface D3JSGraphElement {
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSLink.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSLink.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.support;
+
+/**
+ * A d3.js link only has meaning between {@link D3JSNode} inside arrays.
+ *
+ * @author Michael J. Simons
+ */
+public class D3JSLink implements D3JSGraphElement {
+
+	private final int source;
+
+	private final int target;
+
+	public D3JSLink(int source, int target) {
+		this.source = source;
+		this.target = target;
+	}
+
+	public int getSource() {
+		return source;
+	}
+
+	public int getTarget() {
+		return target;
+	}
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSNode.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/support/D3JSNode.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.support;
+
+import java.util.Objects;
+
+/**
+ * Represents a generic node in the graph, without a lifecycle. It is mainly used in d3.js
+ *
+ * @author Michael J. Simons
+ */
+public class D3JSNode implements D3JSGraphElement {
+
+	private final String title;
+
+	private final String label;
+
+	public D3JSNode(String title, String label) {
+		this.title = title;
+		this.label = label;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof D3JSNode))
+			return false;
+		D3JSNode d3JSNode = (D3JSNode) o;
+		return title.equals(d3JSNode.title) &&
+			label.equals(d3JSNode.label);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(title, label);
+	}
+}

--- a/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/web/MovieController.java
+++ b/examples/imperative-web/src/main/java/org/neo4j/springframework/data/examples/spring_boot/web/MovieController.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot.web;
+
+import java.util.List;
+
+import org.neo4j.springframework.data.examples.spring_boot.domain.MovieEntity;
+import org.neo4j.springframework.data.examples.spring_boot.domain.MovieRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Michael J. Simons
+ */
+@RestController
+@RequestMapping("/movies")
+public class MovieController {
+
+	private final MovieRepository movieRepository;
+
+	public MovieController(MovieRepository movieRepository) {
+		this.movieRepository = movieRepository;
+	}
+
+	@PutMapping
+	MovieEntity createOrUpdateMovie(@RequestBody MovieEntity newMovie) {
+		return movieRepository.save(newMovie);
+	}
+
+	@GetMapping(value = { "", "/" })
+	List<MovieEntity> getMovies() {
+		return movieRepository.findAll();
+	}
+
+	@GetMapping("/by-title")
+	MovieEntity byTitle(@RequestParam String title) {
+		return movieRepository.findOneByTitle(title)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+	}
+
+	@DeleteMapping("/{id}")
+	void delete(@PathVariable String id) {
+		movieRepository.deleteById(id);
+	}
+}

--- a/examples/imperative-web/src/main/resources/application.properties
+++ b/examples/imperative-web/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 "Neo4j,"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.neo4j.driver.uri=neo4j://localhost:7687
+org.neo4j.driver.authentication.username=neo4j
+org.neo4j.driver.authentication.password=secret
+
+logging.level.org.neo4j.springframework.data=DEBUG
+

--- a/examples/imperative-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
+++ b/examples/imperative-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.examples.spring_boot;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.springframework.boot.test.autoconfigure.data.DataNeo4jTest;
+import org.neo4j.springframework.data.examples.spring_boot.domain.MovieRepository;
+import org.neo4j.springframework.data.examples.spring_boot.domain.PersonRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Michael J. Simons
+ */
+@DataNeo4jTest
+class RepositoryTests {
+
+	@Autowired
+	private PersonRepository repository;
+
+	@Autowired
+	private MovieRepository movieRepository;
+
+	@Autowired
+	private Driver driver;
+
+	@BeforeEach
+	void setup() throws IOException {
+		try (BufferedReader moviesReader = new BufferedReader(
+			new InputStreamReader(this.getClass().getResourceAsStream("/movies.cypher")));
+			Session session = driver.session()) {
+			session.run("MATCH (n) DETACH DELETE n");
+			String moviesCypher = moviesReader.lines().collect(Collectors.joining(" "));
+			session.run(moviesCypher);
+		}
+	}
+
+	@Test
+	void loadAllPersonsFromGraph() {
+		int expectedPersonCount = 133;
+		assertThat(repository.count()).isEqualTo(expectedPersonCount);
+	}
+
+	@Test
+	void findPersonByName() {
+		assertThat(repository.findByName("Tom Hanks"))
+			.isPresent().get()
+			.satisfies(personEntity -> assertThat(personEntity.getBorn()).isEqualTo(1956));
+	}
+
+	@Test
+	void findsPersonsWhoActAndDirect() {
+		int expectedActorAndDirectorCount = 5;
+		assertThat(repository.getPersonsWhoActAndDirect()).hasSize(expectedActorAndDirectorCount);
+	}
+
+	@Test
+	void findOneMovie() {
+		assertThat(movieRepository.findOneByTitle("The Matrix"))
+			.isPresent().get()
+			.satisfies(movie -> {
+				assertThat(movie.getTitle()).isEqualTo("The Matrix");
+				assertThat(movie.getDescription()).isEqualTo("Welcome to the Real World");
+				assertThat(movie.getDirectors()).hasSize(2);
+				assertThat(movie.getActors()).hasSize(5);
+			});
+	}
+}

--- a/examples/imperative-web/src/test/resources/movies.cypher
+++ b/examples/imperative-web/src/test/resources/movies.cypher
@@ -1,0 +1,509 @@
+CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real World'})
+CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})
+CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})
+CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})
+CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})
+CREATE (LillyW:Person {name:'Lilly Wachowski', born:1967})
+CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})
+CREATE (JoelS:Person {name:'Joel Silver', born:1952})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),
+  (LillyW)-[:DIRECTED]->(TheMatrix),
+  (LanaW)-[:DIRECTED]->(TheMatrix),
+  (JoelS)-[:PRODUCED]->(TheMatrix)
+
+CREATE (Emil:Person {name:"Emil Eifrem", born:1978})
+CREATE (Emil)-[:ACTED_IN {roles:["Emil"]}]->(TheMatrix)
+
+CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free your mind'})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),
+  (LillyW)-[:DIRECTED]->(TheMatrixReloaded),
+  (LanaW)-[:DIRECTED]->(TheMatrixReloaded),
+  (JoelS)-[:PRODUCED]->(TheMatrixReloaded)
+
+CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, tagline:'Everything that has a beginning has an end'})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),
+  (LillyW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (LanaW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (JoelS)-[:PRODUCED]->(TheMatrixRevolutions)
+
+CREATE (TheDevilsAdvocate:Movie {title:"The Devil's Advocate", released:1997, tagline:'Evil has its winning ways'})
+CREATE (Charlize:Person {name:'Charlize Theron', born:1975})
+CREATE (Al:Person {name:'Al Pacino', born:1940})
+CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),
+  (Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),
+  (Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),
+  (Taylor)-[:DIRECTED]->(TheDevilsAdvocate)
+
+CREATE (AFewGoodMen:Movie {title:"A Few Good Men", released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth."})
+CREATE (TomC:Person {name:'Tom Cruise', born:1962})
+CREATE (JackN:Person {name:'Jack Nicholson', born:1937})
+CREATE (DemiM:Person {name:'Demi Moore', born:1962})
+CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})
+CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})
+CREATE (NoahW:Person {name:'Noah Wyle', born:1971})
+CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})
+CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})
+CREATE (JTW:Person {name:'J.T. Walsh', born:1943})
+CREATE (JamesM:Person {name:'James Marshall', born:1967})
+CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})
+CREATE (RobR:Person {name:'Rob Reiner', born:1947})
+CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),
+  (JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),
+  (DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),
+  (KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),
+  (KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),
+  (NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),
+  (CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),
+  (KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),
+  (JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),
+  (JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),
+  (ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),
+  (AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),
+  (RobR)-[:DIRECTED]->(AFewGoodMen),
+  (AaronS)-[:WROTE]->(AFewGoodMen)
+
+CREATE (TopGun:Movie {title:"Top Gun", released:1986, tagline:'I feel the need, the need for speed.'})
+CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})
+CREATE (ValK:Person {name:'Val Kilmer', born:1959})
+CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})
+CREATE (TomS:Person {name:'Tom Skerritt', born:1933})
+CREATE (MegR:Person {name:'Meg Ryan', born:1961})
+CREATE (TonyS:Person {name:'Tony Scott', born:1944})
+CREATE (JimC:Person {name:'Jim Cash', born:1941})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),
+  (KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),
+  (ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),
+  (AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),
+  (TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),
+  (MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),
+  (TonyS)-[:DIRECTED]->(TopGun),
+  (JimC)-[:WROTE]->(TopGun)
+
+CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his life begins now.'})
+CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})
+CREATE (KellyP:Person {name:'Kelly Preston', born:1962})
+CREATE (JerryO:Person {name:"Jerry O'Connell", born:1974})
+CREATE (JayM:Person {name:'Jay Mohr', born:1970})
+CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})
+CREATE (ReginaK:Person {name:'Regina King', born:1971})
+CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})
+CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),
+  (CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),
+  (ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),
+  (KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),
+  (JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),
+  (JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),
+  (BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),
+  (ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),
+  (JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),
+  (CameronC)-[:DIRECTED]->(JerryMaguire),
+  (CameronC)-[:PRODUCED]->(JerryMaguire),
+  (CameronC)-[:WROTE]->(JerryMaguire)
+
+CREATE (StandByMe:Movie {title:"Stand By Me", released:1986, tagline:"For some, it's the last real taste of innocence, and the first real taste of life. But for everyone, it's the time that memories are made of."})
+CREATE (RiverP:Person {name:'River Phoenix', born:1970})
+CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})
+CREATE (WilW:Person {name:'Wil Wheaton', born:1972})
+CREATE (JohnC:Person {name:'John Cusack', born:1966})
+CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})
+CREATE
+  (WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),
+  (RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),
+  (JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),
+  (CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),
+  (JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),
+  (KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),
+  (MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),
+  (RobR)-[:DIRECTED]->(StandByMe)
+
+CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy from the heart that goes for the throat.'})
+CREATE (HelenH:Person {name:'Helen Hunt', born:1963})
+CREATE (GregK:Person {name:'Greg Kinnear', born:1963})
+CREATE (JamesB:Person {name:'James L. Brooks', born:1940})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),
+  (HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),
+  (GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),
+  (CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),
+  (JamesB)-[:DIRECTED]->(AsGoodAsItGets)
+
+CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, tagline:'After life there is more. The end is just the beginning.'})
+CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})
+CREATE (MaxS:Person {name:'Max von Sydow', born:1929})
+CREATE (WernerH:Person {name:'Werner Herzog', born:1942})
+CREATE (Robin:Person {name:'Robin Williams', born:1951})
+CREATE (VincentW:Person {name:'Vincent Ward', born:1956})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),
+  (CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),
+  (AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),
+  (MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),
+  (WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),
+  (VincentW)-[:DIRECTED]->(WhatDreamsMayCome)
+
+CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, tagline:'First loves last. Forever.'})
+CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})
+CREATE (RickY:Person {name:'Rick Yune', born:1971})
+CREATE (JamesC:Person {name:'James Cromwell', born:1940})
+CREATE (ScottH:Person {name:'Scott Hicks', born:1953})
+CREATE
+  (EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),
+  (RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),
+  (MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),
+  (JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),
+  (ScottH)-[:DIRECTED]->(SnowFallingonCedars)
+
+CREATE (YouveGotMail:Movie {title:"You've Got Mail", released:1998, tagline:'At odds in life... in love on-line.'})
+CREATE (ParkerP:Person {name:'Parker Posey', born:1968})
+CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})
+CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})
+CREATE (TomH:Person {name:'Tom Hanks', born:1956})
+CREATE (NoraE:Person {name:'Nora Ephron', born:1941})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),
+  (MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),
+  (GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),
+  (ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),
+  (DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),
+  (SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),
+  (NoraE)-[:DIRECTED]->(YouveGotMail)
+
+CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, tagline:'What if someone you never met, someone you never saw, someone you never knew was the only someone for you?'})
+CREATE (RitaW:Person {name:'Rita Wilson', born:1956})
+CREATE (BillPull:Person {name:'Bill Pullman', born:1953})
+CREATE (VictorG:Person {name:'Victor Garber', born:1949})
+CREATE (RosieO:Person {name:"Rosie O'Donnell", born:1962})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),
+  (MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),
+  (RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),
+  (BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),
+  (VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),
+  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),
+  (NoraE)-[:DIRECTED]->(SleeplessInSeattle)
+
+CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, tagline:'A story of love, lava and burning desire.'})
+CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})
+CREATE (Nathan:Person {name:'Nathan Lane', born:1956})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),
+  (MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->(JoeVersustheVolcano),
+  (Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),
+  (JohnS)-[:DIRECTED]->(JoeVersustheVolcano)
+
+CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'At odds in life... in love on-line.'})
+CREATE (BillyC:Person {name:'Billy Crystal', born:1948})
+CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})
+CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})
+CREATE
+  (BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),
+  (MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),
+  (CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),
+  (BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),
+  (RobR)-[:DIRECTED]->(WhenHarryMetSally),
+  (RobR)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:WROTE]->(WhenHarryMetSally)
+
+CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every life there comes a time when that thing you dream becomes that thing you do'})
+CREATE (LivT:Person {name:'Liv Tyler', born:1977})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),
+  (LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),
+  (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),
+  (TomH)-[:DIRECTED]->(ThatThingYouDo)
+
+CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain heals, Chicks dig scars... Glory lasts forever'})
+CREATE (Brooke:Person {name:'Brooke Langton', born:1970})
+CREATE (Gene:Person {name:'Gene Hackman', born:1930})
+CREATE (Orlando:Person {name:'Orlando Jones', born:1968})
+CREATE (Howard:Person {name:'Howard Deutch', born:1950})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),
+  (Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),
+  (Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),
+  (Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),
+  (Howard)-[:DIRECTED]->(TheReplacements)
+
+CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:"Based on the extraordinary true story of one man's fight for freedom"})
+CREATE (ChristianB:Person {name:'Christian Bale', born:1974})
+CREATE (ZachG:Person {name:'Zach Grenier', born:1954})
+CREATE
+  (MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),
+  (ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),
+  (ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),
+  (SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),
+  (WernerH)-[:DIRECTED]->(RescueDawn)
+
+CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you are'})
+CREATE (MikeN:Person {name:'Mike Nichols', born:1931})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),
+  (Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),
+  (Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),
+  (MikeN)-[:DIRECTED]->(TheBirdcage)
+
+CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:"It's a hell of a thing, killing a man"})
+CREATE (RichardH:Person {name:'Richard Harris', born:1930})
+CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})
+CREATE
+  (RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),
+  (ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),
+  (Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),
+  (ClintE)-[:DIRECTED]->(Unforgiven)
+
+CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest data on earth. In the coolest head in town'})
+CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})
+CREATE (Dina:Person {name:'Dina Meyer', born:1968})
+CREATE (IceT:Person {name:'Ice-T', born:1958})
+CREATE (RobertL:Person {name:'Robert Longo', born:1953})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),
+  (Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),
+  (Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),
+  (IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),
+  (RobertL)-[:DIRECTED]->(JohnnyMnemonic)
+
+CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is connected'})
+CREATE (HalleB:Person {name:'Halle Berry', born:1966})
+CREATE (JimB:Person {name:'Jim Broadbent', born:1949})
+CREATE (TomT:Person {name:'Tom Tykwer', born:1965})
+CREATE (DavidMitchell:Person {name:'David Mitchell', born:1969})
+CREATE (StefanArndt:Person {name:'Stefan Arndt', born:1961})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas),
+  (Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),
+  (HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->(CloudAtlas),
+  (JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->(CloudAtlas),
+  (TomT)-[:DIRECTED]->(CloudAtlas),
+  (LillyW)-[:DIRECTED]->(CloudAtlas),
+  (LanaW)-[:DIRECTED]->(CloudAtlas),
+  (DavidMitchell)-[:WROTE]->(CloudAtlas),
+  (StefanArndt)-[:PRODUCED]->(CloudAtlas)
+
+CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The Codes'})
+CREATE (IanM:Person {name:'Ian McKellen', born:1939})
+CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})
+CREATE (PaulB:Person {name:'Paul Bettany', born:1971})
+CREATE (RonH:Person {name:'Ron Howard', born:1954})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),
+  (IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),
+  (AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),
+  (PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),
+  (RonH)-[:DIRECTED]->(TheDaVinciCode)
+
+CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! Forever!'})
+CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})
+CREATE (StephenR:Person {name:'Stephen Rea', born:1946})
+CREATE (JohnH:Person {name:'John Hurt', born:1940})
+CREATE (BenM:Person {name: 'Ben Miles', born:1967})
+CREATE
+  (Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),
+  (NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),
+  (StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),
+  (JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),
+  (BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),
+  (JamesM)-[:DIRECTED]->(VforVendetta),
+  (LillyW)-[:PRODUCED]->(VforVendetta),
+  (LanaW)-[:PRODUCED]->(VforVendetta),
+  (JoelS)-[:PRODUCED]->(VforVendetta),
+  (LillyW)-[:WROTE]->(VforVendetta),
+  (LanaW)-[:WROTE]->(VforVendetta)
+
+CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no limits'})
+CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})
+CREATE (JohnG:Person {name:'John Goodman', born:1960})
+CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})
+CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})
+CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})
+CREATE (Rain:Person {name:'Rain', born:1982})
+CREATE
+  (EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),
+  (JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),
+  (SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),
+  (MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),
+  (ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),
+  (Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),
+  (BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),
+  (LillyW)-[:DIRECTED]->(SpeedRacer),
+  (LanaW)-[:DIRECTED]->(SpeedRacer),
+  (LillyW)-[:WROTE]->(SpeedRacer),
+  (LanaW)-[:WROTE]->(SpeedRacer),
+  (JoelS)-[:PRODUCED]->(SpeedRacer)
+
+CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to enter a secret world of assassins'})
+CREATE (NaomieH:Person {name:'Naomie Harris'})
+CREATE
+  (Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),
+  (NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),
+  (RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),
+  (BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),
+  (JamesM)-[:DIRECTED]->(NinjaAssassin),
+  (LillyW)-[:PRODUCED]->(NinjaAssassin),
+  (LanaW)-[:PRODUCED]->(NinjaAssassin),
+  (JoelS)-[:PRODUCED]->(NinjaAssassin)
+
+CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:"Walk a mile you'll never forget."})
+CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})
+CREATE (DavidM:Person {name:'David Morse', born:1953})
+CREATE (SamR:Person {name:'Sam Rockwell', born:1968})
+CREATE (GaryS:Person {name:'Gary Sinise', born:1955})
+CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})
+CREATE (FrankD:Person {name:'Frank Darabont', born:1959})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),
+  (MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),
+  (DavidM)-[:ACTED_IN {roles:['Brutus "Brutal" Howell']}]->(TheGreenMile),
+  (BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),
+  (JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),
+  (SamR)-[:ACTED_IN {roles:['"Wild Bill" Wharton']}]->(TheGreenMile),
+  (GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),
+  (PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),
+  (FrankD)-[:DIRECTED]->(TheGreenMile)
+
+CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people were waiting for the truth.'})
+CREATE (FrankL:Person {name:'Frank Langella', born:1938})
+CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})
+CREATE (OliverP:Person {name:'Oliver Platt', born:1960})
+CREATE
+  (FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),
+  (MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),
+  (KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),
+  (OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),
+  (SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),
+  (RonH)-[:DIRECTED]->(FrostNixon)
+
+CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:"He didn't want law. He wanted justice."})
+CREATE (DannyD:Person {name:'Danny DeVito', born:1944})
+CREATE (JohnR:Person {name:'John C. Reilly', born:1965})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),
+  (DannyD)-[:ACTED_IN {roles:['Robert "Bobby" Ciaro']}]->(Hoffa),
+  (JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),
+  (JohnR)-[:ACTED_IN {roles:['Peter "Pete" Connelly']}]->(Hoffa),
+  (DannyD)-[:DIRECTED]->(Hoffa)
+
+CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a problem.'})
+CREATE (EdH:Person {name:'Ed Harris', born:1950})
+CREATE (BillPax:Person {name:'Bill Paxton', born:1955})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),
+  (KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),
+  (EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),
+  (BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),
+  (GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),
+  (RonH)-[:DIRECTED]->(Apollo13)
+
+CREATE (Twister:Movie {title:'Twister', released:1996, tagline:"Don't Breathe. Don't Look Back."})
+CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})
+CREATE (JanB:Person {name:'Jan de Bont', born:1943})
+CREATE
+  (BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),
+  (HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),
+  (ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),
+  (PhilipH)-[:ACTED_IN {roles:['Dustin "Dusty" Davis']}]->(Twister),
+  (JanB)-[:DIRECTED]->(Twister)
+
+CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the world, his journey begins.'})
+CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),
+  (HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),
+  (RobertZ)-[:DIRECTED]->(CastAway)
+
+CREATE (OneFlewOvertheCuckoosNest:Movie {title:"One Flew Over the Cuckoo's Nest", released:1975, tagline:"If he's crazy, what does that make you?"})
+CREATE (MilosF:Person {name:'Milos Forman', born:1932})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),
+  (DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),
+  (MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)
+
+CREATE (SomethingsGottaGive:Movie {title:"Something's Gotta Give", released:2003})
+CREATE (DianeK:Person {name:'Diane Keaton', born:1946})
+CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),
+  (DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),
+  (Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),
+  (NancyM)-[:DIRECTED]->(SomethingsGottaGive),
+  (NancyM)-[:PRODUCED]->(SomethingsGottaGive),
+  (NancyM)-[:WROTE]->(SomethingsGottaGive)
+
+CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:"One robot's 200 year journey to become an ordinary man."})
+CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),
+  (OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),
+  (ChrisC)-[:DIRECTED]->(BicentennialMan)
+
+CREATE (CharlieWilsonsWar:Movie {title:"Charlie Wilson's War", released:2007, tagline:"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring down the Soviet empire."})
+CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),
+  (JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),
+  (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),
+  (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)
+
+CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season… Believe'})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa Claus']}]->(ThePolarExpress),
+  (RobertZ)-[:DIRECTED]->(ThePolarExpress)
+
+CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, tagline:'Once in a lifetime you get a chance to do something different.'})
+CREATE (Madonna:Person {name:'Madonna', born:1954})
+CREATE (GeenaD:Person {name:'Geena Davis', born:1956})
+CREATE (LoriP:Person {name:'Lori Petty', born:1963})
+CREATE (PennyM:Person {name:'Penny Marshall', born:1943})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),
+  (GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),
+  (LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),
+  (RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),
+  (Madonna)-[:ACTED_IN {roles:['"All the Way" Mae Mordabito']}]->(ALeagueofTheirOwn),
+  (BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),
+  (PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)
+
+CREATE (PaulBlythe:Person {name:'Paul Blythe'})
+CREATE (AngelaScope:Person {name:'Angela Scope'})
+CREATE (JessicaThompson:Person {name:'Jessica Thompson'})
+CREATE (JamesThompson:Person {name:'James Thompson'})
+
+CREATE
+  (JamesThompson)-[:FOLLOWS]->(JessicaThompson),
+  (AngelaScope)-[:FOLLOWS]->(JessicaThompson),
+  (PaulBlythe)-[:FOLLOWS]->(AngelaScope)
+
+CREATE
+  (JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),
+  (JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements),
+  (JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->(TheReplacements),
+  (AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->(TheReplacements),
+  (JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven),
+  (JessicaThompson)-[:REVIEWED {summary:"Slapstick redeemed only by the Robin Williams and Gene Hackman's stellar performances", rating:45}]->(TheBirdcage),
+  (JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),
+  (JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->(TheDaVinciCode),
+  (JessicaThompson)-[:REVIEWED {summary:'You had me at Jerry', rating:92}]->(JerryMaguire)
+
+WITH TomH as a
+MATCH (a)-[:ACTED_IN]->(m)<-[:DIRECTED]-(d) RETURN a,m,d LIMIT 10
+;

--- a/examples/reactive-web/README.adoc
+++ b/examples/reactive-web/README.adoc
@@ -48,7 +48,7 @@ java -jar examples/reactive-web/target/movie-api.jar \
 
 with parameters fitting to your needs.
 
-Here are some CURL commands, you can try out.
+Here are some _curl_ commands, you can try out.
 The same examples are also available in the file `movie-api-examples.http` that you can call from IDEA.
 
 [source,bash]

--- a/examples/reactive-web/pom.xml
+++ b/examples/reactive-web/pom.xml
@@ -32,7 +32,7 @@
 	<artifactId>spring-data-neo4j-rx-examples-reactive-web</artifactId>
 	<version>999-SNAPSHOT</version>
 
-	<name>SDN⚡️RX Examples for Spring Boot</name>
+	<name>SDN⚡️RX Examples for Reactive Spring Boot</name>
 	<description>Demonstrating how to use SDN⚡️RX from within Spring Boot.</description>
 
 	<properties>
@@ -56,6 +56,12 @@
 			<groupId>org.neo4j.springframework.data</groupId>
 			<artifactId>spring-data-neo4j-rx-spring-boot-starter</artifactId>
 			<version>${spring-data-neo4j-rx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j.springframework.data</groupId>
+			<artifactId>spring-data-neo4j-rx-spring-boot-test-autoconfigure</artifactId>
+			<version>${spring-data-neo4j-rx.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -202,7 +208,7 @@
 				</property>
 			</activation>
 			<properties>
-				<changelist>-beta01</changelist>
+				<changelist>-SNAPSHOT</changelist>
 			</properties>
 		</profile>
 	</profiles>

--- a/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
+++ b/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
@@ -37,7 +37,6 @@ import org.neo4j.springframework.boot.test.autoconfigure.data.DataNeo4jTest;
 import org.neo4j.springframework.data.examples.spring_boot.domain.MovieRepository;
 import org.neo4j.springframework.data.examples.spring_boot.domain.PersonRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -51,10 +50,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * @author Gerrit Meier
  */
 @Testcontainers
-@EnabledIfEnvironmentVariable(named = DemoApplicationIT.SYS_PROPERTY_NEO4J_VERSION, matches = "4\\.0.*")
+@EnabledIfEnvironmentVariable(named = RepositoryTests.SYS_PROPERTY_NEO4J_VERSION, matches = "4\\.0.*")
 @DataNeo4jTest
-@ContextConfiguration(initializers = DemoApplicationIT.Initializer.class)
-class DemoApplicationIT {
+@ContextConfiguration(initializers = RepositoryTests.Initializer.class)
+class RepositoryTests {
 
 	private static final String SYS_PROPERTY_NEO4J_ACCEPT_COMMERCIAL_EDITION = "SDN_RX_NEO4J_ACCEPT_COMMERCIAL_EDITION";
 	protected static final String SYS_PROPERTY_NEO4J_VERSION = "SDN_RX_NEO4J_VERSION";

--- a/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
+++ b/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
+import org.neo4j.springframework.boot.test.autoconfigure.data.DataNeo4jTest;
 import org.neo4j.springframework.data.examples.spring_boot.domain.MovieRepository;
 import org.neo4j.springframework.data.examples.spring_boot.domain.PersonRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = DemoApplicationIT.SYS_PROPERTY_NEO4J_VERSION, matches = "4\\.0.*")
-@SpringBootTest
+@DataNeo4jTest
 @ContextConfiguration(initializers = DemoApplicationIT.Initializer.class)
 class DemoApplicationIT {
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 		<module>spring-data-neo4j-rx</module>
 		<module>spring-data-neo4j-rx-spring-boot-starter-parent</module>
 		<module>examples/reactive-web</module>
+		<module>examples/imperative-web</module>
 		<module>examples/mapping</module>
 	</modules>
 

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/pom.xml
@@ -38,6 +38,7 @@
 	<modules>
 		<module>spring-data-neo4j-rx-spring-boot-autoconfigure</module>
 		<module>spring-data-neo4j-rx-spring-boot-starter</module>
+		<module>spring-data-neo4j-rx-spring-boot-test-autoconfigure</module>
 	</modules>
 
 	<properties>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jRepositoriesAutoConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jRepositoriesAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Shared entry point for the configuration of SDN-RX reposistories in their imperative and reactive forms.
+ * Shared entry point for the configuration of SDN-RX repositories in their imperative and reactive forms.
  *
  * @author Michael J. Simons
  */

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
@@ -33,31 +33,40 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.neo4j.driver</groupId>
-			<artifactId>neo4j-java-driver-spring-boot-starter</artifactId>
+			<groupId>org.neo4j.springframework.data</groupId>
+			<artifactId>spring-data-neo4j-rx-spring-boot-autoconfigure</artifactId>
+			<version>${revision}${sha1}${changelist}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j.springframework.data</groupId>
 			<artifactId>spring-data-neo4j-rx</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-core</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure-processor</artifactId>
-			<optional>true</optional>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
@@ -69,10 +78,6 @@
 			<artifactId>neo4j</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+
 	</dependencies>
 </project>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
@@ -53,8 +53,9 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.neo4j.springframework.data</groupId>
-			<artifactId>spring-data-neo4j-rx</artifactId>
+			<groupId>org.neo4j.test</groupId>
+			<artifactId>neo4j-harness</artifactId>
+			<version>${neo4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -80,4 +81,23 @@
 		</dependency>
 
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- DependencyConvergence has been removed here due to Neo4j test harness having
+			     a lot of non converging, transitive dependencies. The test harness is an optional dependency for us -->
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<phase>validate</phase>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
@@ -70,6 +70,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright (c) 2019 "Neo4j,"
+ | Neo4j Sweden AB [https://neo4j.com]
+ |
+ | This file is part of Neo4j.
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |     https://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>spring-data-neo4j-rx-spring-boot-starter-parent</artifactId>
+		<groupId>org.neo4j.springframework.data</groupId>
+		<version>${revision}${sha1}${changelist}</version>
+	</parent>
+
+	<artifactId>spring-data-neo4j-rx-spring-boot-test-autoconfigure</artifactId>
+
+	<name>SDN⚡️RX Spring Boot Test Autoconfiguration</name>
+	<description>Testslices for Neo4j SDN/RX.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.neo4j.driver</groupId>
+			<artifactId>neo4j-java-driver-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j.springframework.data</groupId>
+			<artifactId>spring-data-neo4j-rx</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>neo4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/AutoConfigureDataNeo4j.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/AutoConfigureDataNeo4j.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * {@link ImportAutoConfiguration Auto-configuration imports} for typical Data Neo4j
+ * tests. Most tests should consider using {@link DataNeo4jTest @DataNeo4jTest} rather
+ * than using this annotation directly.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Rock In Rio
+ * @since 1.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureDataNeo4j {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTest.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTest.java
@@ -27,9 +27,13 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,4 +69,47 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureDataNeo4j
 @ImportAutoConfiguration
 public @interface DataNeo4jTest {
+
+	/**
+	 * Properties in form {@literal key=value} that should be added to the Spring
+	 * {@link Environment} before the test runs.
+	 *
+	 * @return the properties to add
+	 */
+	String[] properties() default {};
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default no beans are
+	 * included.
+	 *
+	 * @return if default filters should be used
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 *
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 *
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 *
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
 }

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTest.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Annotation that can be used for a Neo4j test that focuses <strong>only</strong> on
+ * Neo4j components.
+ * <p>
+ * Using this annotation will disable full auto-configuration and instead apply only
+ * configuration relevant to Neo4j tests.
+ * <p>
+ * By default, tests annotated with {@code @DataNeo4jTest} will use an embedded in-memory
+ * Neo4j process (if available). They will also be transactional with the usual
+ * test-related semantics (i.e. rollback by default).
+ * <p>
+ * When using JUnit 4, this annotation should be used in combination with
+ * {@code @RunWith(SpringRunner.class)}.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ * @soundtrack Iron Maiden - Rock In Rio
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(DataNeo4jTestContextBootstrapper.class)
+@ExtendWith(SpringExtension.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(DataNeo4jTypeExcludeFilter.class)
+@Transactional
+@AutoConfigureCache
+@AutoConfigureDataNeo4j
+@ImportAutoConfiguration
+public @interface DataNeo4jTest {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestContextBootstrapper.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestContextBootstrapper.java
@@ -21,6 +21,7 @@ package org.neo4j.springframework.boot.test.autoconfigure.data;
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.test.context.TestContextBootstrapper;
 
 /**
  * {@link TestContextBootstrapper} for {@link DataNeo4jTest @DataNeo4jTest} support.

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestContextBootstrapper.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestContextBootstrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+
+/**
+ * {@link TestContextBootstrapper} for {@link DataNeo4jTest @DataNeo4jTest} support.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ * @soundtrack Iron Maiden - Rock In Rio
+ */
+class DataNeo4jTestContextBootstrapper extends SpringBootTestContextBootstrapper {
+
+	@Override
+	protected String[] getProperties(Class<?> testClass) {
+		return MergedAnnotations.from(testClass, SearchStrategy.INHERITED_ANNOTATIONS).get(DataNeo4jTest.class)
+			.getValue("properties", String[].class).orElse(null);
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilter.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilter.java
@@ -18,6 +18,15 @@
  */
 package org.neo4j.springframework.boot.test.autoconfigure.data;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.core.Neo4jClient;
+import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
 
@@ -32,5 +41,22 @@ class DataNeo4jTypeExcludeFilter extends StandardAnnotationCustomizableTypeExclu
 
 	DataNeo4jTypeExcludeFilter(Class<?> testClass) {
 		super(testClass);
+	}
+
+	private static final Set<Class<?>> DEFAULT_INCLUDES;
+
+	static {
+		Set<Class<?>> includes = new LinkedHashSet<>();
+		includes.add(Driver.class);
+		includes.add(Neo4jClient.class);
+		includes.add(ReactiveNeo4jClient.class);
+		includes.add(Neo4jRepository.class);
+		includes.add(ReactiveNeo4jRepository.class);
+		DEFAULT_INCLUDES = Collections.unmodifiableSet(includes);
+	}
+
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		return DEFAULT_INCLUDES;
 	}
 }

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilter.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.boot.test.autoconfigure.filter.StandardAnnotationCustomizableTypeExcludeFilter;
+
+/**
+ * {@link TypeExcludeFilter} for {@link DataNeo4jTest @DataNeo4jTest}.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Iron Maiden - Rock In Rio
+ * @since 1.0
+ */
+class DataNeo4jTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<DataNeo4jTest> {
+
+	DataNeo4jTypeExcludeFilter(Class<?> testClass) {
+		super(testClass);
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration;
+import org.neo4j.harness.ServerControls;
+import org.neo4j.harness.TestServerBuilder;
+import org.neo4j.harness.TestServerBuilders;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Automatic configuration that provides {@link ServerControls} when the Neo4j test harness (community edition) is on the
+ * classpath and a {@link Driver} using the internal Bolt connection to those controls.
+ * <p>
+ * By providing the {@link ServerControls} manually one can use the enterprise edition of the test harness as well, the
+ * automatic configuration will then just configure the driver accordingly.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore(Neo4jDriverAutoConfiguration.class)
+public class Neo4jTestHarnessAutoConfiguration {
+
+	@Bean
+	@ConditionalOnClass({ TestServerBuilder.class })
+	@ConditionalOnMissingBean(ServerControls.class)
+	ServerControls neo4jServerControls() {
+		return TestServerBuilders.newInProcessBuilder().newServer();
+	}
+
+	@Bean
+	@ConditionalOnBean(ServerControls.class)
+	@ConditionalOnMissingBean(Driver.class)
+	Driver neo4jDriver(ServerControls serverControls) {
+
+		return GraphDatabase.driver(serverControls.boltURI());
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfiguration.java
@@ -22,10 +22,8 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration;
 import org.neo4j.harness.ServerControls;
-import org.neo4j.harness.TestServerBuilder;
 import org.neo4j.harness.TestServerBuilders;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -42,19 +40,18 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.0
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(ServerControls.class)
+@ConditionalOnMissingBean(Driver.class)
 @AutoConfigureBefore(Neo4jDriverAutoConfiguration.class)
 public class Neo4jTestHarnessAutoConfiguration {
 
 	@Bean
-	@ConditionalOnClass({ TestServerBuilder.class })
 	@ConditionalOnMissingBean(ServerControls.class)
 	ServerControls neo4jServerControls() {
 		return TestServerBuilders.newInProcessBuilder().newServer();
 	}
 
 	@Bean
-	@ConditionalOnBean(ServerControls.class)
-	@ConditionalOnMissingBean(Driver.class)
 	Driver neo4jDriver(ServerControls serverControls) {
 
 		return GraphDatabase.driver(serverControls.boltURI());

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/package-info.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains testslices for SDN/RX, providing an embedded Neo4j instance or a connection to a Neo4j testcontainer and the
+ * possibility to configure a custom connection.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/package-info.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/java/org/neo4j/springframework/boot/test/autoconfigure/data/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Contains testslices for SDN/RX, providing an embedded Neo4j instance or a connection to a Neo4j testcontainer and the
- * possibility to configure a custom connection.
+ * Contains a test slice for SDN/RX, providing an embedded Neo4j instance if the Neo4j Test-Harness is available on the
+ * classpath. Otherwise delegates to the auto configuration of the Bolt driver for a usable driver bean.
  */
 package org.neo4j.springframework.boot.test.autoconfigure.data;

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.neo4j.springframework.boot.test.autoconfigure.data.AutoConfigureDataNeo4j=\
 org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration,\
 org.neo4j.springframework.boot.autoconfigure.data.Neo4jDataAutoConfiguration,\
 org.neo4j.springframework.boot.autoconfigure.data.Neo4jRepositoriesAutoConfiguration,\
+org.neo4j.springframework.boot.test.autoconfigure.data.Neo4jTestHarnessAutoConfiguration,\
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,6 @@
+# AutoConfigureDataNeo4j auto-configuration imports
+org.neo4j.springframework.boot.test.autoconfigure.data.AutoConfigureDataNeo4j=\
+org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration,\
+org.neo4j.springframework.boot.autoconfigure.data.Neo4jDataAutoConfiguration,\
+org.neo4j.springframework.boot.autoconfigure.data.Neo4jRepositoriesAutoConfiguration,\
+org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration tests for the SDN/RX Neo4j test slice.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@ContextConfiguration(initializers = DataNeo4jTestIT.Initializer.class)
+@DataNeo4jTest
+@Testcontainers
+class DataNeo4jTestIT {
+
+	@Container
+	static final Neo4jContainer<?> neo4j = new Neo4jContainer<>().withoutAuthentication();
+
+	@Autowired
+	private Driver driver;
+
+	@Autowired
+	private ExampleRepository exampleRepository;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void testRepository() {
+		ExampleEntity entity = new ExampleEntity("Look, new @DataNeo4jTest!");
+		assertThat(entity.getId()).isNull();
+		ExampleEntity persistedEntity = this.exampleRepository.save(entity);
+		assertThat(persistedEntity.getId()).isNotNull();
+		/*
+		try(Session session = driver.session(SessionConfig.builder().withDefaultAccessMode(AccessMode.READ).build())) {
+			// assertThat(this.session.countEntitiesOfType(ExampleGraph.class)).isEqualTo(1);
+		}
+
+		 */
+
+	}
+
+	@Test
+	void didNotInjectExampleService() {
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+			.isThrownBy(() -> this.applicationContext.getBean(ExampleService.class));
+	}
+
+	static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+			TestPropertyValues.of("org.neo4j.driver.uri=" + neo4j.getBoltUrl())
+				.applyTo(configurableApplicationContext.getEnvironment());
+		}
+
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
@@ -34,7 +34,10 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.Neo4jContainer;
 
@@ -50,6 +53,34 @@ class DataNeo4jTestIT {
 	@DisplayName("Default usage with test harness")
 	@DataNeo4jTest
 	class DriverBasedOnTestHarness extends TestBase {
+	}
+
+	@Nested
+	@DisplayName("Properties should be applied.")
+	@DataNeo4jTest(properties = "spring.profiles.active=test")
+	class DataNeo4jTestPropertiesIT {
+
+		@Autowired
+		private Environment environment;
+
+		@Test
+		void environmentWithNewProfile() {
+			assertThat(this.environment.getActiveProfiles()).containsExactly("test");
+		}
+	}
+
+	@Nested
+	@DisplayName("Include filter should work")
+	@DataNeo4jTest(includeFilters = @ComponentScan.Filter(Service.class))
+	class DataNeo4jTestWithIncludeFilterIntegrationTests {
+
+		@Autowired
+		private ExampleService service;
+
+		@Test
+		void testService() {
+			assertThat(this.service.hasNode(ExampleEntity.class)).isFalse();
+		}
 	}
 
 	@Nested

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTestIT.java
@@ -85,7 +85,7 @@ class DataNeo4jTestIT {
 
 	@Nested
 	@DisplayName("Usage with driver auto configuration")
-	// TODO We don't use @Containers, but the new attribute is helpful to prevent unnessary failing tests.
+	// TODO We don't use @Containers, but the new attribute is helpful to prevent unnecessary failing tests.
 	// @Testcontainers(disabledWithoutDocker = true)
 	@ContextConfiguration(initializers = TestContainerInitializer.class)
 	@DataNeo4jTest(excludeAutoConfiguration = Neo4jTestHarnessAutoConfiguration.class)

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilterTest.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/DataNeo4jTypeExcludeFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+
+/**
+ * @author Michael J. Simons
+ */
+class DataNeo4jTypeExcludeFilterTest {
+
+	private MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+	@Test
+	void matchWithExcludeFilter() throws Exception {
+		DataNeo4jTypeExcludeFilter filter = new DataNeo4jTypeExcludeFilter(WithExcludeFilter.class);
+		assertThat(excludes(filter, ExampleService.class)).isTrue();
+		assertThat(excludes(filter, ExampleRepository.class)).isTrue();
+	}
+
+	@Test
+	void matchWithoutExcludeFilter() throws Exception {
+		DataNeo4jTypeExcludeFilter filter = new DataNeo4jTypeExcludeFilter(WithoutExcludeFilter.class);
+		assertThat(excludes(filter, ExampleService.class)).isTrue();
+		assertThat(excludes(filter, ExampleRepository.class)).isFalse();
+	}
+
+	@DataNeo4jTest(excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = ExampleRepository.class))
+	static class WithExcludeFilter {
+	}
+
+	@DataNeo4jTest
+	static class WithoutExcludeFilter {
+	}
+
+	private boolean excludes(DataNeo4jTypeExcludeFilter filter, Class<?> type) throws IOException {
+		MetadataReader metadataReader = this.metadataReaderFactory.getMetadataReader(type.getName());
+		return filter.match(metadataReader, this.metadataReaderFactory);
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleEntity.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * A sample {@link Node}.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@Node
+public class ExampleEntity {
+
+	@Id @GeneratedValue
+	private Long id;
+
+	private final String name;
+
+	public ExampleEntity(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleNeo4jApplication.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleNeo4jApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Example {@link SpringBootApplication @SpringBootApplication} used with
+ * {@link DataNeo4jTest @DataNeo4jTest} tests.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@SpringBootApplication
+public class ExampleNeo4jApplication {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleRepository.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+
+/**
+ * A sample {@link org.springframework.data.repository.Repository}.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+public interface ExampleRepository extends Neo4jRepository<ExampleEntity, Long> {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleService.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * A sample service serving as a negative probe.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@Service
+public class ExampleService {
+	private final ExampleRepository exampleRepository;
+
+	public ExampleService(ExampleRepository exampleRepository) {
+		this.exampleRepository = exampleRepository;
+	}
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleService.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/ExampleService.java
@@ -18,19 +18,25 @@
  */
 package org.neo4j.springframework.boot.test.autoconfigure.data;
 
+import org.neo4j.springframework.data.core.Neo4jClient;
 import org.springframework.stereotype.Service;
 
 /**
- * A sample service serving as a negative probe.
+ * A sample service.
  *
  * @author Michael J. Simons
  * @since 1.0
  */
 @Service
 public class ExampleService {
-	private final ExampleRepository exampleRepository;
+	private final Neo4jClient neo4jClient;
 
-	public ExampleService(ExampleRepository exampleRepository) {
-		this.exampleRepository = exampleRepository;
+	public ExampleService(Neo4jClient neo4jClient) {
+		this.neo4jClient = neo4jClient;
+	}
+
+	public boolean hasNode(Class<?> clazz) {
+		return neo4jClient.query(String.format("MATCH (n:%s) RETURN count(n) > 0", clazz.getSimpleName()))
+			.fetchAs(Boolean.class).one().get();
 	}
 }

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfigurationTest.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-test-autoconfigure/src/test/java/org/neo4j/springframework/boot/test/autoconfigure/data/Neo4jTestHarnessAutoConfigurationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.test.autoconfigure.data;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.harness.ServerControls;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Michael J. Simons
+ */
+class Neo4jTestHarnessAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(Neo4jTestHarnessAutoConfiguration.class));
+
+	@Test
+	void shouldRequireTestHarness() {
+		contextRunner
+			.withClassLoader(new FilteredClassLoader(ServerControls.class))
+			.run(ctx -> assertThat(ctx)
+				.doesNotHaveBean(ServerControls.class)
+				.doesNotHaveBean(Driver.class));
+	}
+
+	@Test
+	void shouldCreateServerControlsAndDriver() {
+		contextRunner
+			.run(ctx -> assertThat(ctx)
+				.hasSingleBean(ServerControls.class)
+				.hasSingleBean(Driver.class));
+	}
+
+	@Test
+	void existingDriverShouldHavePrecedence() {
+		contextRunner
+			.withUserConfiguration(ConfigurationWithDriver.class)
+			.run(ctx -> {
+				assertThat(ctx)
+					.doesNotHaveBean(ServerControls.class)
+					.hasSingleBean(Driver.class);
+
+				Driver driver = ctx.getBean(Driver.class);
+				driver.session();
+				verify(driver).session();
+			});
+	}
+
+	@Test
+	void existingServerControlsShouldHavePrecedence() {
+		contextRunner
+			.withUserConfiguration(ConfigurationWithServerControls.class)
+			.run(ctx -> {
+				assertThat(ctx)
+					.hasSingleBean(ServerControls.class)
+					.hasSingleBean(Driver.class);
+
+				verify(ctx.getBean(ServerControls.class)).boltURI();
+			});
+	}
+
+	@Configuration
+	static class ConfigurationWithDriver {
+
+		@Bean
+		Driver neo4jDriver() {
+			return mock(Driver.class);
+		}
+	}
+
+	@Configuration
+	static class ConfigurationWithServerControls {
+
+		@Bean
+		ServerControls serverControls() {
+			final ServerControls mockedServerControls = mock(ServerControls.class);
+			when(mockedServerControls.boltURI()).thenReturn(URI.create("bolt://localhost:4711"));
+			return mockedServerControls;
+		}
+	}
+}


### PR DESCRIPTION
This adds a new `@DataNeo4jTest` that provides additional auto configuration. When the Neo4j test harness (https://medium.com/neo4j/testing-your-neo4j-based-java-application-34bef487cc3c)  is on the class-path and no other Driver bean is provided, it creates an embedded test server.

An already existing test server is recognised, so that user can run their own enterprise test harness if they want.

If test harness isn't on the class-path or excluded from the slice, the slice falls back to using an existing driver bean respectively delegates to the drivers auto configuration, thus recognising `org.neo4j.driver.uri` and related properties.

We can upgrade the optional dependencies for the test harness in a later step.

@hantsy Feel free to have a look. I have added two examples, one using the test harness, one a test container. This closes #36 .