### PR TITLE
Fix same type bidirectional save.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -412,11 +412,11 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		});
 	}
 
-	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions,
+	private boolean hasProcessed(Set<RelationshipDescription> processedRelationshipDescriptions,
 		RelationshipDescription relationshipDescription) {
 
 		if (relationshipDescription != null) {
-			return relationshipDescriptions.contains(relationshipDescription);
+			return processedRelationshipDescriptions.contains(relationshipDescription);
 		}
 		return false;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -28,9 +28,11 @@ import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
@@ -47,6 +49,7 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.core.schema.CypherGenerator;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
+import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.neo4j.springframework.data.core.support.Relationships;
 import org.neo4j.springframework.data.repository.NoResultException;
 import org.neo4j.springframework.data.repository.event.BeforeBindCallback;
@@ -193,11 +196,11 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		PersistentPropertyAccessor<T> propertyAccessor = entityMetaData.getPropertyAccessor(entityToBeSaved);
 
 		if (!entityMetaData.isUsingInternalIds()) {
-			processNestedAssociations(entityMetaData, entityToBeSaved, inDatabase);
+			processAssociations(entityMetaData, entityToBeSaved, inDatabase);
 			return entityToBeSaved;
 		} else {
 			propertyAccessor.setProperty(entityMetaData.getRequiredIdProperty(), internalId);
-			processNestedAssociations(entityMetaData, entityToBeSaved, inDatabase);
+			processAssociations(entityMetaData, entityToBeSaved, inDatabase);
 
 			return propertyAccessor.getBean();
 		}
@@ -246,7 +249,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 		// Save related
 		entitiesToBeSaved.forEach(entityToBeSaved -> {
-			processNestedAssociations(entityMetaData, entityToBeSaved, databaseName);
+			processAssociations(entityMetaData, entityToBeSaved, databaseName);
 		});
 
 		SummaryCounters counters = resultSummary.counters();
@@ -324,7 +327,13 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		return toExecutableQuery(preparedQuery);
 	}
 
-	private void processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
+	private void processAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+		@Nullable String inDatabase) {
+		processNestedAssociations(neo4jPersistentEntity, parentObject, inDatabase, new HashSet<>());
+	}
+
+	private void processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+		@Nullable String inDatabase, Set<RelationshipDescription> processedRelationshipDescriptions) {
 
 		PersistentPropertyAccessor<?> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(parentObject);
 
@@ -333,6 +342,12 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			// create context to bundle parameters
 			NestedRelationshipContext relationshipContext = NestedRelationshipContext
 				.of(handler, propertyAccessor, neo4jPersistentEntity);
+
+			// break recursive procession and deletion of previously created relationships
+			RelationshipDescription relationshipObverse = relationshipContext.getRelationship().getRelationshipObverse();
+			if (hasProcessed(processedRelationshipDescriptions, relationshipObverse)) {
+				return;
+			}
 
 			Neo4jPersistentEntity<?> targetNodeDescription = neo4jMappingContext
 				.getPersistentEntity(relationshipContext.getAssociationTargetType());
@@ -349,10 +364,12 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 					.bind(fromId).to(FROM_ID_PARAMETER_NAME).run();
 			}
 
-			// break recursive
+			// nothing to do because there is nothing to map
 			if (relationshipContext.inverseValueIsEmpty()) {
 				return;
 			}
+
+			processedRelationshipDescriptions.add(relationshipContext.getRelationship());
 
 			for (Object relatedValue : Relationships
 				.unifyRelationshipValue(relationshipContext.getInverse(), relationshipContext.getValue())) {
@@ -390,9 +407,16 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 					targetPropertyAccessor
 						.setProperty(targetNodeDescription.getRequiredIdProperty(), relatedInternalId);
 				}
-				processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase);
+				processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase, processedRelationshipDescriptions);
 			}
 		});
+	}
+
+	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions, RelationshipDescription rd) {
+		if (rd != null) {
+			return relationshipDescriptions.contains(rd);
+		}
+		return false;
 	}
 
 	private <Y> Long saveRelatedNode(Object entity, Class<Y> entityType, NodeDescription targetNodeDescription, @Nullable String inDatabase) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -412,9 +412,11 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		});
 	}
 
-	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions, RelationshipDescription rd) {
-		if (rd != null) {
-			return relationshipDescriptions.contains(rd);
+	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions,
+		RelationshipDescription relationshipDescription) {
+
+		if (relationshipDescription != null) {
+			return relationshipDescriptions.contains(relationshipDescription);
 		}
 		return false;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
@@ -20,7 +20,6 @@ package org.neo4j.springframework.data.core;
 
 import java.util.Map;
 
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
@@ -57,7 +56,6 @@ final class NestedRelationshipContext {
 		return inverse;
 	}
 
-	@NotNull
 	Object getValue() {
 		return value;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -423,11 +423,11 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		});
 	}
 
