### PR TITLE
correct string template parameter type

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -251,7 +251,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		String nameOfParameter = "id";
 		Condition condition = entityMetaData.getIdExpression().isEqualTo(parameter(nameOfParameter));
 
-		log.debug(() -> String.format("Deleting entity with id %d ", id));
+		log.debug(() -> String.format("Deleting entity with id %s ", id));
 
 		Statement statement = cypherGenerator.prepareDeleteOf(entityMetaData, condition);
 		ResultSummary summary = this.neo4jClient.query(renderer.render(statement))


### PR DESCRIPTION
While testing the [jhipster](https://github.com/michael-simons/generator-jhipster/tree/feature/neo4j-server-entities) integration I stumbled across the fact you couldn't delete users. This fixes the incorrect template variable resulting in failing of the delete method in case the log level is debug. 

I have signed the CLA (just now).