### PR TITLE
GH-93 - Fix conversion of Enums and general collection handling.

### DIFF
--- a/docs/conversions.adoc
+++ b/docs/conversions.adoc
@@ -160,4 +160,12 @@ Primitive types of wrapper types are equally supported.
 |Point with CRS 4326 and x/y corresponding to lat/long
 |
 
+|Instances of `Enum`
+|String (The name value of the enum)
+|
+
+|Instances of `Enum[]`
+|List of String (The name value of the enum)
+|
+
 |===

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConversions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConversions.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apiguardian.api.API;
-import org.neo4j.driver.Value;
-import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.data.convert.CustomConversions;
 
 /**
@@ -38,7 +36,6 @@ public final class Neo4jConversions extends CustomConversions {
 
 	private static final StoreConversions STORE_CONVERSIONS;
 	private static final List<Object> STORE_CONVERTERS;
-	private static final TypeDescriptor TYPE_DESCRIPTOR_OF_VALUE = TypeDescriptor.valueOf(Value.class);
 
 	static {
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConversions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConversions.java
@@ -18,24 +18,15 @@
  */
 package org.neo4j.springframework.data.core.convert;
 
-import static java.util.stream.Collectors.*;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.neo4j.driver.Value;
-import org.neo4j.driver.Values;
-import org.springframework.core.CollectionFactory;
-import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.core.convert.converter.ConverterRegistry;
-import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.convert.CustomConversions;
-import org.springframework.lang.Nullable;
 
 /**
  * @author Michael J. Simons
@@ -75,82 +66,5 @@ public final class Neo4jConversions extends CustomConversions {
 	 */
 	public Neo4jConversions(Collection<?> converters) {
 		super(STORE_CONVERSIONS, converters);
-	}
-
-	@Override
-	public void registerConvertersIn(ConverterRegistry conversionService) {
-		super.registerConvertersIn(conversionService);
-
-		// Those can only be added at this point, as they will delegate to the target conversion service.
-		conversionService.addConverter(new ValueToCollectionConverter((ConversionService) conversionService));
-		conversionService.addConverter(new CollectionToValueConverter((ConversionService) conversionService));
-	}
-
-	private static class ValueToCollectionConverter implements GenericConverter {
-
-		private static final Set<ConvertiblePair> CONVERTIBLE_TYPES = Collections
-			.singleton(new ConvertiblePair(Value.class, Collection.class));
-		private final ConversionService conversionService;
-
-		ValueToCollectionConverter(ConversionService conversionService) {
-			this.conversionService = conversionService;
-		}
-
-		@Override
-		public Set<ConvertiblePair> getConvertibleTypes() {
-			return CONVERTIBLE_TYPES;
-		}
-
-		@Override
-		@Nullable
-		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
-			if (source == null) {
-				return null;
-			}
-
-			Value value = (Value) source;
-			TypeDescriptor elementDesc = targetType.getElementTypeDescriptor();
-			Collection<Object> target = CollectionFactory.createCollection(targetType.getType(),
-				(elementDesc != null ? elementDesc.getType() : null), value.size());
-
-			if (elementDesc == null) {
-				target.addAll(value.asList());
-			} else {
-				value.values().forEach(sourceElement -> target.add(this.conversionService.convert(sourceElement,
-					TYPE_DESCRIPTOR_OF_VALUE, elementDesc)));
-			}
-
-			return target;
-		}
-	}
-
-	private static class CollectionToValueConverter implements GenericConverter {
-
-		private static final Set<ConvertiblePair> CONVERTIBLE_TYPES = Collections
-			.singleton(new ConvertiblePair(Collection.class, Value.class));
-
-		private final ConversionService conversionService;
-
-		CollectionToValueConverter(ConversionService conversionService) {
-			this.conversionService = conversionService;
-		}
-
-		@Override
-		public Set<ConvertiblePair> getConvertibleTypes() {
-			return CONVERTIBLE_TYPES;
-		}
-
-		@Override
-		@Nullable
-		public Object convert(@Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
-			if (source == null) {
-				return null;
-			}
-			Collection<?> sourceCollection = (Collection<?>) source;
-
-			return Values.value((sourceCollection).stream().map(v -> conversionService
-				.convert(v, sourceType.elementTypeDescriptor(v), TYPE_DESCRIPTOR_OF_VALUE))
-				.collect(toList()));
-		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -80,8 +80,7 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 
 			return conversionService.convert(value, rawType);
 		} catch (Exception e) {
-			String msg = String.format("Could not convert %s into %s",
-				(value == null ? "literal null" : value), type.toString());
+			String msg = String.format("Could not convert %s into %s", value, type.toString());
 			throw new TypeMismatchDataAccessException(msg, e);
 		}
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -18,11 +18,14 @@
  */
 package org.neo4j.springframework.data.core.mapping;
 
+import java.util.Collection;
+
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.convert.Neo4jConverter;
+import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.ConfigurableConversionService;
@@ -65,7 +68,17 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 		}
 
 		try {
-			return conversionService.convert(value, type.getType());
+			Class<?> rawType = type.getType();
+
+			if (isCollection(type)) {
+				Collection<Object> target = CollectionFactory.createCollection(rawType,
+					type.getComponentType().getType(), value.size());
+				value.values().forEach(
+					element -> target.add(conversionService.convert(element, type.getComponentType().getType())));
+				return target;
+			}
+
+			return conversionService.convert(value, rawType);
 		} catch (Exception e) {
 			String msg = String.format("Could not convert %s into %s",
 				(value == null ? "literal null" : value), type.toString());
@@ -80,14 +93,25 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 			return Values.NULL;
 		}
 