-	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions,
+	private boolean hasProcessed(Set<RelationshipDescription> processedRelationshipDescriptions,
 		RelationshipDescription relationshipDescription) {
 
 		if (relationshipDescription != null) {
-			return relationshipDescriptions.contains(relationshipDescription);
+			return processedRelationshipDescriptions.contains(relationshipDescription);
 		}
 		return false;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -423,9 +423,11 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		});
 	}
 
-	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions, RelationshipDescription rd) {
-		if (rd != null) {
-			return relationshipDescriptions.contains(rd);
+	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions,
+		RelationshipDescription relationshipDescription) {
+
+		if (relationshipDescription != null) {
+			return relationshipDescriptions.contains(relationshipDescription);
 		}
 		return false;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -33,8 +33,10 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
@@ -51,6 +53,7 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.core.schema.CypherGenerator;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
+import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.neo4j.springframework.data.repository.event.ReactiveBeforeBindCallback;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -195,7 +198,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 						.fetchAs(Long.class).one();
 
 				if (!entityMetaData.isUsingInternalIds()) {
-					return idMono.then(processNestedAssociations(entityMetaData, entity, inDatabase))
+					return idMono.then(processAssociations(entityMetaData, entity, inDatabase))
 						.thenReturn(entity);
 				} else {
 					return idMono.map(internalId -> {
@@ -203,7 +206,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 						propertyAccessor.setProperty(entityMetaData.getRequiredIdProperty(), internalId);
 
 						return propertyAccessor.getBean();
-					}).flatMap(savedEntity -> processNestedAssociations(entityMetaData, savedEntity, inDatabase)
+					}).flatMap(savedEntity -> processAssociations(entityMetaData, savedEntity, inDatabase)
 						.thenReturn(savedEntity));
 				}
 			});
@@ -318,7 +321,14 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		return this.toExecutableQuery(preparedQuery);
 	}
 
-	private Mono<Void> processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
+	private Mono<Void> processAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+		@Nullable String inDatabase) {
+
+		return processNestedAssociations(neo4jPersistentEntity, parentObject, inDatabase, new HashSet<>());
+	}
+
+	private Mono<Void> processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+		@Nullable String inDatabase, Set<RelationshipDescription> processedRelationshipDescriptions) {
 
 		return Mono.defer(() -> {
 			PersistentPropertyAccessor<?> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(parentObject);
@@ -330,6 +340,12 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 				// create context to bundle parameters
 				NestedRelationshipContext relationshipContext = NestedRelationshipContext
 					.of(handler, propertyAccessor, neo4jPersistentEntity);
+
+				// break recursive procession and deletion of previously created relationships
+				RelationshipDescription relationshipObverse = relationshipContext.getRelationship().getRelationshipObverse();
+				if (hasProcessed(processedRelationshipDescriptions, relationshipObverse)) {
+					return;
+				}
 
 				Neo4jPersistentEntity<?> targetNodeDescription = (Neo4jPersistentEntity<?>) neo4jMappingContext
 					.getRequiredNodeDescription(relationshipContext.getAssociationTargetType());
@@ -347,9 +363,12 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 							.run().checkpoint("delete relationships").then());
 				}
 
+				// nothing to do because there is nothing to map
 				if (relationshipContext.inverseValueIsEmpty()) {
 					return;
 				}
+
+				processedRelationshipDescriptions.add(relationshipContext.getRelationship());
 
 				for (Object relatedValue : unifyRelationshipValue(relationshipContext.getInverse(),
 					relationshipContext.getValue())) {
@@ -395,13 +414,20 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 											.run();
 
 										return relationshipCreationMonoNested.checkpoint()
-											.then(processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase));
+											.then(processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase, processedRelationshipDescriptions));
 									}).checkpoint()));
 				}
 			});
 
 			return Flux.concat(relationshipCreationMonos).checkpoint().then();
 		});
