### PR TITLE
Fix order of auditing and isNew check

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdGeneratingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/IdGeneratingBeforeBindCallback.java
@@ -46,6 +46,6 @@ public final class IdGeneratingBeforeBindCallback implements BeforeBindCallback<
 
 	@Override
 	public int getOrder() {
-		return AuditingBeforeBindCallback.NEO4J_AUDITING_ORDER - 10;
+		return AuditingBeforeBindCallback.NEO4J_AUDITING_ORDER + 10;
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveIdGeneratingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveIdGeneratingBeforeBindCallback.java
@@ -49,6 +49,6 @@ public final class ReactiveIdGeneratingBeforeBindCallback implements ReactiveBef
 
 	@Override
 	public int getOrder() {
-		return ReactiveAuditingBeforeBindCallback.NEO4J_REACTIVE_AUDITING_ORDER - 10;
+		return ReactiveAuditingBeforeBindCallback.NEO4J_REACTIVE_AUDITING_ORDER + 10;
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditableThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/AuditableThing.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author Gerrit Meier
+ */
+public interface AuditableThing {
+
+	LocalDateTime getCreatedAt();
+	String getCreatedBy();
+	LocalDateTime getModifiedAt();
+	String getModifiedBy();
+	String getName();
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThingWithGeneratedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ImmutableAuditableThingWithGeneratedId.java
@@ -25,6 +25,7 @@ import lombok.With;
 import java.time.LocalDateTime;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.support.UUIDStringGenerator;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
@@ -40,9 +41,9 @@ import org.springframework.data.annotation.Persistent;
 @With
 @AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
 @Persistent
-public class ImmutableAuditableThing implements AuditableThing {
+public class ImmutableAuditableThingWithGeneratedId implements AuditableThing {
 
-	@Id @GeneratedValue Long id;
+	@Id @GeneratedValue(UUIDStringGenerator.class) String id;
 	@CreatedDate LocalDateTime createdAt;
 	@CreatedBy String createdBy;
 	@LastModifiedDate LocalDateTime modifiedAt;
@@ -50,7 +51,7 @@ public class ImmutableAuditableThing implements AuditableThing {
 
 	String name;
 
-	public ImmutableAuditableThing(String name) {
+	public ImmutableAuditableThingWithGeneratedId(String name) {
 		this(null, null, null, null, null, name);
 	}
 }


### PR DESCRIPTION
An id generator in IdGeneratingBeforeBindCallback is now
ordered after the AuditingBeforeBindCallback to ensure
that entities with generated ids will get picked up as new.

Closes #109 