### PR TITLE
GH-112 - Add support for derived countBy and pageable methods.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
@@ -299,7 +299,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
-		public final OngoingReadingAndReturn orderBy(SortItem... sortItem) {
+		public final OngoingMatchAndReturnWithOrder orderBy(SortItem... sortItem) {
 			orderBuilder.orderBy(sortItem);
 			return this;
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
@@ -352,10 +352,9 @@ public interface StatementBuilder {
 		 * all expression with {@link Cypher#sort(Expression)} or directly from properties.
 		 *
 		 * @param sortItem One or more sort items
-		 * @param <T>      The type of the step being returned
 		 * @return A build step that still offers methods for defining skip and limit
 		 */
-		<T extends TerminalExposesSkip & TerminalExposesLimit & BuildableStatement> T orderBy(SortItem... sortItem);
+		OngoingMatchAndReturnWithOrder orderBy(SortItem... sortItem);
 
 		/**
 		 * Order the result set by an expression.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractNeo4jQuery.java
@@ -47,9 +47,9 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 	protected final Neo4jOperations neo4jOperations;
 
 	AbstractNeo4jQuery(Neo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
-		Neo4jQueryMethod queryMethod) {
+		Neo4jQueryMethod queryMethod, Neo4jQueryType queryType) {
 
-		super(mappingContext, queryMethod);
+		super(mappingContext, queryMethod, queryType);
 
 		Assert.notNull(neo4jOperations, "The Neo4j operations are required.");
 		this.neo4jOperations = neo4jOperations;
@@ -80,7 +80,7 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 			return PageableExecutionUtils.getPage((List<?>) processedResult, parameterAccessor.getPageable(), () -> {
 
 				PreparedQuery<Long> countQuery = prepareQuery(Long.class, Collections.emptyList(), parameterAccessor,
-					Neo4jQueryType.count(), null);
+					Neo4jQueryType.COUNT, null);
 				return neo4jOperations.toExecutableQuery(countQuery).getRequiredSingleResult();
 			});
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractNeo4jQuery.java
@@ -18,12 +18,21 @@
  */
 package org.neo4j.springframework.data.repository.query;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.neo4j.driver.Record;
+import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jOperations;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.repository.query.Neo4jQueryExecution.DefaultQueryExecution;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
+import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -56,31 +65,29 @@ abstract class AbstractNeo4jQuery extends Neo4jQuerySupport implements Repositor
 
 		Neo4jParameterAccessor parameterAccessor = getParameterAccessor(parameters);
 		ResultProcessor resultProcessor = queryMethod.getResultProcessor().withDynamicProjection(parameterAccessor);
-		return resultProcessor.processResult(new Neo4jQueryExecution.DefaultQueryExecution(neo4jOperations)
-				.execute(prepareQuery(resultProcessor, parameterAccessor), queryMethod.isCollectionLikeQuery()),
-			OptionalUnwrappingConverter.INSTANCE);
+
+		PreparedQuery<?> preparedQuery = prepareQuery(resultProcessor.getReturnedType().getReturnedType(),
+			getInputProperties(resultProcessor), parameterAccessor, null, getMappingFunction(resultProcessor));
+
+		Object rawResult = new DefaultQueryExecution(neo4jOperations).execute(
+			preparedQuery, queryMethod.isCollectionLikeQuery() || queryMethod.isPageQuery());
+
+		Object processedResult = resultProcessor.processResult(rawResult, OptionalUnwrappingConverter.INSTANCE);
+
+		if (!queryMethod.isPageQuery()) {
+			return processedResult;
+		} else {
+			return PageableExecutionUtils.getPage((List<?>) processedResult, parameterAccessor.getPageable(), () -> {
+
+				PreparedQuery<Long> countQuery = prepareQuery(Long.class, Collections.emptyList(), parameterAccessor,
+					Neo4jQueryType.count(), null);
+				return neo4jOperations.toExecutableQuery(countQuery).getRequiredSingleResult();
+			});
+		}
 	}
 
-	protected abstract PreparedQuery prepareQuery(ResultProcessor resultProcessor,
-		Neo4jParameterAccessor parameterAccessor);
-
-	/**
-	 * @return True if the query should get a count projection applied.
-	 */
-	protected abstract boolean isCountQuery();
-
-	/**
-	 * @return True if the query should get an exists projection applied.
-	 */
-	protected abstract boolean isExistsQuery();
-
-	/**
-	 * @return True if the query should delete matching nodes.
-	 */
-	protected abstract boolean isDeleteQuery();
-
-	/**
-	 * @return True if the query has an explicit limit set.
-	 */
-	protected abstract boolean isLimiting();
+	protected abstract <T extends Object> PreparedQuery<T> prepareQuery(
+		Class<T> returnedType, List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
+		@Nullable Neo4jQueryType queryType,
+		@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction);
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractReactiveNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/AbstractReactiveNeo4jQuery.java
@@ -44,9 +44,9 @@ abstract class AbstractReactiveNeo4jQuery extends Neo4jQuerySupport implements R
 	protected final ReactiveNeo4jOperations neo4jOperations;
 
 	AbstractReactiveNeo4jQuery(ReactiveNeo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
-		Neo4jQueryMethod queryMethod) {
+		Neo4jQueryMethod queryMethod, Neo4jQueryType queryType) {
 
-		super(mappingContext, queryMethod);
+		super(mappingContext, queryMethod, queryType);
 
 		Assert.notNull(neo4jOperations, "The Neo4j operations are required.");
 		this.neo4jOperations = neo4jOperations;
@@ -76,25 +76,4 @@ abstract class AbstractReactiveNeo4jQuery extends Neo4jQuerySupport implements R
 		Class<T> returnedType, List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
 		@Nullable Neo4jQueryType queryType,
 		@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction);
-
-	/**
-	 *
-	 * @return True if the query shout get a count projection applied.
-	 */
-	protected abstract boolean isCountQuery();
-
-	/**
-	 * @return True if the query should get an exists projection applied.
-	 */
-	protected abstract boolean isExistsQuery();
-
-	/**
-	 * @return True if the query should delete matching nodes.
-	 */
-	protected abstract boolean isDeleteQuery();
-
-	/**
-	 * @return True if the query has an explicit limit set.
-	 */
-	protected abstract boolean isLimiting();
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -80,7 +80,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 	private final Class<?> domainType;
 	private final NodeDescription<?> nodeDescription;
 
-	private final Neo4jQueryType queryCharacteristics;
+	private final Neo4jQueryType queryType;
 
 	private final Iterator<?> formalParameters;
 	private final Queue<Parameter> lastParameter = new LinkedList<>();
@@ -104,7 +104,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 
 	private final List<String> includedProperties;
 
-	CypherQueryCreator(Neo4jMappingContext mappingContext, Class<?> domainType, Neo4jQueryType queryCharacteristics,
+	CypherQueryCreator(Neo4jMappingContext mappingContext, Class<?> domainType, Neo4jQueryType queryType,
 		PartTree tree,
 		ParametersParameterAccessor actualParameters,
 		List<String> includedProperties,
@@ -116,7 +116,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 		this.domainType = domainType;
 		this.nodeDescription = this.mappingContext.getRequiredNodeDescription(this.domainType);
 
-		this.queryCharacteristics = queryCharacteristics;
+		this.queryType = queryType;
 
 		this.formalParameters = actualParameters.getParameters().iterator();
 		this.maxResults = tree.isLimiting() ? tree.getMaxResults() : null;
@@ -152,7 +152,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 
 		CypherGenerator cypherGenerator = CypherGenerator.INSTANCE;
 		Statement statement;
-		if (queryCharacteristics.isCountQuery()) {
+		if (queryType == Neo4jQueryType.COUNT) {
 			statement = cypherGenerator
 				.prepareMatchOf(nodeDescription, condition)
 				.returning(Functions.count(asterisk()))

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.repository.query;
 
+import static java.util.stream.Collectors.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 import static org.neo4j.springframework.data.core.cypher.Functions.*;
 import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
@@ -28,8 +29,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.neo4j.driver.types.Point;
@@ -40,13 +45,15 @@ import org.neo4j.springframework.data.core.cypher.Expression;
 import org.neo4j.springframework.data.core.cypher.Functions;
 import org.neo4j.springframework.data.core.cypher.SortItem;
 import org.neo4j.springframework.data.core.cypher.Statement;
+import org.neo4j.springframework.data.core.cypher.StatementBuilder.OngoingMatchAndReturnWithOrder;
 import org.neo4j.springframework.data.core.cypher.renderer.Renderer;
-import org.neo4j.springframework.data.core.schema.CypherGenerator;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.neo4j.springframework.data.core.schema.CypherGenerator;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
 import org.neo4j.springframework.data.repository.query.Neo4jQueryMethod.Neo4jParameter;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.geo.Circle;
@@ -60,21 +67,30 @@ import org.springframework.data.repository.query.parser.PartTree;
 /**
  * A Cypher-DSL based implementation of the {@link AbstractQueryCreator} that eventually creates Cypher queries as strings
  * to be used by a Neo4j client or driver as statement template.
- * <p />
+ * <p/>
  * This class is not thread safe and not reusable.
  *
  * @author Michael J. Simons
  * @since 1.0
  */
-final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
+final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, Condition> {
 
 	private final Neo4jMappingContext mappingContext;
 
 	private final Class<?> domainType;
 	private final NodeDescription<?> nodeDescription;
 
+	private final Neo4jQueryType queryCharacteristics;
+
 	private final Iterator<?> formalParameters;
 	private final Queue<Parameter> lastParameter = new LinkedList<>();
+
+	private final Supplier<String> indexSupplier = new IndexSupplier();
+
+	private final Function<Object, Object> parameterConversion;
+	private final List<Parameter> boundedParameters = new ArrayList<>();
+
+	private final Pageable pagingParameter;
 
 	/**
 	 * Stores the number of max results, if the {@link PartTree tree} is limiting.
@@ -88,9 +104,11 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 
 	private final List<String> includedProperties;
 
-	CypherQueryCreator(Neo4jMappingContext mappingContext, Class<?> domainType, PartTree tree,
+	CypherQueryCreator(Neo4jMappingContext mappingContext, Class<?> domainType, Neo4jQueryType queryCharacteristics,
+		PartTree tree,
 		ParametersParameterAccessor actualParameters,
-		List<String> includedProperties
+		List<String> includedProperties,
+		Function<Object, Object> parameterConversion
 	) {
 		super(tree, actualParameters);
 		this.mappingContext = mappingContext;
@@ -98,10 +116,15 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 		this.domainType = domainType;
 		this.nodeDescription = this.mappingContext.getRequiredNodeDescription(this.domainType);
 
+		this.queryCharacteristics = queryCharacteristics;
+
 		this.formalParameters = actualParameters.getParameters().iterator();
 		this.maxResults = tree.isLimiting() ? tree.getMaxResults() : null;
 
 		this.includedProperties = includedProperties;
+		this.parameterConversion = parameterConversion;
+
+		this.pagingParameter = actualParameters.getPageable();
 	}
 
 	@Override
@@ -125,22 +148,38 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 	}
 
 	@Override
-	protected String complete(Condition condition, Sort sort) {
+	protected QueryAndParameters complete(Condition condition, Sort sort) {
 
 		CypherGenerator cypherGenerator = CypherGenerator.INSTANCE;
-		Statement statement = cypherGenerator
-			.prepareMatchOf(nodeDescription, condition)
-			.returning(cypherGenerator.createReturnStatementForMatch(nodeDescription, includedProperties))
-			.orderBy(
-				Stream.concat(
-					sortItems.stream(),
-					sort.stream().map(sortAdapterFor(nodeDescription))
-				).toArray(SortItem[]::new)
-			)
-			.limit(maxResults)
-			.build();
+		Statement statement;
+		if (queryCharacteristics.isCountQuery()) {
+			statement = cypherGenerator
+				.prepareMatchOf(nodeDescription, condition)
+				.returning(Functions.count(asterisk()))
+				.build();
+		} else {
+			OngoingMatchAndReturnWithOrder ongoingMatchAndReturnWithOrder = cypherGenerator
+				.prepareMatchOf(nodeDescription, condition)
+				.returning(cypherGenerator.createReturnStatementForMatch(nodeDescription, includedProperties))
+				.orderBy(
+					Stream.concat(
+						sortItems.stream(),
+						pagingParameter.getSort().and(sort).stream().map(sortAdapterFor(nodeDescription))
+					).toArray(SortItem[]::new)
+				);
+			if (pagingParameter.isUnpaged()) {
+				statement = ongoingMatchAndReturnWithOrder.limit(maxResults).build();
+			} else {
+				long skip = pagingParameter.getOffset();
+				int pageSize = pagingParameter.getPageSize();
+				statement = ongoingMatchAndReturnWithOrder.skip(skip).limit(pageSize).build();
+			}
+		}
 
-		return Renderer.getDefaultRenderer().render(statement);
+		Map<String, Object> convertedParameters = this.boundedParameters
+			.stream().collect(toMap(p -> p.nameOrIndex, p -> parameterConversion.apply(p.value)));
+
+		return new QueryAndParameters(Renderer.getDefaultRenderer().render(statement), convertedParameters);
 	}
 
 	private Condition createImpl(Part part, Iterator<Object> actualParameters) {
@@ -378,7 +417,10 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 			return Optional.of(nextRequiredParameter);
 		} else if (formalParameters.hasNext()) {
 			final Neo4jParameter parameter = (Neo4jParameter) formalParameters.next();
-			return Optional.of(new Parameter(parameter.getNameOrIndex(), actualParameters.next()));
+			Parameter boundedParameter = new Parameter(parameter.getName().orElseGet(indexSupplier),
+				actualParameters.next());
+			boundedParameters.add(boundedParameter);
+			return Optional.of(boundedParameter);
 		} else {
 			return Optional.empty();
 		}
@@ -394,7 +436,10 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 				throw new IllegalStateException("Not enough formal, bindable parameters for parts");
 			}
 			final Neo4jParameter parameter = (Neo4jParameter) formalParameters.next();
-			return new Parameter(parameter.getNameOrIndex(), actualParameters.next());
+			Parameter boundedParameter = new Parameter(parameter.getName().orElseGet(indexSupplier),
+				actualParameters.next());
+			boundedParameters.add(boundedParameter);
+			return boundedParameter;
 		}
 	}
 
@@ -419,6 +464,20 @@ final class CypherQueryCreator extends AbstractQueryCreator<String, Condition> {
 				"nameOrIndex='" + nameOrIndex + '\'' +
 				", value=" + value +
 				'}';
+		}
+	}
+
+	/**
+	 * Provides unique, incrementing indexes for parameter. Parameter indexes in derived query methods
+	 * are not necessary dense.
+	 */
+	static final class IndexSupplier implements Supplier<String> {
+
+		private AtomicInteger current = new AtomicInteger(0);
+
+		@Override
+		public String get() {
+			return Integer.toString(current.getAndIncrement());
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryLookupStrategy.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryLookupStrategy.java
@@ -68,7 +68,7 @@ public final class Neo4jQueryLookupStrategy implements QueryLookupStrategy {
 		} else if (queryMethod.hasQueryAnnotation()) {
 			return StringBasedNeo4jQuery.create(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod);
 		} else {
-			return new PartTreeNeo4jQuery(neo4jOperations, mappingContext, queryMethod);
+			return PartTreeNeo4jQuery.create(neo4jOperations, mappingContext, queryMethod);
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
@@ -56,17 +56,23 @@ abstract class Neo4jQuerySupport {
 	protected final Neo4jMappingContext mappingContext;
 	protected final Neo4jQueryMethod queryMethod;
 	protected final Class<?> domainType;
+	/**
+	 * The query type.
+	 */
+	protected final Neo4jQueryType queryType;
 
 	private static final LogAccessor log = new LogAccessor(LogFactory.getLog(Neo4jQuerySupport.class));
 
-	Neo4jQuerySupport(Neo4jMappingContext mappingContext, Neo4jQueryMethod queryMethod) {
+	Neo4jQuerySupport(Neo4jMappingContext mappingContext, Neo4jQueryMethod queryMethod, Neo4jQueryType queryType) {
 
 		Assert.notNull(mappingContext, "The mapping context is required.");
 		Assert.notNull(queryMethod, "Query method must not be null!");
+		Assert.notNull(queryType, "Query type must not be null!");
 
 		this.mappingContext = mappingContext;
 		this.queryMethod = queryMethod;
 		this.domainType = queryMethod.getDomainClass();
+		this.queryType = queryType;
 	}
 
 	protected final Neo4jParameterAccessor getParameterAccessor(Object[] actualParameters) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryType.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryType.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.query;
+
+import org.springframework.data.repository.query.parser.PartTree;
+
+/**
+ * Describes the characteristics of a query.
+ *
+ * @author Michael J. Simons
+ */
+final class Neo4jQueryType {
+
+	private final boolean countQuery;
+	private final boolean existsQuery;
+	private final boolean deleteQuery;
+
+	static Neo4jQueryType fromPartTree(PartTree partTree) {
+
+		return new Neo4jQueryType(partTree.isCountProjection(), partTree.isExistsProjection(), partTree.isDelete());
+	}
+
+	static Neo4jQueryType count() {
+
+		return new Neo4jQueryType(true, false, false);
+	}
+
+	private Neo4jQueryType(boolean countQuery, boolean existsQuery, boolean deleteQuery) {
+		this.countQuery = countQuery;
+		this.existsQuery = existsQuery;
+		this.deleteQuery = deleteQuery;
+	}
+
+	/**
+	 * @return True if the query should get a count projection applied.
+	 */
+	public boolean isCountQuery() {
+		return countQuery;
+	}
+
+	/**
+	 * @return True if the query should get an exists projection applied.
+	 */
+	public boolean isExistsQuery() {
+		return existsQuery;
+	}
+
+	/**
+	 * @return True if the query should delete matching nodes.
+	 */
+	public boolean isDeleteQuery() {
+		return deleteQuery;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/PartTreeNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/PartTreeNeo4jQuery.java
@@ -74,15 +74,21 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 
 	private final PartTree tree;
 
-	PartTreeNeo4jQuery(
+	public static RepositoryQuery create(Neo4jOperations neo4jOperations, Neo4jMappingContext mappingContext,
+		Neo4jQueryMethod queryMethod) {
+		return new PartTreeNeo4jQuery(neo4jOperations, mappingContext, queryMethod,
+			new PartTree(queryMethod.getName(), queryMethod.getDomainClass()));
+	}
+
+	private PartTreeNeo4jQuery(
 		Neo4jOperations neo4jOperations,
 		Neo4jMappingContext mappingContext,
-		Neo4jQueryMethod queryMethod
+		Neo4jQueryMethod queryMethod,
+		PartTree tree
 	) {
-		super(neo4jOperations, mappingContext, queryMethod);
+		super(neo4jOperations, mappingContext, queryMethod, Neo4jQueryType.fromPartTree(tree));
 
-		this.tree = new PartTree(queryMethod.getName(), domainType);
-
+		this.tree = tree;
 		// Validate parts. Sort properties will be validated by Spring Data already.
 		PartValidator validator = new PartValidator(queryMethod);
 		this.tree.flatMap(OrPart::stream).forEach(validator::validatePart);

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/PartTreeNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/PartTreeNeo4jQuery.java
@@ -30,19 +30,23 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 
+import org.neo4j.driver.Record;
 import org.neo4j.driver.types.Point;
+import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jOperations;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.springframework.data.repository.query.RepositoryQuery;
-import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.data.repository.query.parser.PartTree.OrPart;
 import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -85,22 +89,23 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 	}
 
 	@Override
-	protected PreparedQuery prepareQuery(ResultProcessor resultProcessor, Neo4jParameterAccessor parameterAccessor) {
+	protected <T extends Object> PreparedQuery<T> prepareQuery(
+		Class<T> returnedType, List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
+		@Nullable Neo4jQueryType queryType,
+		@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
 
 		CypherQueryCreator queryCreator = new CypherQueryCreator(
-			mappingContext, domainType, tree, parameterAccessor, getInputProperties(resultProcessor)
+			mappingContext, domainType, Optional.ofNullable(queryType).orElseGet(() -> Neo4jQueryType.fromPartTree(tree)), tree, parameterAccessor,
+			includedProperties,
+			this::convertParameter
 		);
 
-		String cypherQuery = queryCreator.createQuery();
-		Map<String, Object> boundedParameters = parameterAccessor.getParameters()
-			.getBindableParameters().stream()
-			.collect(toMap(Neo4jQueryMethod.Neo4jParameter::getNameOrIndex,
-				formalParameter -> convertParameter(parameterAccessor.getBindableValue(formalParameter.getIndex()))));
+		QueryAndParameters queryAndParameters = queryCreator.createQuery();
 
-		return PreparedQuery.queryFor(resultProcessor.getReturnedType().getReturnedType())
-			.withCypherQuery(cypherQuery)
-			.withParameters(boundedParameters)
-			.usingMappingFunction(getMappingFunction(resultProcessor))
+		return PreparedQuery.queryFor(returnedType)
+			.withCypherQuery(queryAndParameters.getQuery())
+			.withParameters(queryAndParameters.getParameters())
+			.usingMappingFunction(mappingFunction)
 			.build();
 	}
 
@@ -113,26 +118,6 @@ final class PartTreeNeo4jQuery extends AbstractNeo4jQuery {
 	static boolean canIgnoreCase(Part part) {
 		return part.getProperty().getLeafType() == String.class && TYPES_SUPPORTING_CASE_INSENSITIVITY
 			.contains(part.getType());
-	}
-
-	@Override
-	protected boolean isCountQuery() {
-		return tree.isCountProjection();
-	}
-
-	@Override
-	protected boolean isExistsQuery() {
-		return tree.isExistsProjection();
-	}
-
-	@Override
-	protected boolean isDeleteQuery() {
-		return tree.isDelete();
-	}
-
-	@Override
-	protected boolean isLimiting() {
-		return tree.isLimiting();
 	}
 
 	static class PartValidator {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/QueryAndParameters.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/QueryAndParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.query;
+
+import java.util.Map;
+
+/**
+ * Wraps a cypher statement and it's parameters.
+ *
+ * @author Michael J. Simons
+ */
+final class QueryAndParameters {
+
+	private final String query;
+	private final Map<String, Object> parameters;
+
+	QueryAndParameters(String query, Map<String, Object> parameters) {
+
+		this.query = query;
+		this.parameters = parameters;
+	}
+
+	public String getQuery() {
+		return query;
+	}
+
+	public Map<String, Object> getParameters() {
+		return parameters;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryLookupStrategy.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryLookupStrategy.java
@@ -70,7 +70,7 @@ public final class ReactiveNeo4jQueryLookupStrategy implements QueryLookupStrate
 			return ReactiveStringBasedNeo4jQuery
 				.create(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod);
 		} else {
-			return new ReactivePartTreeNeo4jQuery(neo4jOperations, mappingContext, queryMethod);
+			return ReactivePartTreeNeo4jQuery.create(neo4jOperations, mappingContext, queryMethod);
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -67,21 +67,6 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 		.of(ReactiveStringBasedNeo4jQuery::parameterNameSource, ReactiveStringBasedNeo4jQuery::replacementSource);
 
 	/**
-	 * Is this a count projection?
-	 */
-	private final boolean countQuery;
-
-	/**
-	 * Is this an exists projection?
-	 */
-	private final boolean existsQuery;
-
-	/**
-	 * Is this a modifying delete query?
-	 */
-	private final boolean deleteQuery;
-
-	/**
 	 * Used to evaluate the expression found while parsing the cypher template of this query against the actual parameters
 	 * with the help of the formal parameters during the building of the {@link PreparedQuery}.
 	 */
@@ -115,7 +100,7 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 			.orElseThrow(() -> new MappingException("Expected @Query annotation to have a value, but it did not."));
 
 		return new ReactiveStringBasedNeo4jQuery(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod,
-			cypherTemplate, queryAnnotation.count(), queryAnnotation.exists(), queryAnnotation.delete());
+			cypherTemplate, Neo4jQueryType.fromDefinition(queryAnnotation));
 	}
 
 	/**
@@ -135,19 +120,14 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 		Assert.hasText(cypherTemplate, "Cannot create String based Neo4j query without a cypher template.");
 
 		return new ReactiveStringBasedNeo4jQuery(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod,
-			cypherTemplate, false, false, false);
+			cypherTemplate, Neo4jQueryType.DEFAULT);
 	}
 
 	private ReactiveStringBasedNeo4jQuery(ReactiveNeo4jOperations neo4jOperations,
 		Neo4jMappingContext mappingContext, QueryMethodEvaluationContextProvider evaluationContextProvider,
-		Neo4jQueryMethod queryMethod, String cypherTemplate, boolean countQuery,
-		boolean existsQuery, boolean deleteQuery) {
+		Neo4jQueryMethod queryMethod, String cypherTemplate, Neo4jQueryType queryType) {
 
-		super(neo4jOperations, mappingContext, queryMethod);
-
-		this.countQuery = countQuery;
-		this.existsQuery = existsQuery;
-		this.deleteQuery = deleteQuery;
+		super(neo4jOperations, mappingContext, queryMethod, queryType);
 
 		SpelExtractor spelExtractor = SPEL_QUERY_CONTEXT.parse(cypherTemplate);
 		this.spelEvaluator = new SpelEvaluator(evaluationContextProvider, queryMethod.getParameters(), spelExtractor);
@@ -172,26 +152,6 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 			.withParameters(bindParameters(parameterAccessor))
 			.usingMappingFunction(mappingFunction)
 			.build();
-	}
-
-	@Override
-	public boolean isCountQuery() {
-		return countQuery;
-	}
-
-	@Override
-	public boolean isExistsQuery() {
-		return existsQuery;
-	}
-
-	@Override
-	public boolean isDeleteQuery() {
-		return deleteQuery;
-	}
-
-	@Override
-	protected boolean isLimiting() {
-		return false;
 	}
 
 	Map<String, Object> bindParameters(Neo4jParameterAccessor parameterAccessor) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -19,9 +19,13 @@
 package org.neo4j.springframework.data.repository.query;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
+import org.neo4j.driver.Record;
+import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
@@ -30,10 +34,10 @@ import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.RepositoryQuery;
-import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.SpelEvaluator;
 import org.springframework.data.repository.query.SpelQueryContext;
 import org.springframework.data.repository.query.SpelQueryContext.SpelExtractor;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -158,12 +162,15 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	}
 
 	@Override
-	protected PreparedQuery prepareQuery(ResultProcessor resultProcessor,  Neo4jParameterAccessor parameterAccessor) {
+	protected <T extends Object> PreparedQuery<T> prepareQuery(
+		Class<T> returnedType, List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
+		@Nullable Neo4jQueryType queryType,
+		@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
 
-		return PreparedQuery.queryFor(resultProcessor.getReturnedType().getReturnedType())
+		return PreparedQuery.queryFor(returnedType)
 			.withCypherQuery(cypherQuery)
 			.withParameters(bindParameters(parameterAccessor))
-			.usingMappingFunction(getMappingFunction(resultProcessor))
+			.usingMappingFunction(mappingFunction)
 			.build();
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
@@ -19,9 +19,13 @@
 package org.neo4j.springframework.data.repository.query;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
+import org.neo4j.driver.Record;
+import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jOperations;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
@@ -30,10 +34,10 @@ import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.RepositoryQuery;
-import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.SpelEvaluator;
 import org.springframework.data.repository.query.SpelQueryContext;
 import org.springframework.data.repository.query.SpelQueryContext.SpelExtractor;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -158,34 +162,16 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 	}
 
 	@Override
-	protected PreparedQuery<?> prepareQuery(ResultProcessor resultProcessor, Neo4jParameterAccessor parameterAccessor) {
+	protected <T extends Object> PreparedQuery<T> prepareQuery(
+		Class<T> returnedType, List<String> includedProperties, Neo4jParameterAccessor parameterAccessor,
+		@Nullable Neo4jQueryType queryType,
+		@Nullable BiFunction<TypeSystem, Record, ?> mappingFunction) {
 
-		return PreparedQuery.queryFor(resultProcessor.getReturnedType().getReturnedType())
+		return PreparedQuery.queryFor(returnedType)
 			.withCypherQuery(cypherQuery)
 			.withParameters(bindParameters(parameterAccessor))
-			.usingMappingFunction(
-				getMappingFunction(resultProcessor))
+			.usingMappingFunction(mappingFunction)
 			.build();
-	}
-
-	@Override
-	public boolean isCountQuery() {
-		return countQuery;
-	}
-
-	@Override
-	public boolean isExistsQuery() {
-		return existsQuery;
-	}
-
-	@Override
-	public boolean isDeleteQuery() {
-		return deleteQuery;
-	}
-
-	@Override
-	protected boolean isLimiting() {
-		return false;
 	}
 
 	Map<String, Object> bindParameters(Neo4jParameterAccessor parameterAccessor) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
@@ -67,21 +67,6 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 		.of(StringBasedNeo4jQuery::parameterNameSource, StringBasedNeo4jQuery::replacementSource);
 
 	/**
-	 * Is this a count projection?
-	 */
-	private final boolean countQuery;
-
-	/**
-	 * Is this an exists projection?
-	 */
-	private final boolean existsQuery;
-
-	/**
-	 * Is this a modifying delete query?
-	 */
-	private final boolean deleteQuery;
-
-	/**
 	 * Used to evaluate the expression found while parsing the cypher template of this query against the actual parameters
 	 * with the help of the formal parameters during the building of the {@link PreparedQuery}.
 	 */
@@ -115,7 +100,7 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 			.orElseThrow(() -> new MappingException("Expected @Query annotation to have a value, but it did not."));
 
 		return new StringBasedNeo4jQuery(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod,
-			cypherTemplate, queryAnnotation.count(), queryAnnotation.exists(), queryAnnotation.delete());
+			cypherTemplate, Neo4jQueryType.fromDefinition(queryAnnotation));
 	}
 
 	/**
@@ -135,19 +120,14 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 		Assert.hasText(cypherTemplate, "Cannot create String based Neo4j query without a cypher template.");
 
 		return new StringBasedNeo4jQuery(neo4jOperations, mappingContext, evaluationContextProvider, queryMethod,
-			cypherTemplate, false, false, false);
+			cypherTemplate, Neo4jQueryType.DEFAULT);
 	}
 
 	private StringBasedNeo4jQuery(Neo4jOperations neo4jOperations,
 		Neo4jMappingContext mappingContext, QueryMethodEvaluationContextProvider evaluationContextProvider,
-		Neo4jQueryMethod queryMethod, String cypherTemplate, boolean countQuery,
-		boolean existsQuery, boolean deleteQuery) {
+		Neo4jQueryMethod queryMethod, String cypherTemplate, Neo4jQueryType queryType) {
 
-		super(neo4jOperations, mappingContext, queryMethod);
-
-		this.countQuery = countQuery;
-		this.existsQuery = existsQuery;
-		this.deleteQuery = deleteQuery;
+		super(neo4jOperations, mappingContext, queryMethod, queryType);
 
 		SpelExtractor spelExtractor = SPEL_QUERY_CONTEXT.parse(cypherTemplate);
 		this.spelEvaluator = new SpelEvaluator(evaluationContextProvider, queryMethod.getParameters(), spelExtractor);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/PersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/PersonRepository.java
@@ -34,6 +34,8 @@ import org.neo4j.springframework.data.integration.shared.PersonWithNoConstructor
 import org.neo4j.springframework.data.integration.shared.PersonWithWither;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.query.Query;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
@@ -101,6 +103,12 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 
 	// Derived finders, should be extracted into another repo.
 	Optional<PersonWithAllConstructor> findOneByNameAndFirstName(String name, String firstName);
+
+	Page<PersonWithAllConstructor> findAllByNameOrName(Pageable pageable, String aName, String anotherName);
+
+	Page<PersonWithAllConstructor> findAllByNameOrName(String aName, String anotherName, Pageable pageable);
+
+	Long countAllByNameOrName(String aName, String anotherName);
 
 	Optional<PersonWithAllConstructor> findOneByNameAndFirstNameAllIgnoreCase(String name, String firstName);
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -1326,6 +1326,32 @@ class RepositoryIT {
 		assertThat(optionalPerson).isPresent().contains(person1);
 	}
 
+	@Test // GH-112
+	void findByPropertyWithPageable() {
+
+		Page<PersonWithAllConstructor> people;
+
+		Sort sort = Sort.by("name").descending();
+		people  = repository.findAllByNameOrName(PageRequest.of(0, 1, sort), TEST_PERSON1_NAME, TEST_PERSON2_NAME);
+		assertThat(people.get()).hasSize(1).extracting("name").containsExactly(TEST_PERSON2_NAME);
+		assertThat(people.getTotalPages()).isEqualTo(2);
+
+		people  = repository.findAllByNameOrName(PageRequest.of(1, 1, sort), TEST_PERSON1_NAME, TEST_PERSON2_NAME);
+		assertThat(people.get()).hasSize(1).extracting("name").containsExactly(TEST_PERSON1_NAME);
+		assertThat(people.getTotalPages()).isEqualTo(2);
+
+		people  = repository.findAllByNameOrName(TEST_PERSON1_NAME, TEST_PERSON2_NAME, PageRequest.of(1, 1, sort));
+		assertThat(people.get()).hasSize(1).extracting("name").containsExactly(TEST_PERSON1_NAME);
+		assertThat(people.getTotalPages()).isEqualTo(2);
+	}
+
+	@Test // GH-112
+	void countBySimplePropertiesOred() {
+
+		long count = repository.countAllByNameOrName(TEST_PERSON1_NAME, TEST_PERSON2_NAME);
+		assertThat(count).isEqualTo(2L);
+	}
+
 	@Test
 	void findBySimplePropertiesOred() {
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
@@ -48,6 +48,8 @@ public interface ReactivePersonRepository extends ReactiveNeo4jRepository<Person
 
 	Mono<PersonWithAllConstructor> findOneByNameAndFirstNameAllIgnoreCase(String name, String firstName);
 
+	Mono<Long> countAllByNameOrName(String aName, String anotherName);
+
 	Flux<PersonWithAllConstructor> findAllByNameOrName(String aName, String anotherName);
 
 	Flux<PersonWithAllConstructor> findAllBySameValue(String sameValue);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -688,7 +688,7 @@ class ReactiveRepositoryIT {
 			.verifyComplete();
 	}
 
-	@Test // GH-114
+	@Test // GH-112
 	void countBySimplePropertiesOred() {
 
 		repository.countAllByNameOrName(TEST_PERSON1_NAME, TEST_PERSON2_NAME)

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -688,6 +688,13 @@ class ReactiveRepositoryIT {
 			.verifyComplete();
 	}
 
+	@Test // GH-114
+	void countBySimplePropertiesOred() {
+
+		repository.countAllByNameOrName(TEST_PERSON1_NAME, TEST_PERSON2_NAME)
+			.as(StepVerifier::create).expectNext(2L).verifyComplete();
+	}
+
 	@Test
 	void findBySimpleProperty() {
 		List<PersonWithAllConstructor> personList = Arrays.asList(person1, person2);


### PR DESCRIPTION
This add support for derived countBy and pageable methods. It removes the need for having the result processor in concrete classes (part and string based version) and allows the imperative version to execute an additional count query for building the page.

This also addresses the fact that the indexes of bindable parameters are not necessarly dense, that is: They can contain special, non bindable parameters before and in between. This has been fixed with an index supplier.

This fixes #112.