### PR TITLE
GH-122 - Upgrade R2DBC dependency to release version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 		<neo4j.version>3.5.8</neo4j.version>
 		<objenesis.version>3.0.1</objenesis.version> <!-- mockk requires objenesis >= 3 -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<r2dbc.releasetrain>Arabba-BUILD-SNAPSHOT</r2dbc.releasetrain>
+		<r2dbc.releasetrain>Arabba-RELEASE</r2dbc.releasetrain>
 		<reactive-streams.version>1.2.1</reactive-streams.version>
 		<revision>1.0.0</revision>
 		<rxjava.version>1.3.8</rxjava.version>


### PR DESCRIPTION
Although the R2DBC dependency is only used for testing
the BOM will get picked up by gradle.
Because it is a SNAPSHOT dependency the resolution will fail
and SDN-RX cannot be used in gradle projects if the users
do not add the Spring snapshots repository.

Closes #122 