### PR TITLE
Issue/105 Persisting Relationships with Properties

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipPattern.html">RelationshipPattern</a>.
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -42,6 +43,7 @@ public final class Relationship implements
 
 	/**
 	 * While the direction in the schema package is centered around the node, the direction here is the direction between two nodes.
+	 *
 	 * @since 1.0
 	 */
 	public enum Direction {
@@ -78,6 +80,14 @@ public final class Relationship implements
 
 	static Relationship create(Node left,
 		@Nullable Direction direction, Node right, String... types) {
+		return create(left, direction, right, null, types);
+	}
+
+	static Relationship create(Node left,
+		@Nullable Direction direction,
+		Node right,
+		@Nullable Properties properties,
+		String... types) {
 
 		Assert.notNull(left, "Left node is required.");
 		Assert.notNull(right, "Right node is required.");
@@ -88,7 +98,9 @@ public final class Relationship implements
 
 		RelationshipDetail details = new RelationshipDetail(
 			Optional.ofNullable(direction).orElse(Direction.UNI),
-			null, listOfTypes);
+			null,
+			listOfTypes,
+			properties);
 		return new Relationship(left, details, right);
 	}
 
@@ -176,6 +188,8 @@ public final class Relationship implements
 	 * @return A map projection.
 	 */
 	public MapProjection project(Object... entries) {
-		return MapProjection.create(this.getSymbolicName().orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")), entries);
+		return MapProjection.create(this.getSymbolicName()
+				.orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")),
+			entries);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipDetail.html">RelationshipDetail</a>
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -48,10 +49,17 @@ public final class RelationshipDetail implements Visitable {
 
 	private final List<String> types;
 
+	private @Nullable final Properties properties;
+
 	RelationshipDetail(Direction direction,
 		@Nullable SymbolicName symbolicName, List<String> types) {
+		this(direction, symbolicName, types, null);
+	}
 
-		this(direction, symbolicName);
+	RelationshipDetail(Direction direction,
+		@Nullable SymbolicName symbolicName, List<String> types, @Nullable Properties properties) {
+
+		this(direction, symbolicName, properties);
 
 		boolean nullTypePresent = types.stream().filter(type -> type == null || type.isEmpty()).findAny().isPresent();
 		Assert.isTrue(!nullTypePresent, "The list of types may not contain literal null or an empty type.");
@@ -59,17 +67,18 @@ public final class RelationshipDetail implements Visitable {
 	}
 
 	private RelationshipDetail(Direction direction,
-		@Nullable SymbolicName symbolicName) {
+		@Nullable SymbolicName symbolicName, @Nullable Properties properties) {
 
 		this.direction = direction;
 		this.symbolicName = symbolicName;
 		this.types = new ArrayList<>();
+		this.properties = properties;
 	}
 
 	RelationshipDetail named(String newSymbolicName) {
 
 		Assert.hasText(newSymbolicName, "Symbolic name is required.");
-		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types);
+		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types, properties);
 	}
 
 	public Direction getDirection() {
@@ -88,11 +97,16 @@ public final class RelationshipDetail implements Visitable {
 		return !this.types.isEmpty();
 	}
 
+	public Optional<Properties> getProperties() {
+		return Optional.ofNullable(this.properties);
+	}
+
 	@Override
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
 		Visitable.visitIfNotNull(this.symbolicName, visitor);
+		Visitable.visitIfNotNull(this.properties, visitor);
 		visitor.leave(this);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -66,6 +66,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @soundtrack The Kleptones - A Night At The Hip-Hopera
  * @since 1.0
  */
@@ -184,8 +185,11 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 		});
 
 		parameters.put(NAME_OF_PROPERTIES_PARAM, properties);
-		parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
 
+		// in case of relationship properties ignore internal id property for now
+		if (nodeDescription.hasIdProperty()) {
+			parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
+		}
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
@@ -20,12 +20,14 @@ package org.neo4j.springframework.data.core.mapping;
 
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
+import org.neo4j.springframework.data.core.schema.RelationshipProperties;
 import org.springframework.data.mapping.PersistentProperty;
 
 /**
  * A {@link org.springframework.data.mapping.PersistentProperty} interface with additional methods for metadata related to Neo4j.
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -39,5 +41,17 @@ public interface Neo4jPersistentProperty
 	 */
 	default boolean isDynamicAssociation() {
 		return isAssociation() && isMap() && getComponentType() == String.class;
+	}
+
+	/**
+	 * see if the Association has a property class
+	 *
+	 * @return True, if this association has properties
+	 */
+	default boolean isRelationshipWithProperties() {
+		return isAssociation()
+			&& isMap()
+			&& getMapValueType() != null
+			&& getMapValueType().isAnnotationPresent(RelationshipProperties.class);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
@@ -26,20 +26,25 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 
 /**
  * @author Michael J. Simons
+ * @author Philipp Tölle
  */
 public final class Relationships {
 
 	/**
-	 * The value for a relationship can be a scalar object (1:1), a collection (1:n) or a map (1:n, but with dynamic
-	 * relationship types). This method unifies the type into something iterable, depending on the given inverse type.
+	 * The value for a relationship can be a scalar object (1:1), a collection (1:n), a map (1:n, but with dynamic
+	 * relationship types) or a map (1:n) with properties for each relationship.
+	 * This method unifies the type into something iterable, depending on the given inverse type.
 	 *
 	 * @param rawValue The raw value to unify
-	 * @return A unified collection (Either a collection of Map.Entry or a list of related values)
+	 * @return A unified collection (Either a collection of Map.Entry (for dynamic and relationships with properties
+	 * 			or a list of related values)
 	 */
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
 		if (property.isDynamicAssociation()) {
 			unifiedValue = ((Map<String, Object>) rawValue).entrySet();
+		} else if (property.isRelationshipWithProperties()) {
+			unifiedValue = ((Map<Object, Object>) rawValue).entrySet();
 		} else if (property.isCollectionLike()) {
 			unifiedValue = (Collection<Object>) rawValue;
 		} else {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
@@ -27,6 +27,7 @@ import org.neo4j.springframework.data.core.schema.Relationship;
 
 /**
  * @author Gerrit Meier
+ * @author Philipp Tölle
  */
 @Node
 public class PersonWithRelationshipWithProperties {
@@ -48,5 +49,9 @@ public class PersonWithRelationshipWithProperties {
 
 	public Map<Hobby, LikesHobbyRelationship> getHobbies() {
 		return hobbies;
+	}
+
+	public void setHobbies(Map<Hobby, LikesHobbyRelationship> hobbies) {
+		this.hobbies = hobbies;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.springframework.data.integration.imperative
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig
+import org.neo4j.springframework.data.core.schema.GeneratedValue
+import org.neo4j.springframework.data.core.schema.Id
+import org.neo4j.springframework.data.core.schema.Node
+import org.neo4j.springframework.data.core.schema.Relationship
+import org.neo4j.springframework.data.repository.Neo4jRepository
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+/**
+ * This test originate from https://github.com/neo4j/sdn-rx/issues/102.
+ * It is designed to ensure the capability of creating dependent relationships for immutable objects before
+ * the creation of the object itself.
+ *
+ * @author Gerrit Meier
+ */
+@ExtendWith(SpringExtension::class)
+class ImmutableRelationshipsIT @Autowired constructor(
+    private val repository: DeviceRepository,
+    private val driver: Driver
+) {
+    @Test
+    fun createRelationshipsBeforeRootObject() {
+
+        driver.session().use { session ->
+            session.run("MATCH (n) DETACH DELETE n")
+            session.run("CREATE (n:DeviceEntity {deviceId:'123', phoneNumber:'some number'})-[:LATEST_LOCATION]->(l1: LocationEntity{latitude: 20.0, longitude: 20.0})")
+        }
+        val device = repository.findById("123").get()
+        assertThat(device.deviceId).isEqualTo("123")
+        assertThat(device.phoneNumber).isEqualTo("some number")
+
+        assertThat(device.location).isNotNull
+        assertThat(device.location!!.latitude).isEqualTo(20.0)
+        assertThat(device.location!!.longitude).isEqualTo(20.0)
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    @EnableNeo4jRepositories
+    open class MyConfig : AbstractNeo4jConfig() {
+        @Bean
+        override fun driver(): Driver {
+            return GraphDatabase.driver("neo4j://localhost:7687", AuthTokens.basic("neo4j", "secret"))
+        }
+
+        override fun getMappingBasePackages(): Collection<String> {
+            return listOf(ImmutableRelationshipsIT::class.java.getPackage().name)
+        }
+
+    }
+
+}
+
+interface DeviceRepository: Neo4jRepository<DeviceEntity, String>
+
+@Node
+data class DeviceEntity(
+    @Id
+    val deviceId: String,
+    val phoneNumber: String,
+    @Relationship(type = "LATEST_LOCATION", direction = Relationship.Direction.OUTGOING)
+    val location: LocationEntity?
+)
+
+@Node
+data class LocationEntity(
+    @Id
+    @GeneratedValue
+    val locationId: Long? = null,
+    val latitude: Double,
+    val longitude: Double,
+    @Relationship(type = "PREVIOUS_LOCATION", direction = Relationship.Direction.OUTGOING)
+    val previousLocation: LocationEntity?
+)
+

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
@@ -21,10 +21,7 @@ package org.neo4j.springframework.data.integration.imperative
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
-import org.neo4j.driver.GraphDatabase
 import org.neo4j.springframework.data.config.AbstractNeo4jConfig
 import org.neo4j.springframework.data.core.schema.GeneratedValue
 import org.neo4j.springframework.data.core.schema.Id
@@ -32,10 +29,11 @@ import org.neo4j.springframework.data.core.schema.Node
 import org.neo4j.springframework.data.core.schema.Relationship
 import org.neo4j.springframework.data.repository.Neo4jRepository
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories
+import org.neo4j.springframework.data.test.Neo4jExtension
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 /**
@@ -45,11 +43,18 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
  *
  * @author Gerrit Meier
  */
-@ExtendWith(SpringExtension::class)
+@Neo4jIntegrationTest
 class ImmutableRelationshipsIT @Autowired constructor(
     private val repository: DeviceRepository,
     private val driver: Driver
 ) {
+
+    companion object {
+        @JvmStatic
+        private lateinit var neo4jConnectionSupport: Neo4jExtension.Neo4jConnectionSupport
+    }
+
+
     @Test
     fun createRelationshipsBeforeRootObject() {
 
@@ -72,7 +77,7 @@ class ImmutableRelationshipsIT @Autowired constructor(
     open class MyConfig : AbstractNeo4jConfig() {
         @Bean
         override fun driver(): Driver {
-            return GraphDatabase.driver("neo4j://localhost:7687", AuthTokens.basic("neo4j", "secret"))
+            return neo4jConnectionSupport.driver
         }
 
         override fun getMappingBasePackages(): Collection<String> {


### PR DESCRIPTION
This PR combines the commits from issue/104 and fixes for issue/105.

Therefor issue/104 should be merged first.

A couple of notes:
1. Persistence of relationships with properties via `saveAll()` is most probably not implemented yet.
2. The function `Neo4JTemplate#save` and especially `Neo4jTemplate#processNestedAnnotations` and its reactive counterparts would benefit from some refactoring (probably should be done after `saveAll()` implementation
3. Also `CypherGenerator#createRelationshipCreationQuery`and `CypherGenerator#createRelationshipWithPropertiesCreationQuery` could be combined and improved

Since this is my first Pull Request I'm very much open for any improvement suggestion and hope to bring this project forward. So please take your time for a proper review.