+		if (isCollection(type)) {
+			Collection<?> sourceCollection = (Collection<?>) value;
+			Object[] targetCollection = (sourceCollection).stream().map(element ->
+				conversionService.convert(element, Value.class)).toArray();
+			return Values.value(targetCollection);
+		}
+
 		return conversionService.convert(value, Value.class);
+	}
+
+	private static boolean isCollection(TypeInformation<?> type) {
+		return Collection.class.isAssignableFrom(type.getType());
 	}
 
 	@Override
 	public <T> PersistentPropertyAccessor<T> decoratePropertyAccessor(TypeSystem typeSystem,
 		PersistentPropertyAccessor<T> targetPropertyAccessor) {
 
-		return new ConvertingPropertyAccessor<>(targetPropertyAccessor, new DelegatingConversionService(conversionService));
+		return new ConvertingPropertyAccessor<>(targetPropertyAccessor, new DelegatingConversionService());
 	}
 
 	@Override
@@ -106,12 +130,6 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 	}
 
 	class DelegatingConversionService implements ConversionService {
-
-		private final ConversionService delegate;
-
-		DelegatingConversionService(ConversionService delegate) {
-			this.delegate = delegate;
-		}
 
 		@Override
 		public boolean canConvert(Class<?> sourceType, Class<?> targetType) {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThing.java
@@ -20,7 +20,7 @@ package org.neo4j.springframework.data.integration.shared;
 
 import lombok.AllArgsConstructor;
 import lombok.Value;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.time.LocalDateTime;
 
@@ -37,7 +37,7 @@ import org.springframework.data.annotation.Persistent;
  * @author Michael J. Simons
  */
 @Value
-@Wither
+@With
 @AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
 @Persistent
 public class ImmutableAuditableThing {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
@@ -28,6 +28,7 @@ import java.util.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
+import org.neo4j.springframework.data.integration.shared.ThingWithAllAdditionalTypes.SomeEnum;
 import org.neo4j.springframework.data.test.Neo4jExtension;
 import org.neo4j.springframework.data.types.CartesianPoint2d;
 import org.neo4j.springframework.data.types.CartesianPoint3d;
@@ -88,6 +89,10 @@ public abstract class Neo4jConversionsITBase {
 		hlp.put("setOfStrings", new HashSet<>(Arrays.asList("Hallo", "wereld")));
 		hlp.put("anInstant", Instant.from(LocalDateTime.of(2019, 9, 26, 20, 34, 23).atOffset(ZoneOffset.UTC)));
 		hlp.put("aUUID", UUID.fromString("d4ec9208-4b17-4ec7-a709-19a5e53865a8"));
+		hlp.put("anEnum", SomeEnum.TheUsualMisfit);
+		hlp.put("anArrayOfEnums", new SomeEnum[] { SomeEnum.ValueA, SomeEnum.ValueB });
+		hlp.put("aCollectionOfEnums", Arrays.asList(SomeEnum.ValueC, SomeEnum.TheUsualMisfit));
+		hlp.put("listOfDoubles", Arrays.asList(1.0));
 		ADDITIONAL_TYPES = Collections.unmodifiableMap(hlp);
 	}
 
@@ -191,7 +196,11 @@ public abstract class Neo4jConversionsITBase {
 					+ " n.listOfStrings = ['Hello', 'World'],"
 					+ " n.setOfStrings = ['Hallo', 'wereld'],"
 					+ " n.anInstant = datetime('2019-09-26T20:34:23Z'),"
-					+ " n.aUUID = 'd4ec9208-4b17-4ec7-a709-19a5e53865a8'"
+					+ " n.aUUID = 'd4ec9208-4b17-4ec7-a709-19a5e53865a8',"
+					+ " n.listOfDoubles = [1.0],"
+					+ " n.anEnum = 'TheUsualMisfit',"
+					+ " n.anArrayOfEnums = ['ValueA', 'ValueB'],"
+					+ " n.aCollectionOfEnums = ['ValueC', 'TheUsualMisfit']"
 					+ " RETURN id(n) AS id", parameters).single().get("id").asLong();
 
 				parameters = new HashMap<>();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithAllConstructor.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithAllConstructor.java
@@ -23,7 +23,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,7 +48,7 @@ import org.neo4j.springframework.data.core.schema.Property;
 public class PersonWithAllConstructor {
 
 	@Id @GeneratedValue
-	@Wither
+	@With
 	private final Long id;
 
 	private final String name;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllAdditionalTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllAdditionalTypes.java
@@ -22,7 +22,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,8 +50,12 @@ import org.neo4j.springframework.data.core.schema.Node;
 @Builder
 public class ThingWithAllAdditionalTypes {
 
+	enum SomeEnum {
+		ValueA, ValueB, TheUsualMisfit, ValueC
+	}
+
 	@Id @GeneratedValue
-	@Wither
+	@With
 	public final Long id;
 
 	private boolean[] booleanArray;
@@ -99,4 +103,12 @@ public class ThingWithAllAdditionalTypes {
 	private Instant anInstant;
 
 	private UUID aUUID;
+
+	private SomeEnum anEnum;
+
+	private SomeEnum[] anArrayOfEnums;
+
+	private List<Double> listOfDoubles;
+
+	private List<SomeEnum> aCollectionOfEnums;
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllCypherTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllCypherTypes.java
@@ -22,7 +22,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,7 +48,7 @@ import org.neo4j.springframework.data.core.schema.Node;
 public class ThingWithAllCypherTypes {
 
 	@Id @GeneratedValue
-	@Wither
+	@With
 	public final Long id;
 
 	private boolean aBoolean;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllSpatialTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithAllSpatialTypes.java
@@ -22,7 +22,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
@@ -45,7 +45,7 @@ import org.springframework.data.geo.Point;
 public class ThingWithAllSpatialTypes {
 
 	@Id @GeneratedValue
-	@Wither
+	@With
 	public final Long id;
 
 	private Point sdnPoint;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/event/ImmutableSample.java
@@ -21,7 +21,7 @@ package org.neo4j.springframework.data.repository.event;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Value;
-import lombok.experimental.Wither;
+import lombok.With;
 
 import java.util.Date;
 
@@ -33,7 +33,7 @@ import org.springframework.data.annotation.LastModifiedDate;
  * @author Michael J. Simons
  */
 @Value
-@Wither
+@With
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 public class ImmutableSample {


### PR DESCRIPTION
While there have been conversions ins place for enum, they didn’t work for either arrays of enums nor collections thereof. While fixing the later, it became appearent that neither converting collections of anything else than String worked.

This has been fixed by moving the creation of collections into the `Neo4jConverter` itself and not as an afterthought registering in the conversion service. The additional converters are triggered to late in the process and don’t get hold of the original type descriptor anymore it seems. The type descriptor they receive doesn’t know about the element type anymore, as we cannot easily convert Spring Datas type information into Spring Frameworks type descriptor. Therefor, we stay in Spring Data land.