### PR TITLE
Make database selection reactive capable.

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -469,7 +469,8 @@ That bean could use for example Spring's security context to retrieve a tenant:
 ----
 import java.util.Optional;
 
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelection;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -489,7 +490,9 @@ public class Neo4jConfig {
 			.filter(Authentication::isAuthenticated)
 			.map(Authentication::getPrincipal)
 			.map(User.class::cast)
-			.map(User::getUsername);
+			.map(User::getUsername)
+			.map(DatabaseName::of)
+			.orElseGet(DatabaseName::defaultName);
 	}
 }
 ----

--- a/examples/multi-database/src/main/java/org/neo4j/springframework/data/examples/spring_boot/Neo4jConfig.java
+++ b/examples/multi-database/src/main/java/org/neo4j/springframework/data/examples/spring_boot/Neo4jConfig.java
@@ -21,7 +21,8 @@ package org.neo4j.springframework.data.examples.spring_boot;
 import java.util.Optional;
 
 import org.neo4j.driver.Driver;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelection;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.neo4j.springframework.data.core.transaction.Neo4jTransactionManager;
 import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.context.annotation.Bean;
@@ -39,7 +40,7 @@ import org.springframework.security.core.userdetails.User;
 public class Neo4jConfig {
 
 	/**
-	 * This bean is only active in profile {@literal "selection-by-user"}. The {@link Neo4jDatabaseNameProvider} created here
+	 * This bean is only active in profile {@literal "selection-by-user"}. The {@link DatabaseSelectionProvider} created here
 	 * uses Springs security context to retrieve the authenticated principal and extracts the username. Thus all requests
 	 * will use a different database, depending on the user being logged into the application.
 	 *
@@ -47,14 +48,16 @@ public class Neo4jConfig {
 	 */
 	@Profile("selection-by-user")
 	@Bean
-	Neo4jDatabaseNameProvider databaseNameProvider() {
+	DatabaseSelectionProvider databaseNameProvider() {
 
 		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
 			.map(SecurityContext::getAuthentication)
 			.filter(Authentication::isAuthenticated)
 			.map(Authentication::getPrincipal)
 			.map(User.class::cast)
-			.map(User::getUsername);
+			.map(User::getUsername)
+			.map(DatabaseSelection::byName)
+			.orElseGet(DatabaseSelection::undecided);
 	}
 
 	@Profile("multiple-transaction-manager")
@@ -70,7 +73,7 @@ public class Neo4jConfig {
 		 */
 		@Bean
 		public Neo4jTransactionManager transactionManager(Driver driver,
-			Neo4jDatabaseNameProvider databaseNameProvider) {
+			DatabaseSelectionProvider databaseNameProvider) {
 
 			return new Neo4jTransactionManager(driver, databaseNameProvider);
 		}
@@ -84,7 +87,7 @@ public class Neo4jConfig {
 		@Bean
 		public Neo4jTransactionManager transactionManagerForOtherDb(Driver driver) {
 			return new Neo4jTransactionManager(driver,
-				Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider("otherDb"));
+				DatabaseSelectionProvider.createStaticDatabaseSelectionProvider("otherDb"));
 		}
 	}
 }

--- a/examples/multi-database/src/main/java/org/neo4j/springframework/data/examples/spring_boot/Neo4jConfig.java
+++ b/examples/multi-database/src/main/java/org/neo4j/springframework/data/examples/spring_boot/Neo4jConfig.java
@@ -48,7 +48,7 @@ public class Neo4jConfig {
 	 */
 	@Profile("selection-by-user")
 	@Bean
-	DatabaseSelectionProvider databaseNameProvider() {
+	DatabaseSelectionProvider databaseSelectionProvider() {
 
 		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
 			.map(SecurityContext::getAuthentication)

--- a/examples/multi-database/src/test/java/org/neo4j/springframework/data/examples/spring_boot/ExampleUsingDynamicDatabaseNameTest.java
+++ b/examples/multi-database/src/test/java/org/neo4j/springframework/data/examples/spring_boot/ExampleUsingDynamicDatabaseNameTest.java
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 /**
  * This examples brings up the complete application and starts it in profile {@literal "selection-by-user"}, thus activating
- * {@link Neo4jConfig#databaseNameProvider()}.
+ * {@link Neo4jConfig#databaseSelectionProvider()}.
  * <p>The test mocks a user name {@literal "someMovieEnthusiast"}. We create a database with the same name and load our
  * movie data into it.
  *

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/pom.xml
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/pom.xml
@@ -74,5 +74,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jDataAutoConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jDataAutoConfiguration.java
@@ -21,20 +21,17 @@ package org.neo4j.springframework.boot.autoconfigure.data;
 import java.util.Set;
 
 import org.neo4j.driver.Driver;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
 import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScanner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.annotation.Order;
 
 /**
  * Automatic configuration of base infrastructure that imports configuration for both imperative and reactive Neo4j
@@ -53,23 +50,6 @@ public final class Neo4jDataAutoConfiguration {
 	@ConditionalOnMissingBean
 	public Neo4jConversions neo4jConversions() {
 		return new Neo4jConversions();
-	}
-
-	@Bean
-	@ConditionalOnProperty(prefix = "org.neo4j.data", name = "database")
-	@ConditionalOnMissingBean
-	@Order(-30)
-	public Neo4jDatabaseNameProvider staticDatabaseNameProvider(Neo4jDataProperties dataProperties) {
-
-		return Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(dataProperties.getDatabase());
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	@Order(-20)
-	public Neo4jDatabaseNameProvider defaultNeo4jDatabaseNameProvider() {
-
-		return Neo4jDatabaseNameProvider.getDefaultDatabaseNameProvider();
 	}
 
 	@Bean

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jDataProperties.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jDataProperties.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.boot.autoconfigure.data;
 
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -35,7 +36,7 @@ public class Neo4jDataProperties {
 	 * or server and will lead to errors if used with a prior version of Neo4j. Leave this null (the default) to indicate
 	 * that you like the server to decide the default database to use. The database name set here will be statically used
 	 * throughout the lifetime of the application. If you need more flexibility you can declare a bean of type
-	 * {@link org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider} which can for example use Spring's Security
+	 * {@link DatabaseSelectionProvider} which can for example use Spring's Security
 	 * Context or similar to determine the current principal on which you could decide which database to use.
 	 */
 	private String database;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractNeo4jConfig.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractNeo4jConfig.java
@@ -24,7 +24,7 @@ import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.Neo4jTemplate;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.transaction.Neo4jTransactionManager;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,7 +62,7 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
 	public Neo4jTemplate neo4jTemplate(final Neo4jClient neo4jClient, final Neo4jMappingContext mappingContext,
-		Neo4jDatabaseNameProvider databaseNameProvider) {
+		DatabaseSelectionProvider databaseNameProvider) {
 
 		return new Neo4jTemplate(neo4jClient, mappingContext, databaseNameProvider);
 	}
@@ -76,8 +76,19 @@ public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 	 */
 	@Bean(Neo4jRepositoryConfigurationExtension.DEFAULT_TRANSACTION_MANAGER_BEAN_NAME)
 	public PlatformTransactionManager transactionManager(Driver driver,
-		Neo4jDatabaseNameProvider databaseNameProvider) {
+		DatabaseSelectionProvider databaseNameProvider) {
 
 		return new Neo4jTransactionManager(driver, databaseNameProvider);
+	}
+
+	/**
+	 * Configures the database name provider.
+	 *
+	 * @return The default database name provider, defaulting to the default database on Neo4j 4.0 and on no default on Neo4j 3.5 and prior.
+	 */
+	@Bean
+	protected DatabaseSelectionProvider neo4jDatabaseNameProvider() {
+
+		return DatabaseSelectionProvider.getDefaultSelectionProvider();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractReactiveNeo4jConfig.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractReactiveNeo4jConfig.java
@@ -21,10 +21,10 @@ package org.neo4j.springframework.data.config;
 import org.apiguardian.api.API;
 import org.neo4j.driver.Driver;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
+import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
 import org.neo4j.springframework.data.core.ReactiveNeo4jTemplate;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.transaction.ReactiveNeo4jTransactionManager;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
 import org.neo4j.springframework.data.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -63,7 +63,7 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_NEO4J_TEMPLATE_BEAN_NAME)
 	public ReactiveNeo4jTemplate neo4jTemplate(final ReactiveNeo4jClient neo4jClient,
-		final Neo4jMappingContext mappingContext, final Neo4jDatabaseNameProvider databaseNameProvider) {
+		final Neo4jMappingContext mappingContext, final ReactiveDatabaseSelectionProvider databaseNameProvider) {
 
 		return new ReactiveNeo4jTemplate(neo4jClient, mappingContext, databaseNameProvider);
 	}
@@ -75,8 +75,19 @@ public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupp
 	 * @return A platform transaction manager
 	 */
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_TRANSACTION_MANAGER_BEAN_NAME)
-	public ReactiveTransactionManager reactiveTransactionManager(Driver driver, Neo4jDatabaseNameProvider databaseNameProvider) {
+	public ReactiveTransactionManager reactiveTransactionManager(Driver driver, ReactiveDatabaseSelectionProvider databaseNameProvider) {
 
 		return new ReactiveNeo4jTransactionManager(driver, databaseNameProvider);
+	}
+
+	/**
+	 * Configures the database name provider.
+	 *
+	 * @return The default database name provider, defaulting to the default database on Neo4j 4.0 and on no default on Neo4j 3.5 and prior.
+	 */
+	@Bean
+	protected ReactiveDatabaseSelectionProvider reactiveNeo4jDatabaseNameProvider() {
+
+		return ReactiveDatabaseSelectionProvider.getDefaultSelectionProvider();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jConfigurationSupport.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jConfigurationSupport.java
@@ -27,7 +27,6 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.schema.Node;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
@@ -127,16 +126,5 @@ abstract class Neo4jConfigurationSupport {
 		}
 
 		return initialEntitySet;
-	}
-
-	/**
-	 * Configures the database name provider.
-	 *
-	 * @return The default database name provider, defaulting to the default database on Neo4j 4.0 and on no default on Neo4j 3.5 and prior.
-	 */
-	@Bean
-	protected Neo4jDatabaseNameProvider neo4jDatabaseNameProvider() {
-
-		return Neo4jDatabaseNameProvider.getDefaultDatabaseNameProvider();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DatabaseSelection.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DatabaseSelection.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core;
+
+import java.util.Objects;
+
+import org.apiguardian.api.API;
+import org.springframework.lang.Nullable;
+
+/**
+ * A value holder indicating a database selection based on a optional name.
+ * {@literal null} indicates to let the server decide.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Rage - Reign Of Fear
+ * @since 1.0
+ */
+@API(status = API.Status.STABLE, since = "1.0")
+public final class DatabaseSelection {
+
+	private final static DatabaseSelection DEFAULT_DATABASE_NAME = new DatabaseSelection(null);
+
+	@Nullable private final String value;
+
+	public static DatabaseSelection undecided() {
+
+		return DEFAULT_DATABASE_NAME;
+	}
+
+	/**
+	 * Create a new database selection by the given databaseName.
+	 *
+	 * @param databaseName The database name to select the database with.
+	 * @return A database selection
+	 */
+	public static DatabaseSelection byName(String databaseName) {
+
+		return new DatabaseSelection(databaseName);
+	}
+
+	private DatabaseSelection(String value) {
+		this.value = value;
+	}
+
+	@Nullable
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		DatabaseSelection that = (DatabaseSelection) o;
+		return Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(value);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DatabaseSelectionProvider.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DatabaseSelectionProvider.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.springframework.data.core;
 
-import java.util.Optional;
-
 import org.apiguardian.api.API;
 import org.springframework.util.Assert;
 
@@ -38,43 +36,43 @@ import org.springframework.util.Assert;
  */
 @API(status = API.Status.STABLE, since = "1.0")
 @FunctionalInterface
-public interface Neo4jDatabaseNameProvider {
+public interface DatabaseSelectionProvider {
 
 	/**
-	 * @return The optional name of the database name to interact with. Use the empty optional to indicate the default database.
+	 * @return The selected database me to interact with. Use {@link DatabaseSelection#undecided()} to indicate the default database.
 	 */
-	Optional<String> getCurrentDatabaseName();
+	DatabaseSelection getDatabaseSelection();
 
 	/**
-	 * Creates a statically configured database name provider always answering with the configured {@code databaseName}.
+	 * Creates a statically configured database selection provider always selecting the database with the given name {@code databaseName}.
 	 *
 	 * @param databaseName The database name to use, must not be null nor empty.
 	 * @return A statically configured database name provider.
 	 */
-	static Neo4jDatabaseNameProvider createStaticDatabaseNameProvider(String databaseName) {
+	static DatabaseSelectionProvider createStaticDatabaseSelectionProvider(String databaseName) {
 
 		Assert.notNull(databaseName, "The database name must not be null.");
 		Assert.hasText(databaseName, "The database name must not be empty.");
 
-		return () -> Optional.of(databaseName);
+		return () -> DatabaseSelection.byName(databaseName);
 	}
 
 	/**
-	 * A database name provider always returning the empty optional.
+	 * A database selection provider always returning the default selection.
 	 *
 	 * @return A provider for the default database name.
 	 */
-	static Neo4jDatabaseNameProvider getDefaultDatabaseNameProvider() {
+	static DatabaseSelectionProvider getDefaultSelectionProvider() {
 
-		return DefaultNeo4jDatabaseNameProvider.INSTANCE;
+		return DefaultDatabaseSelectionProvider.INSTANCE;
 	}
 }
 
-enum DefaultNeo4jDatabaseNameProvider implements Neo4jDatabaseNameProvider {
+enum DefaultDatabaseSelectionProvider implements DatabaseSelectionProvider {
 	INSTANCE;
 
 	@Override
-	public Optional<String> getCurrentDatabaseName() {
-		return Optional.empty();
+	public DatabaseSelection getDatabaseSelection() {
+		return DatabaseSelection.undecided();
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -83,23 +83,23 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 	private Neo4jEvents eventSupport;
 
-	private final Neo4jDatabaseNameProvider databaseNameProvider;
+	private final DatabaseSelectionProvider databaseSelectionProvider;
 
 	public Neo4jTemplate(Neo4jClient neo4jClient) {
-		this(neo4jClient, new Neo4jMappingContext(), Neo4jDatabaseNameProvider.getDefaultDatabaseNameProvider());
+		this(neo4jClient, new Neo4jMappingContext(), DatabaseSelectionProvider.getDefaultSelectionProvider());
 	}
 
-	public Neo4jTemplate(Neo4jClient neo4jClient, Neo4jMappingContext neo4jMappingContext, Neo4jDatabaseNameProvider databaseNameProvider) {
+	public Neo4jTemplate(Neo4jClient neo4jClient, Neo4jMappingContext neo4jMappingContext, DatabaseSelectionProvider databaseSelectionProvider) {
 
 		Assert.notNull(neo4jClient, "The Neo4jClient is required");
 		Assert.notNull(neo4jMappingContext, "The Neo4jMappingContext is required");
-		Assert.notNull(databaseNameProvider, "The database name provider is required");
+		Assert.notNull(databaseSelectionProvider, "The database name provider is required");
 
 		this.neo4jClient = neo4jClient;
 		this.neo4jMappingContext = neo4jMappingContext;
 		this.cypherGenerator = CypherGenerator.INSTANCE;
 		this.eventSupport = new Neo4jEvents(null);
-		this.databaseNameProvider = databaseNameProvider;
+		this.databaseSelectionProvider = databaseSelectionProvider;
 	}
 
 	@Override
@@ -404,7 +404,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 	private String getDatabaseName() {
 
-		return this.databaseNameProvider.getCurrentDatabaseName().orElse(null);
+		return this.databaseSelectionProvider.getDatabaseSelection().getValue();
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveDatabaseSelectionProvider.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveDatabaseSelectionProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core;
+
+import reactor.core.publisher.Mono;
+
+import org.apiguardian.api.API;
+import org.springframework.util.Assert;
+
+/**
+ * This is the reactive version of a the {@link DatabaseSelectionProvider} and it works in the same way but uses
+ * reactive return types containing the target database name. An empty mono indicates the default database.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Rage - Reign Of Fear
+ * @since 1.0
+ */
+@API(status = API.Status.STABLE, since = "1.0")
+@FunctionalInterface
+public interface ReactiveDatabaseSelectionProvider {
+
+	/**
+	 * @return The selected database to interact with.
+	 */
+	Mono<DatabaseSelection> getDatabaseSelection();
+
+	/**
+	 * Creates a statically configured database selection provider always selecting the database with the given name {@code databaseName}.
+	 *
+	 * @param databaseName The database name to use, must not be null nor empty.
+	 * @return A statically configured database name provider.
+	 */
+	static ReactiveDatabaseSelectionProvider createStaticDatabaseSelectionProvider(String databaseName) {
+
+		Assert.notNull(databaseName, "The database name must not be null.");
+		Assert.hasText(databaseName, "The database name must not be empty.");
+
+		return () -> Mono.just(DatabaseSelection.byName(databaseName));
+	}
+
+	/**
+	 * A database selector always selecting the default database.
+	 *
+	 * @return A provider for the default database name.
+	 */
+	static ReactiveDatabaseSelectionProvider getDefaultSelectionProvider() {
+
+		return DefaultReactiveDatabaseSelectionProvider.INSTANCE;
+	}
+}
+
+enum DefaultReactiveDatabaseSelectionProvider implements ReactiveDatabaseSelectionProvider {
+	INSTANCE;
+
+	@Override
+	public Mono<DatabaseSelection> getDatabaseSelection() {
+		return Mono.empty();
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
@@ -132,7 +132,7 @@ public interface ReactiveNeo4jOperations {
 	 * @param <T>           The type of the objects returned by this query.
 	 * @return An executable query
 	 */
-	<T> ExecutableQuery<T> toExecutableQuery(PreparedQuery<T> preparedQuery);
+	<T> Mono<ExecutableQuery<T>> toExecutableQuery(PreparedQuery<T> preparedQuery);
 
 	/**
 	 * An interface for controlling query execution in a reactive fashion.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/transaction/Neo4jTransactionManager.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/transaction/Neo4jTransactionManager.java
@@ -29,7 +29,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionConfig;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
@@ -59,17 +59,17 @@ public class Neo4jTransactionManager extends AbstractPlatformTransactionManager 
 	/**
 	 * Database name provider.
 	 */
-	private final Neo4jDatabaseNameProvider databaseNameProvider;
+	private final DatabaseSelectionProvider databaseSelectionProvider;
 
 	public Neo4jTransactionManager(Driver driver) {
 
-		this(driver, Neo4jDatabaseNameProvider.getDefaultDatabaseNameProvider());
+		this(driver, DatabaseSelectionProvider.getDefaultSelectionProvider());
 	}
 
-	public Neo4jTransactionManager(Driver driver, Neo4jDatabaseNameProvider databaseNameProvider) {
+	public Neo4jTransactionManager(Driver driver, DatabaseSelectionProvider databaseSelectionProvider) {
 
 		this.driver = driver;
-		this.databaseNameProvider = databaseNameProvider;
+		this.databaseSelectionProvider = databaseSelectionProvider;
 	}
 
 	/**
@@ -158,7 +158,7 @@ public class Neo4jTransactionManager extends AbstractPlatformTransactionManager 
 		TransactionSynchronizationManager.setCurrentTransactionReadOnly(readOnly);
 
 		try {
-			String databaseName = databaseNameProvider.getCurrentDatabaseName().orElse(null);
+			String databaseName = databaseSelectionProvider.getDatabaseSelection().getValue();
 
 			List<Bookmark> bookmarks = Collections.emptyList(); // TODO Bookmarksupport;
 			Session session = this.driver.session(sessionConfig(readOnly, bookmarks, databaseName));

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryExecution.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQueryExecution.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.repository.query;
 
+import reactor.core.publisher.Mono;
+
 import org.neo4j.springframework.data.core.Neo4jOperations;
 import org.neo4j.springframework.data.core.PreparedQuery;
 import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
@@ -67,11 +69,12 @@ interface Neo4jQueryExecution {
 		@Override
 		public Object execute(PreparedQuery preparedQuery, boolean asCollectionQuery) {
 
-			ReactiveNeo4jOperations.ExecutableQuery executableQuery = neo4jOperations.toExecutableQuery(preparedQuery);
+			Mono<ReactiveNeo4jOperations.ExecutableQuery> executableQuery = neo4jOperations
+				.toExecutableQuery(preparedQuery);
 			if (asCollectionQuery) {
-				return executableQuery.getResults();
+				return executableQuery.flatMapMany(q -> q.getResults());
 			} else {
-				return executableQuery.getSingleResult();
+				return executableQuery.flatMap(q -> q.getSingleResult());
 			}
 		}
 	}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/DatabaseSelectionProviderTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/DatabaseSelectionProviderTest.java
@@ -27,12 +27,13 @@ import org.junit.jupiter.api.Test;
  * @author Michael J. Simons
  * @soundtrack Dr. Dre - The Chronic
  */
-class Neo4jDatabaseNameProviderTest {
+class DatabaseSelectionProviderTest {
 
 	@Test
 	void defaultProviderShallDefaultToNullDatabase() {
 
-		assertThat(Neo4jDatabaseNameProvider.getDefaultDatabaseNameProvider().getCurrentDatabaseName()).isEmpty();
+		assertThat(DatabaseSelectionProvider.getDefaultSelectionProvider().getDatabaseSelection())
+			.isEqualTo(DatabaseSelection.undecided());
 	}
 
 	@Nested
@@ -42,7 +43,7 @@ class Neo4jDatabaseNameProviderTest {
 		void databaseNameMustNotBeNull() {
 
 			assertThatIllegalArgumentException()
-				.isThrownBy(() -> Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(null))
+				.isThrownBy(() -> DatabaseSelectionProvider.createStaticDatabaseSelectionProvider(null))
 				.withMessage("The database name must not be null.");
 		}
 
@@ -50,15 +51,16 @@ class Neo4jDatabaseNameProviderTest {
 		void databaseNameMustNotBeEmpty() {
 
 			assertThatIllegalArgumentException()
-				.isThrownBy(() -> Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(" \t"))
+				.isThrownBy(() -> DatabaseSelectionProvider.createStaticDatabaseSelectionProvider(" \t"))
 				.withMessage("The database name must not be empty.");
 		}
 
 		@Test
 		void shouldReturnConfiguredName() {
 
-			Neo4jDatabaseNameProvider provider = Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider("foobar");
-			assertThat(provider.getCurrentDatabaseName()).hasValue("foobar");
+			DatabaseSelectionProvider provider = DatabaseSelectionProvider
+				.createStaticDatabaseSelectionProvider("foobar");
+			assertThat(provider.getDatabaseSelection()).isEqualTo(DatabaseSelection.byName("foobar"));
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/Neo4jTransactionManagerTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/Neo4jTransactionManagerTest.java
@@ -42,7 +42,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jClient;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -153,7 +153,7 @@ class Neo4jTransactionManagerTest {
 			@Test
 			void shouldUseTxFromNeo4jTxManager() {
 
-				Neo4jTransactionManager txManager = new Neo4jTransactionManager(driver, Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(databaseName));
+				Neo4jTransactionManager txManager = new Neo4jTransactionManager(driver, DatabaseSelectionProvider.createStaticDatabaseSelectionProvider(databaseName));
 				TransactionTemplate txTemplate = new TransactionTemplate(txManager);
 
 				txTemplate.execute(new TransactionCallbackWithoutResult() {
@@ -186,7 +186,7 @@ class Neo4jTransactionManagerTest {
 			@Test
 			void shouldParticipateInOngoingTransaction() {
 
-				Neo4jTransactionManager txManager = new Neo4jTransactionManager(driver, Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(databaseName));
+				Neo4jTransactionManager txManager = new Neo4jTransactionManager(driver, DatabaseSelectionProvider.createStaticDatabaseSelectionProvider(databaseName));
 				TransactionTemplate txTemplate = new TransactionTemplate(txManager);
 
 				txTemplate.execute(new TransactionCallbackWithoutResult() {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManagerTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/transaction/ReactiveNeo4jTransactionManagerTest.java
@@ -43,7 +43,7 @@ import org.neo4j.driver.TransactionConfig;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxTransaction;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
 import org.springframework.data.r2dbc.connectionfactory.R2dbcTransactionManager;
 import org.springframework.transaction.reactive.TransactionSynchronizationManager;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -92,8 +92,8 @@ class ReactiveNeo4jTransactionManagerTest {
 		@Test
 		void shouldUseTxFromNeo4jTxManager() {
 
-			ReactiveNeo4jTransactionManager txManager = new ReactiveNeo4jTransactionManager(driver, Neo4jDatabaseNameProvider
-				.createStaticDatabaseNameProvider(databaseName));
+			ReactiveNeo4jTransactionManager txManager = new ReactiveNeo4jTransactionManager(driver, ReactiveDatabaseSelectionProvider
+				.createStaticDatabaseSelectionProvider(databaseName));
 			TransactionalOperator transactionalOperator = TransactionalOperator.create(txManager);
 
 			transactionalOperator
@@ -118,8 +118,8 @@ class ReactiveNeo4jTransactionManagerTest {
 		@Test
 		void shouldParticipateInOngoingTransaction() {
 
-			ReactiveNeo4jTransactionManager txManager = new ReactiveNeo4jTransactionManager(driver, Neo4jDatabaseNameProvider
-				.createStaticDatabaseNameProvider(databaseName));
+			ReactiveNeo4jTransactionManager txManager = new ReactiveNeo4jTransactionManager(driver, ReactiveDatabaseSelectionProvider
+				.createStaticDatabaseSelectionProvider(databaseName));
 			TransactionalOperator transactionalOperator = TransactionalOperator.create(txManager);
 
 			transactionalOperator

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
@@ -20,15 +20,14 @@ package org.neo4j.springframework.data.integration.imperative;
 
 import static org.neo4j.springframework.data.test.Neo4jExtension.*;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelection;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -82,8 +81,8 @@ class RepositoryWithADifferentDatabaseIT extends RepositoryIT {
 	static class ConfigWithDatabaseNameProviderBean extends RepositoryIT.Config {
 
 		@Bean
-		Neo4jDatabaseNameProvider databaseNameProvider() {
-			return () -> Optional.of("aTestDatabase");
+		DatabaseSelectionProvider databaseNameProvider() {
+			return () -> DatabaseSelection.byName("aTestDatabase");
 		}
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/TransactionManagerMixedDatabasesTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/TransactionManagerMixedDatabasesTest.java
@@ -41,7 +41,7 @@ import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
 import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.transaction.Neo4jTransactionManager;
 import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -102,7 +102,8 @@ class TransactionManagerMixedDatabasesTest {
 
 	@Test
 	void usingSameDatabaseExplicitTx() {
-		Neo4jTransactionManager otherTransactionManger = new Neo4jTransactionManager(driver, Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(DATABASE_NAME));
+		Neo4jTransactionManager otherTransactionManger = new Neo4jTransactionManager(driver, DatabaseSelectionProvider
+			.createStaticDatabaseSelectionProvider(DATABASE_NAME));
 		TransactionTemplate otherTransactionTemplate = new TransactionTemplate(otherTransactionManger);
 
 		Optional<Long> numberOfNodes = otherTransactionTemplate.execute(
@@ -132,7 +133,8 @@ class TransactionManagerMixedDatabasesTest {
 	@Test
 	void usingAnotherDatabaseDeclarativeFromRepo() {
 
-		Neo4jTransactionManager otherTransactionManger = new Neo4jTransactionManager(driver, Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(DATABASE_NAME));
+		Neo4jTransactionManager otherTransactionManger = new Neo4jTransactionManager(driver, DatabaseSelectionProvider
+			.createStaticDatabaseSelectionProvider(DATABASE_NAME));
 		TransactionTemplate otherTransactionTemplate = new TransactionTemplate(otherTransactionManger);
 
 		assertThatIllegalStateException().isThrownBy(

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryWithADifferentDatabaseIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryWithADifferentDatabaseIT.java
@@ -20,14 +20,16 @@ package org.neo4j.springframework.data.integration.reactive;
 
 import static org.neo4j.springframework.data.test.Neo4jExtension.*;
 
-import java.util.Optional;
+import reactor.core.publisher.Mono;
+
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
+import org.neo4j.springframework.data.core.DatabaseSelection;
+import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -68,8 +70,8 @@ class ReactiveRepositoryWithADifferentDatabaseIT extends ReactiveRepositoryIT {
 	static class ConfigWithDatabaseNameProviderBean extends ReactiveRepositoryIT.Config {
 
 		@Bean
-		Neo4jDatabaseNameProvider databaseNameProvider() {
-			return () -> Optional.of("aTestDatabase");
+		ReactiveDatabaseSelectionProvider databaseNameProvider() {
+			return () -> Mono.just(DatabaseSelection.byName("aTestDatabase"));
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveTransactionManagerMixedDatabasesTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveTransactionManagerMixedDatabasesTest.java
@@ -42,9 +42,9 @@ import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
 import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
+import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
 import org.neo4j.springframework.data.core.transaction.ReactiveNeo4jTransactionManager;
 import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
-import org.neo4j.springframework.data.core.Neo4jDatabaseNameProvider;
 import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -113,7 +113,7 @@ class ReactiveTransactionManagerMixedDatabasesTest {
 	@Test
 	void usingSameDatabaseExplicitTx() {
 		ReactiveNeo4jTransactionManager otherTransactionManger = new ReactiveNeo4jTransactionManager(driver,
-			Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(DATABASE_NAME));
+			ReactiveDatabaseSelectionProvider.createStaticDatabaseSelectionProvider(DATABASE_NAME));
 		TransactionalOperator otherTransactionTemplate = TransactionalOperator.create(otherTransactionManger);
 
 		Mono<Long> numberOfNodes = neo4jClient.query(TEST_QUERY).in(DATABASE_NAME).fetchAs(Long.class).one()
@@ -157,7 +157,7 @@ class ReactiveTransactionManagerMixedDatabasesTest {
 	void usingAnotherDatabaseDeclarativeFromRepo() {
 
 		ReactiveNeo4jTransactionManager otherTransactionManger = new ReactiveNeo4jTransactionManager(driver,
-			Neo4jDatabaseNameProvider.createStaticDatabaseNameProvider(DATABASE_NAME));
+			ReactiveDatabaseSelectionProvider.createStaticDatabaseSelectionProvider(DATABASE_NAME));
 		TransactionalOperator otherTransactionTemplate = TransactionalOperator.create(otherTransactionManger);
 
 		Mono<PersonWithAllConstructor> p =


### PR DESCRIPTION
While the database name provider in fd8068b24e5a80fc1ded6e5a884ddd6447de9c02 works, it doesn’t help in some reactive scenarios, for example, with the reactive security principle.

We need to role an independent version of it, returning the database selection as a Mono.

While doing this, it becomes obvious that we shouldn’t deal with the raw database name. The value of null is neither a valid database name and nor a valid mono value.
There the notion of a database selection is introduced, with an explicit value of „undecided“ for all the case in which the server should decide.