### PR TITLE
Persist relationships with properties

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -20,6 +20,7 @@ package org.neo4j.springframework.data.core;
 
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
+import static org.neo4j.springframework.data.core.RelationshipStatementHolder.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 import static org.neo4j.springframework.data.core.schema.CypherGenerator.*;
 import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
@@ -27,7 +28,6 @@ import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +47,6 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.core.schema.CypherGenerator;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
-import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.neo4j.springframework.data.core.support.Relationships;
 import org.neo4j.springframework.data.repository.NoResultException;
 import org.neo4j.springframework.data.repository.event.BeforeBindCallback;
@@ -313,83 +312,59 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 	private void processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject) {
 
 		PersistentPropertyAccessor<?> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(parentObject);
-		Object fromId = propertyAccessor.getProperty(neo4jPersistentEntity.getRequiredIdProperty());
 
 		neo4jPersistentEntity.doWithAssociations((AssociationHandler<Neo4jPersistentProperty>) handler -> {
 
-			Neo4jPersistentProperty inverse = handler.getInverse();
-
-			Object value = propertyAccessor.getProperty(inverse);
-
-			Collection<RelationshipDescription> relationships = neo4jPersistentEntity.getRelationships();
-			RelationshipDescription relationship = relationships.stream()
-				.filter(r -> r.getFieldName().equals(inverse.getName()))
-				.findFirst().get();
-
-			Class<?> associationTargetType;
-			// if we have a relationship with properties, the targetNodeType is the Map Key
-			if (relationship.hasRelationshipProperties()) {
-				associationTargetType = inverse.getComponentType();
-			} else {
-				associationTargetType = inverse.getAssociationTargetType();
-			}
+			// create context to bundle parameters
+			NestedRelationshipContext relationshipContext = NestedRelationshipContext
+				.of(handler, propertyAccessor, neo4jPersistentEntity);
 
 			Neo4jPersistentEntity<?> targetNodeDescription = neo4jMappingContext
-				.getPersistentEntity(associationTargetType);
+				.getPersistentEntity(relationshipContext.getAssociationTargetType());
 
+			Object fromId = propertyAccessor.getProperty(neo4jPersistentEntity.getRequiredIdProperty());
 			// remove all relationships before creating all new if the entity is not new
 			// this avoids the usage of cache but might have significant impact on overall performance
 			if (!neo4jPersistentEntity.isNew(parentObject)) {
 				Statement relationshipRemoveQuery = cypherGenerator.createRelationshipRemoveQuery(neo4jPersistentEntity,
-					relationship, targetNodeDescription.getPrimaryLabel());
+					relationshipContext.getRelationship(), targetNodeDescription.getPrimaryLabel());
 
 				neo4jClient.query(renderer.render(relationshipRemoveQuery))
 					.bind(fromId).to(FROM_ID_PARAMETER_NAME).run();
 			}
 
-			if (value == null) {
+			// break recursive
+			if (relationshipContext.inverseValueIsEmpty()) {
 				return;
 			}
 
-			for (Object relatedValue : Relationships.unifyRelationshipValue(inverse, value)) {
+			for (Object relatedValue : Relationships
+				.unifyRelationshipValue(relationshipContext.getInverse(), relationshipContext.getValue())) {
 
 				// here map entry is not always anymore a dynamic association
-				Object valueToBeSaved = relatedValue;
-				if (relatedValue instanceof Map.Entry && inverse.isDynamicAssociation()) {
-					valueToBeSaved = ((Map.Entry) relatedValue).getValue();
-				} else if (relatedValue instanceof Map.Entry && relationship.hasRelationshipProperties()) {
-					valueToBeSaved = ((Map.Entry) relatedValue).getKey();
-				}
+				Object valueToBeSaved = relationshipContext.identifyAndExtractRelationshipValue(relatedValue);
 
 				valueToBeSaved = eventSupport.maybeCallBeforeBind(valueToBeSaved);
 
-				Long relatedInternalId = saveRelatedNode(valueToBeSaved, associationTargetType, targetNodeDescription);
+				Long relatedInternalId = saveRelatedNode(valueToBeSaved, relationshipContext.getAssociationTargetType(),
+					targetNodeDescription);
 
-				Statement relationshipCreationQuery;
-				if (relationship.hasRelationshipProperties()) {
-					relationshipCreationQuery = cypherGenerator.createRelationshipWithPropertiesCreationQuery(
+				// handle creation of relationship depending on properties on relationship or not
+				RelationshipStatementHolder statementHolder = relationshipContext.hasRelationshipWithProperties()
+					? createStatementForRelationShipWithProperties(neo4jMappingContext,
 						neo4jPersistentEntity,
-						relationship,
-						relatedInternalId
-					);
-					Map<String, Object> propMap = new HashMap<>();
-					neo4jMappingContext.getConverter().write(((Map.Entry) relatedValue).getValue(), propMap);
+						relationshipContext,
+						relatedInternalId,
+						(Map.Entry) relatedValue)
+					: createStatementForRelationshipWithoutProperties(neo4jPersistentEntity,
+						relationshipContext,
+						relatedInternalId,
+						relatedValue);
 
-					neo4jClient.query(renderer.render(relationshipCreationQuery))
-						.bind(fromId).to(FROM_ID_PARAMETER_NAME)
-						.bindAll(propMap)
-						.run();
-				} else {
-					relationshipCreationQuery = cypherGenerator
-						.createRelationshipCreationQuery(neo4jPersistentEntity,
-							relationship,
-							relatedValue instanceof Map.Entry ? ((Map.Entry<String, ?>) relatedValue).getKey() : null,
-							relatedInternalId);
-
-					neo4jClient.query(renderer.render(relationshipCreationQuery))
-						.bind(fromId).to(FROM_ID_PARAMETER_NAME)
-						.run();
-				}
+				neo4jClient.query(renderer.render(statementHolder.getRelationshipCreationQuery()))
+					.bind(fromId).to(FROM_ID_PARAMETER_NAME)
+					.bindAll(statementHolder.getProperties())
+					.run();
 
 				// if an internal id is used this must get set to link this entity in the next iteration
 				if (targetNodeDescription.isUsingInternalIds()) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.neo4j.springframework.data.core.schema.RelationshipDescription;
+import org.springframework.data.mapping.Association;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+
+/**
+ * Working on nested relationships happens in a certain algorithmic context.
+ * This context enables a tight cohesion between the algorithmic steps and the data, these steps are performed on.
+ * In our the interaction happens between the data that describes the relationship and the specific steps of
+ * the algorithm.
+ *
+ * @author Philipp Tölle
+ * @since 1.0
+ */
+final class NestedRelationshipContext {
+	private final Neo4jPersistentProperty inverse;
+	private final Object value;
+	private final RelationshipDescription relationship;
+	private final Class<?> associationTargetType;
+
+	private final boolean inverseValueIsEmpty;
+
+	private NestedRelationshipContext(Neo4jPersistentProperty inverse, Object value,
+		RelationshipDescription relationship, Class<?> associationTargetType, boolean inverseValueIsEmpty) {
+		this.inverse = inverse;
+		this.value = value;
+		this.relationship = relationship;
+		this.associationTargetType = associationTargetType;
+		this.inverseValueIsEmpty = inverseValueIsEmpty;
+	}
+
+	Neo4jPersistentProperty getInverse() {
+		return inverse;
+	}
+
+	@NotNull
+	Object getValue() {
+		return value;
+	}
+
+	RelationshipDescription getRelationship() {
+		return relationship;
+	}
+
+	Class<?> getAssociationTargetType() {
+		return associationTargetType;
+	}
+
+	public boolean inverseValueIsEmpty() {
+		return inverseValueIsEmpty;
+	}
+
+	boolean hasRelationshipWithProperties() {
+		return this.relationship.hasRelationshipProperties();
+	}
+
+	Object identifyAndExtractRelationshipValue(Object relatedValue) {
+		Object valueToBeSaved = relatedValue;
+		if (relatedValue instanceof Map.Entry) {
+			Map.Entry relatedValueMapEntry = (Map.Entry) relatedValue;
+
+			if (this.getInverse().isDynamicAssociation()) {
+				valueToBeSaved = relatedValueMapEntry.getValue();
+			} else if (this.hasRelationshipWithProperties()) {
+				valueToBeSaved = relatedValueMapEntry.getKey();
+			}
+		}
+
+		return valueToBeSaved;
+	}
+
+	static NestedRelationshipContext of(Association<Neo4jPersistentProperty> handler,
+		PersistentPropertyAccessor<?> propertyAccessor,
+		Neo4jPersistentEntity<?> neo4jPersistentEntity) {
+
+		Neo4jPersistentProperty inverse = handler.getInverse();
+
+		boolean inverseValueIsEmpty = propertyAccessor.getProperty(inverse) == null;
+		Object value = propertyAccessor.getProperty(inverse);
+
+		RelationshipDescription relationship = neo4jPersistentEntity
+			.getRelationships().stream()
+			.filter(r -> r.getFieldName().equals(inverse.getName()))
+			.findFirst().get();
+
+		// if we have a relationship with properties, the targetNodeType is the map key
+		Class<?> associationTargetType = relationship.hasRelationshipProperties()
+			? inverse.getComponentType()
+			: inverse.getAssociationTargetType();
+
+		return new NestedRelationshipContext(inverse, value, relationship, associationTargetType,
+			inverseValueIsEmpty);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/RelationshipStatementHolder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/RelationshipStatementHolder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.springframework.data.core.cypher.Statement;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.schema.CypherGenerator;
+
+/**
+ * The {@link RelationshipStatementHolder} holds the Cypher Statement to create a relationship as well as the optional
+ * properties that describe the relationship in case of more then a simple relationship.
+ * By holding the relationship creation cypher together with the properties, we can reuse the same logic in the
+ * {@link Neo4jTemplate} as well as in the {@link ReactiveNeo4jTemplate}.
+ *
+ * @author Philipp Tölle
+ * @since 1.0
+ */
+final class RelationshipStatementHolder {
+	private final Statement relationshipCreationQuery;
+	private final Map<String, Object> properties;
+
+	private RelationshipStatementHolder(@NotNull Statement relationshipCreationQuery) {
+		this.relationshipCreationQuery = relationshipCreationQuery;
+		this.properties = Collections.emptyMap();
+	}
+
+	private RelationshipStatementHolder(
+		@NotNull Statement relationshipCreationQuery,
+		@NotNull Map<String, Object> properties) {
+		this.relationshipCreationQuery = relationshipCreationQuery;
+		this.properties = properties;
+	}
+
+	Statement getRelationshipCreationQuery() {
+		return relationshipCreationQuery;
+	}
+
+	Map<String, Object> getProperties() {
+		return properties;
+	}
+
+	static RelationshipStatementHolder createStatementForRelationShipWithProperties(
+		Neo4jMappingContext neo4jMappingContext,
+		Neo4jPersistentEntity<?> neo4jPersistentEntity,
+		NestedRelationshipContext relationshipContext,
+		Long relatedInternalId,
+		Map.Entry relatedValue) {
+
+		Statement relationshipCreationQuery = CypherGenerator.INSTANCE
+			.createRelationshipWithPropertiesCreationQuery(
+				neo4jPersistentEntity,
+				relationshipContext.getRelationship(),
+				relatedInternalId
+			);
+		Map<String, Object> propMap = new HashMap<>();
+		neo4jMappingContext.getConverter().write(relatedValue.getValue(), propMap);
+
+		return new RelationshipStatementHolder(relationshipCreationQuery, propMap);
+	}
+
+	static RelationshipStatementHolder createStatementForRelationshipWithoutProperties(
+		Neo4jPersistentEntity<?> neo4jPersistentEntity,
+		NestedRelationshipContext relationshipContext,
+		Long relatedInternalId,
+		Object relatedValue) {
+
+		Statement relationshipCreationQuery = CypherGenerator.INSTANCE
+			.createRelationshipCreationQuery(neo4jPersistentEntity,
+				relationshipContext.getRelationship(),
+				relatedValue instanceof Map.Entry ? ((Map.Entry<String, ?>) relatedValue).getKey() : null,
+				relatedInternalId);
+		return new RelationshipStatementHolder(relationshipCreationQuery);
+	}
+}
+

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipPattern.html">RelationshipPattern</a>.
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -42,6 +43,7 @@ public final class Relationship implements
 
 	/**
 	 * While the direction in the schema package is centered around the node, the direction here is the direction between two nodes.
+	 *
 	 * @since 1.0
 	 */
 	public enum Direction {
@@ -78,6 +80,14 @@ public final class Relationship implements
 
 	static Relationship create(Node left,
 		@Nullable Direction direction, Node right, String... types) {
+		return create(left, direction, right, null, types);
+	}
+
+	static Relationship create(Node left,
+		@Nullable Direction direction,
+		Node right,
+		@Nullable Properties properties,
+		String... types) {
 
 		Assert.notNull(left, "Left node is required.");
 		Assert.notNull(right, "Right node is required.");
@@ -88,7 +98,9 @@ public final class Relationship implements
 
 		RelationshipDetail details = new RelationshipDetail(
 			Optional.ofNullable(direction).orElse(Direction.UNI),
-			null, listOfTypes);
+			null,
+			listOfTypes,
+			properties);
 		return new Relationship(left, details, right);
 	}
 
@@ -176,6 +188,8 @@ public final class Relationship implements
 	 * @return A map projection.
 	 */
 	public MapProjection project(Object... entries) {
-		return MapProjection.create(this.getSymbolicName().orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")), entries);
+		return MapProjection.create(this.getSymbolicName()
+				.orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")),
+			entries);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -97,10 +97,6 @@ public final class RelationshipDetail implements Visitable {
 		return !this.types.isEmpty();
 	}
 
-	public Optional<Properties> getProperties() {
-		return Optional.ofNullable(this.properties);
-	}
-
 	@Override
 	public void accept(Visitor visitor) {
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipDetail.html">RelationshipDetail</a>
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -48,10 +49,17 @@ public final class RelationshipDetail implements Visitable {
 
 	private final List<String> types;
 
+	private @Nullable final Properties properties;
+
 	RelationshipDetail(Direction direction,
 		@Nullable SymbolicName symbolicName, List<String> types) {
+		this(direction, symbolicName, types, null);
+	}
 
-		this(direction, symbolicName);
+	RelationshipDetail(Direction direction,
+		@Nullable SymbolicName symbolicName, List<String> types, @Nullable Properties properties) {
+
+		this(direction, symbolicName, properties);
 
 		boolean nullTypePresent = types.stream().filter(type -> type == null || type.isEmpty()).findAny().isPresent();
 		Assert.isTrue(!nullTypePresent, "The list of types may not contain literal null or an empty type.");
@@ -59,17 +67,18 @@ public final class RelationshipDetail implements Visitable {
 	}
 
 	private RelationshipDetail(Direction direction,
-		@Nullable SymbolicName symbolicName) {
+		@Nullable SymbolicName symbolicName, @Nullable Properties properties) {
 
 		this.direction = direction;
 		this.symbolicName = symbolicName;
 		this.types = new ArrayList<>();
+		this.properties = properties;
 	}
 
 	RelationshipDetail named(String newSymbolicName) {
 
 		Assert.hasText(newSymbolicName, "Symbolic name is required.");
-		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types);
+		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types, properties);
 	}
 
 	public Direction getDirection() {
@@ -88,11 +97,16 @@ public final class RelationshipDetail implements Visitable {
 		return !this.types.isEmpty();
 	}
 
+	public Optional<Properties> getProperties() {
+		return Optional.ofNullable(this.properties);
+	}
+
 	@Override
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
 		Visitable.visitIfNotNull(this.symbolicName, visitor);
+		Visitable.visitIfNotNull(this.properties, visitor);
 		visitor.leave(this);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -186,7 +186,7 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 
 		parameters.put(NAME_OF_PROPERTIES_PARAM, properties);
 
-		// in case of relationship properties ignore internal id property for now
+		// in case of relationship properties ignore internal id property
 		if (nodeDescription.hasIdProperty()) {
 			parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -66,6 +66,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @soundtrack The Kleptones - A Night At The Hip-Hopera
  * @since 1.0
  */
@@ -184,8 +185,11 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 		});
 
 		parameters.put(NAME_OF_PROPERTIES_PARAM, properties);
-		parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
 
+		// in case of relationship properties ignore internal id property for now
+		if (nodeDescription.hasIdProperty()) {
+			parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
+		}
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
@@ -20,12 +20,14 @@ package org.neo4j.springframework.data.core.mapping;
 
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
+import org.neo4j.springframework.data.core.schema.RelationshipProperties;
 import org.springframework.data.mapping.PersistentProperty;
 
 /**
  * A {@link org.springframework.data.mapping.PersistentProperty} interface with additional methods for metadata related to Neo4j.
  *
  * @author Michael J. Simons
+ * @author Philipp Tölle
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
@@ -39,5 +41,17 @@ public interface Neo4jPersistentProperty
 	 */
 	default boolean isDynamicAssociation() {
 		return isAssociation() && isMap() && getComponentType() == String.class;
+	}
+
+	/**
+	 * see if the association has a property class
+	 *
+	 * @return True, if this association has properties
+	 */
+	default boolean isRelationshipWithProperties() {
+		return isAssociation()
+			&& isMap()
+			&& getMapValueType() != null
+			&& getMapValueType().isAnnotationPresent(RelationshipProperties.class);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
@@ -26,20 +26,25 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 
 /**
  * @author Michael J. Simons
+ * @author Philipp Tölle
  */
 public final class Relationships {
 
 	/**
-	 * The value for a relationship can be a scalar object (1:1), a collection (1:n) or a map (1:n, but with dynamic
-	 * relationship types). This method unifies the type into something iterable, depending on the given inverse type.
+	 * The value for a relationship can be a scalar object (1:1), a collection (1:n), a map (1:n, but with dynamic
+	 * relationship types) or a map (1:n) with properties for each relationship.
+	 * This method unifies the type into something iterable, depending on the given inverse type.
 	 *
 	 * @param rawValue The raw value to unify
-	 * @return A unified collection (Either a collection of Map.Entry or a list of related values)
+	 * @return A unified collection (Either a collection of Map.Entry (for dynamic and relationships with properties
+	 * 			or a list of related values)
 	 */
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
 		if (property.isDynamicAssociation()) {
 			unifiedValue = ((Map<String, Object>) rawValue).entrySet();
+		} else if (property.isRelationshipWithProperties()) {
+			unifiedValue = ((Map<Object, Object>) rawValue).entrySet();
 		} else if (property.isCollectionLike()) {
 			unifiedValue = (Collection<Object>) rawValue;
 		} else {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
@@ -36,8 +36,8 @@ public final class Relationships {
 	 * This method unifies the type into something iterable, depending on the given inverse type.
 	 *
 	 * @param rawValue The raw value to unify
-	 * @return A unified collection (Either a collection of Map.Entry (for dynamic and relationships with properties
-	 * 			or a list of related values)
+	 * @return A unified collection (Either a collection of Map.Entry for dynamic and relationships with properties
+	 * or a list of related values)
 	 */
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -468,44 +468,38 @@ class RepositoryIT {
 	}
 
 	@Test
-	void persistEntityWithRelationshipWithProperties() {
-
+	void saveEntityWithRelationshipWithProperties() {
 		// given
-		long personId;
+		Hobby h1 = new Hobby();
+		h1.setName("Music");
+		LikesHobbyRelationship rel1 = new LikesHobbyRelationship(1995);
+		rel1.setActive(true);
+		rel1.setLocalDate(LocalDate.of(1995, 2, 26));
+		rel1.setMyEnum(LikesHobbyRelationship.MyEnum.SOMETHING);
+		rel1.setPoint(new CartesianPoint2d(0.0, 1.0));
 
-		try (Session session = driver.session()) {
-			Record record = session
-				.run("CREATE (n:PersonWithRelationshipWithProperties{name:'Freddie'}),"
-					+ " (n)-[l1:LIKES"
-					+ "{since: 1995, active: true, localDate: date('1995-02-26'), myEnum: 'SOMETHING', point: point({x: 0, y: 1})}"
-					+ "]->(h1:Hobby{name:'Music'}),"
-					+ " (n)-[l2:LIKES"
-					+ "{since: 2000, active: false, localDate: date('2000-06-28'), myEnum: 'SOMETHING_DIFFERENT', point: point({x: 2, y: 3})}"
-					+ "]->(h2:Hobby{name:'Something else'})"
-					+ "RETURN n, h1, h2").single();
+		Hobby h2 = new Hobby();
+		h2.setName("Something else");
+		LikesHobbyRelationship rel2 = new LikesHobbyRelationship(1995);
+		rel2.setActive(false);
+		rel2.setLocalDate(LocalDate.of(2000, 6, 28));
+		rel2.setMyEnum(LikesHobbyRelationship.MyEnum.SOMETHING_DIFFERENT);
+		rel2.setPoint(new CartesianPoint2d(2.0, 3.0));
 
-			Node personNode = record.get("n").asNode();
-
-			personId = personNode.id();
-		}
+		Map<Hobby, LikesHobbyRelationship> hobbies = new HashMap<>();
+		hobbies.put(h1, rel1);
+		hobbies.put(h2, rel2);
+		PersonWithRelationshipWithProperties clonePerson = new PersonWithRelationshipWithProperties("Freddie clone");
+		clonePerson.setHobbies(hobbies);
 
 		// when
-		Optional<PersonWithRelationshipWithProperties> optionalPerson = relationshipWithPropertiesRepository
-			.findById(personId);
-		assertThat(optionalPerson).isPresent();
-		PersonWithRelationshipWithProperties person = optionalPerson.get();
-
-		PersonWithRelationshipWithProperties clonePerson = new PersonWithRelationshipWithProperties(
-			person.getName() + " clone");
-		clonePerson.setHobbies(person.getHobbies());
-
-		// then
 		PersonWithRelationshipWithProperties shouldBeDifferentPerson = relationshipWithPropertiesRepository
 			.save(clonePerson);
+
+		// then
 		assertThat(shouldBeDifferentPerson)
 			.isNotNull()
-			.isNotEqualTo(person)
-			.isEqualToComparingOnlyGivenFields(person, "hobbies");
+			.isEqualToComparingOnlyGivenFields(clonePerson, "hobbies");
 
 		assertThat(shouldBeDifferentPerson.getName()).isEqualToIgnoringCase("Freddie clone");
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.integration.shared;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.Id;
@@ -38,6 +39,9 @@ public class PersonWithRelationshipWithProperties {
 
 	@Relationship("LIKES")
 	private Map<Hobby, LikesHobbyRelationship> hobbies;
+
+	@Relationship("OWNS")
+	private Set<Pet> pets;
 
 	public PersonWithRelationshipWithProperties(String name) {
 		this.name = name;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelationshipWithProperties.java
@@ -27,6 +27,7 @@ import org.neo4j.springframework.data.core.schema.Relationship;
 
 /**
  * @author Gerrit Meier
+ * @author Philipp Tölle
  */
 @Node
 public class PersonWithRelationshipWithProperties {
@@ -48,5 +49,9 @@ public class PersonWithRelationshipWithProperties {
 
 	public Map<Hobby, LikesHobbyRelationship> getHobbies() {
 		return hobbies;
+	}
+
+	public void setHobbies(Map<Hobby, LikesHobbyRelationship> hobbies) {
+		this.hobbies = hobbies;
 	}
 }


### PR DESCRIPTION
This PR fixes #105 

A couple of notes:
1. Persistence of relationships with properties via `saveAll()` is most probably not implemented yet.
2. The function `Neo4JTemplate#save` and especially `Neo4jTemplate#processNestedAnnotations` and its reactive counterparts would benefit from some refactoring (probably should be done after `saveAll()` implementation
3. Also `CypherGenerator#createRelationshipCreationQuery`and `CypherGenerator#createRelationshipWithPropertiesCreationQuery` could be combined and improved

Since this is my first Pull Request I'm very much open for any improvement suggestion and hope to bring this project forward. So please take your time for a proper review.