+	}
+
+	private boolean hasProcessed(Set<RelationshipDescription> relationshipDescriptions, RelationshipDescription rd) {
+		if (rd != null) {
+			return relationshipDescriptions.contains(rd);
+		}
+		return false;
 	}
 
 	private <Y> Mono<Long> saveRelatedNode(Object entity, Class<Y> entityType, NodeDescription targetNodeDescription,

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -106,6 +106,7 @@ class RepositoryIT {
 	private final PetRepository petRepository;
 	private final BidirectionalStartRepository bidirectionalStartRepository;
 	private final BidirectionalEndRepository bidirectionalEndRepository;
+	private final SimilarThingRepository similarThingRepository;
 	private final Driver driver;
 	private Long id1;
 	private Long id2;
@@ -117,7 +118,8 @@ class RepositoryIT {
 		RelationshipRepository relationshipRepository, PetRepository petRepository, Driver driver,
 		PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository,
 		BidirectionalStartRepository bidirectionalStartRepository,
-		BidirectionalEndRepository bidirectionalEndRepository) {
+		BidirectionalEndRepository bidirectionalEndRepository,
+		SimilarThingRepository similarThingRepository) {
 
 		this.repository = repository;
 		this.relationshipRepository = relationshipRepository;
@@ -127,6 +129,7 @@ class RepositoryIT {
 		this.driver = driver;
 		this.bidirectionalStartRepository = bidirectionalStartRepository;
 		this.bidirectionalEndRepository = bidirectionalEndRepository;
+		this.similarThingRepository = similarThingRepository;
 	}
 
 	/**
@@ -928,6 +931,52 @@ class RepositoryIT {
 			// assert that only one hobby is stored
 			recordList = session.run("MATCH (h:Hobby) RETURN h").list();
 			assertThat(recordList).hasSize(1);
+		}
+	}
+
+	@Test
+	void saveEntityWithDeepSelfReferences() {
+		Pet rootPet = new Pet("Luna");
+		Pet petOfRootPet = new Pet("Daphne");
+		Pet petOfChildPet = new Pet("Mucki");
+		Pet petOfGrandChildPet = new Pet("Blacky");
+
+		rootPet.setFriends(singletonList(petOfRootPet));
+		petOfRootPet.setFriends(singletonList(petOfChildPet));
+		petOfChildPet.setFriends(singletonList(petOfGrandChildPet));
+
+		petRepository.save(rootPet);
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Record record = session.run("MATCH (rootPet:Pet)-[:Has]->(petOfRootPet:Pet)-[:Has]->(petOfChildPet:Pet)"
+				+ "-[:Has]->(petOfGrandChildPet:Pet) "
+				+ "RETURN rootPet, petOfRootPet, petOfChildPet, petOfGrandChildPet", emptyMap()).single();
+
+			assertThat(record.get("rootPet").asNode().get("name").asString()).isEqualTo("Luna");
+			assertThat(record.get("petOfRootPet").asNode().get("name").asString()).isEqualTo("Daphne");
+			assertThat(record.get("petOfChildPet").asNode().get("name").asString()).isEqualTo("Mucki");
+			assertThat(record.get("petOfGrandChildPet").asNode().get("name").asString()).isEqualTo("Blacky");
+		}
+	}
+
+	@Test
+	void saveEntityGraphWithSelfInverseRelationshipDefined() {
+		SimilarThing originalThing = new SimilarThing().withName("Original");
+		SimilarThing similarThing = new SimilarThing().withName("Similar");
+
+
+		originalThing.setSimilar(similarThing);
+		similarThing.setSimilarOf(originalThing);
+		similarThingRepository.save(originalThing);
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Record record = session.run(
+				"MATCH (ot:SimilarThing{name:'Original'})-[r:SimilarTo]->(st:SimilarThing {name:'Similar'})"
+				+ " RETURN r").single();
+
+			assertThat(record.keys()).isNotEmpty();
+			assertThat(record.containsKey("r")).isTrue();
+			assertThat(record.get("r").asRelationship().type()).isEqualToIgnoringCase("SimilarTo");
 		}
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -99,38 +99,19 @@ class RepositoryIT {
 
 	protected static Neo4jConnectionSupport neo4jConnectionSupport;
 
-	private final PersonRepository repository;
-	private final ThingRepository thingRepository;
-	private final RelationshipRepository relationshipRepository;
-	private final PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository;
-	private final PetRepository petRepository;
-	private final BidirectionalStartRepository bidirectionalStartRepository;
-	private final BidirectionalEndRepository bidirectionalEndRepository;
-	private final SimilarThingRepository similarThingRepository;
-	private final Driver driver;
+	@Autowired private PersonRepository repository;
+	@Autowired private ThingRepository thingRepository;
+	@Autowired private RelationshipRepository relationshipRepository;
+	@Autowired private PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository;
+	@Autowired private PetRepository petRepository;
+	@Autowired private BidirectionalStartRepository bidirectionalStartRepository;
+	@Autowired private BidirectionalEndRepository bidirectionalEndRepository;
+	@Autowired private SimilarThingRepository similarThingRepository;
+	@Autowired private Driver driver;
 	private Long id1;
 	private Long id2;
 	private PersonWithAllConstructor person1;
 	private PersonWithAllConstructor person2;
-
-	@Autowired
-	RepositoryIT(PersonRepository repository, ThingRepository thingRepository,
-		RelationshipRepository relationshipRepository, PetRepository petRepository, Driver driver,
-		PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository,
-		BidirectionalStartRepository bidirectionalStartRepository,
-		BidirectionalEndRepository bidirectionalEndRepository,
-		SimilarThingRepository similarThingRepository) {
-
-		this.repository = repository;
-		this.relationshipRepository = relationshipRepository;
-		this.thingRepository = thingRepository;
-		this.petRepository = petRepository;
-		this.relationshipWithPropertiesRepository = relationshipWithPropertiesRepository;
-		this.driver = driver;
-		this.bidirectionalStartRepository = bidirectionalStartRepository;
-		this.bidirectionalEndRepository = bidirectionalEndRepository;
-		this.similarThingRepository = similarThingRepository;
-	}
 
 	/**
 	 * Shall be configured by test making use of database selection, so that the verification queries run in the correct database.

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
@@ -23,12 +23,10 @@ import static org.neo4j.springframework.data.test.Neo4jExtension.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
-import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.springframework.data.core.DatabaseSelection;
 import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,20 +38,6 @@ import org.springframework.context.annotation.Configuration;
 class RepositoryWithADifferentDatabaseIT extends RepositoryIT {
 
 	private static final String TEST_DATABASE_NAME = "aTestDatabase";
-
-	@Autowired
-	RepositoryWithADifferentDatabaseIT(
-		PersonRepository repository, ThingRepository thingRepository,
-		RelationshipRepository relationshipRepository,
-		PetRepository petRepository, Driver driver,
-		PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository,
-		BidirectionalStartRepository bidirectionalStartRepository,
-		BidirectionalEndRepository bidirectionalEndRepository,
-		SimilarThingRepository similarThingRepository) {
-		super(repository, thingRepository, relationshipRepository, petRepository, driver,
-			relationshipWithPropertiesRepository, bidirectionalStartRepository, bidirectionalEndRepository,
-			similarThingRepository);
-	}
 
 	@BeforeAll
 	static void createTestDatabase() {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryWithADifferentDatabaseIT.java
@@ -48,9 +48,11 @@ class RepositoryWithADifferentDatabaseIT extends RepositoryIT {
 		PetRepository petRepository, Driver driver,
 		PersonWithRelationshipWithPropertiesRepository relationshipWithPropertiesRepository,
 		BidirectionalStartRepository bidirectionalStartRepository,
-		BidirectionalEndRepository bidirectionalEndRepository) {
+		BidirectionalEndRepository bidirectionalEndRepository,
+		SimilarThingRepository similarThingRepository) {
 		super(repository, thingRepository, relationshipRepository, petRepository, driver,
-			relationshipWithPropertiesRepository, bidirectionalStartRepository, bidirectionalEndRepository);
+			relationshipWithPropertiesRepository, bidirectionalStartRepository, bidirectionalEndRepository,
+			similarThingRepository);
 	}
 
 	@BeforeAll

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/SimilarThingRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/SimilarThingRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import org.neo4j.springframework.data.integration.shared.SimilarThing;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+
+/**
+ * @author Gerrit Meier
+ */
+public interface SimilarThingRepository extends Neo4jRepository<SimilarThing, Long> {
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveSimilarThingRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveSimilarThingRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import org.neo4j.springframework.data.integration.shared.SimilarThing;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+/**
+ * @author Gerrit Meier
+ */
+public interface ReactiveSimilarThingRepository extends ReactiveCrudRepository<SimilarThing, Long> {
+
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/SimilarThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/SimilarThing.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.neo4j.springframework.data.core.schema.Relationship;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class SimilarThing {
+	@Id @GeneratedValue private Long id;
+
+	private String name;
+
+	@Relationship(type = "SimilarTo", inverse = "similarOf")
+	private SimilarThing similar;
+
+	@Relationship(type = "SimilarTo", direction = Relationship.Direction.INCOMING)
+	private SimilarThing similarOf;
+
+	// included to ensure empty relationships do not cause deletion
+	@Relationship("EmptyRelationship")
+	private List<SimilarThing> noSimilarThings;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public SimilarThing withName(String newName) {
+		SimilarThing h = new SimilarThing();
+		h.id = this.id;
+		h.name = newName;
+		return h;
+	}
+
+	public void setSimilar(SimilarThing similar) {
+		this.similar = similar;
+	}
+
+	public void setSimilarOf(SimilarThing similarOf) {
+		this.similarOf = similarOf;
+	}
+
+	@Override public String toString() {
+		return "Similar{" +
+			"id=" + id +
+			", name='" + name + '\'' +
+			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SimilarThing similarThing = (SimilarThing) o;
+		return id.equals(similarThing.id) &&
+			name.equals(similarThing.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name);
+	}
+}


### PR DESCRIPTION
Due to the processing of self-references on both sides
the relationship may get deleted from the later iteration
after it was created before.
This bug fix prevents the multiple processing of the very same
relationship.

closes #119 