### PR TITLE
Provide limited support for Pageable in reactive.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryMethod.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryMethod.java
@@ -41,7 +41,7 @@ import org.springframework.lang.Nullable;
  * @author Michael J. Simons
  * @since 1.0
  */
-final class Neo4jQueryMethod extends QueryMethod {
+class Neo4jQueryMethod extends QueryMethod {
 
 	/**
 	 * Optional query annotation of the method.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryLookupStrategy.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryLookupStrategy.java
@@ -59,7 +59,7 @@ public final class ReactiveNeo4jQueryLookupStrategy implements QueryLookupStrate
 	public RepositoryQuery resolveQuery(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
 		NamedQueries namedQueries) {
 
-		Neo4jQueryMethod queryMethod = new Neo4jQueryMethod(method, metadata, factory);
+		Neo4jQueryMethod queryMethod = new ReactiveNeo4jQueryMethod(method, metadata, factory);
 		String namedQueryName = queryMethod.getNamedQueryName();
 
 		if (namedQueries.hasQuery(namedQueryName)) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.query;
+
+import static org.springframework.data.repository.util.ClassUtils.*;
+
+import java.lang.reflect.Method;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.util.ReactiveWrappers;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.util.ClassUtils;
+
+/**
+ * This is unfortunately a little bit of a hack to provide the information that the returned types by this query
+ * are always considered as stream.
+ * We try to either separate imperative and reactive concerns but due to type compatibility we extend the
+ * {@link Neo4jQueryMethod} here instead of creating a complete new reactive focused logical branch.
+ * It would only contain duplications of several classes.
+ *
+ * @author Gerrit Meier
+ * @since 1.0
+ */
+final class ReactiveNeo4jQueryMethod extends Neo4jQueryMethod {
+
+	private static final ClassTypeInformation<Page> PAGE_TYPE = ClassTypeInformation.from(Page.class);
+	private static final ClassTypeInformation<Slice> SLICE_TYPE = ClassTypeInformation.from(Slice.class);
+
+	/**
+	 * Creates a new {@link ReactiveNeo4jQueryMethod} from the given parameters.
+	 *
+	 * @param method   must not be {@literal null}.
+	 * @param metadata must not be {@literal null}.
+	 * @param factory  must not be {@literal null}.
+	 */
+	ReactiveNeo4jQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory) {
+		super(method, metadata, factory);
+
+		if (hasParameterOfType(method, Pageable.class)) {
+
+			TypeInformation<?> returnType = ClassTypeInformation.fromReturnTypeOf(method);
+
+			boolean multiWrapper = ReactiveWrappers.isMultiValueType(returnType.getType());
+			boolean singleWrapperWithWrappedPageableResult = ReactiveWrappers.isSingleValueType(returnType.getType())
+				&& (PAGE_TYPE.isAssignableFrom(returnType.getRequiredComponentType())
+				|| SLICE_TYPE.isAssignableFrom(returnType.getRequiredComponentType()));
+
+			if (singleWrapperWithWrappedPageableResult) {
+				throw new InvalidDataAccessApiUsageException(
+					String.format("'%s.%s' must not use sliced or paged execution. Please use Flux.buffer(size, skip).",
+						ClassUtils.getShortName(method.getDeclaringClass()), method.getName()));
+			}
+
+			if (!multiWrapper) {
+				throw new IllegalStateException(String.format(
+					"Method has to use a either multi-item reactive wrapper return type or a wrapped Page/Slice type. "
+						+ "Offending method: %s", method.toString()));
+			}
+		}
+	}
+
+	/**
+	 * Will always return true because a reactive result will always be a stream query.
+	 *
+	 * @return always true
+	 */
+	@Override
+	public boolean isStreamQuery() {
+		return true;
+	}
+
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
@@ -90,5 +90,4 @@ final class ReactiveNeo4jQueryMethod extends Neo4jQueryMethod {
 	public boolean isStreamQuery() {
 		return true;
 	}
-
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveNeo4jQueryMethod.java
@@ -75,8 +75,8 @@ final class ReactiveNeo4jQueryMethod extends Neo4jQueryMethod {
 
 			if (!multiWrapper) {
 				throw new IllegalStateException(String.format(
-					"Method has to use a either multi-item reactive wrapper return type or a wrapped Page/Slice type. "
-						+ "Offending method: %s", method.toString()));
+					"Method has to use a multi-item reactive wrapper return type. Offending method: %s",
+					method.toString()));
 			}
 		}
 	}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
@@ -26,6 +26,7 @@ import org.neo4j.springframework.data.integration.shared.PersonProjection;
 import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
 import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.neo4j.springframework.data.repository.query.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +60,8 @@ public interface ReactivePersonRepository extends ReactiveNeo4jRepository<Person
 	Flux<PersonProjection> findBySameValue(String sameValue);
 
 	Flux<DtoPersonProjection> findByFirstName(String firstName);
+
+	Flux<PersonWithAllConstructor> findByNameStartingWith(String name, Pageable pageable);
 
 	@Query("MATCH (n:PersonWithAllConstructor) where n.name = $name return n{.name}")
 	Mono<PersonProjection> findByNameWithCustomQueryAndMapProjection(@Param("name") String name);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -72,6 +72,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -269,6 +270,25 @@ class ReactiveRepositoryIT {
 
 				assertThat(petHobby).isSameAs(hobby);
 			})
+			.verifyComplete();
+	}
+
+	@Test
+	void findWithPageable() {
+		Sort sort = Sort.by("name");
+		int page = 0;
+		int limit = 1;
+
+		StepVerifier.create(repository.findByNameStartingWith("Test", PageRequest.of(page, limit, sort)))
+			.assertNext(person -> assertThat(person).isEqualTo(person1))
+			.verifyComplete();
+
+		sort = Sort.by("name");
+		page = 1;
+		limit = 1;
+
+		StepVerifier.create(repository.findByNameStartingWith("Test", PageRequest.of(page, limit, sort)))
+			.assertNext(person -> assertThat(person).isEqualTo(person2))
 			.verifyComplete();
 	}
 


### PR DESCRIPTION
This commit enables using Pageable as parameter in a
reactive derived finder method to return a Flux<T>.
It will not support using Page or Slice as the return type.

The only reason for providing this feature is bringing some convenience from the imperative world to the reactive one. There are no plans to bring in broader support e.g. accepting `Mono<Page<T>>` or `Mono<Slice<T>>` as the return types.