### PR TITLE
Make repository base class configurable.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableNeo4jRepositories.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableNeo4jRepositories.java
@@ -27,11 +27,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AliasFor;
-import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
+import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
 
 /**
  * Annotation to activate Neo4j repositories. If no base package is configured through either {@link #value()},
@@ -75,6 +76,13 @@ public @interface EnableNeo4jRepositories {
 	 * {@link Neo4jRepositoryFactoryBean}.
 	 */
 	Class<?> repositoryFactoryBeanClass() default Neo4jRepositoryFactoryBean.class;
+
+	/**
+	 * Configure the repository base class to be used to create repository proxies for this particular configuration.
+	 *
+	 * @return The base class to be used when creating repository proxies.
+	 */
+	Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
 	/**
 	 * Configures the name of the {@link org.neo4j.springframework.data.core.mapping.Neo4jMappingContext} bean to be used with the repositories detected.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableReactiveNeo4jRepositories.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableReactiveNeo4jRepositories.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AliasFor;
 import org.neo4j.springframework.data.repository.support.ReactiveNeo4jRepositoryFactoryBean;
+import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
 
 /**
  * Annotation to activate reactive Neo4j repositories. If no base package is configured through either {@link #value()},
@@ -76,6 +77,13 @@ public @interface EnableReactiveNeo4jRepositories {
 	 * {@link ReactiveNeo4jRepositoryFactoryBean}.
 	 */
 	Class<?> repositoryFactoryBeanClass() default ReactiveNeo4jRepositoryFactoryBean.class;
+
+	/**
+	 * Configure the repository base class to be used to create repository proxies for this particular configuration.
+	 *
+	 * @return The base class to be used when creating repository proxies.
+	 */
+	Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
 	/**
 	 * Configures the name of the {@link org.neo4j.springframework.data.core.mapping.Neo4jMappingContext} bean to be used with the repositories detected.

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/CustomBaseRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/CustomBaseRepositoryIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.core.Neo4jOperations;
+import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.repository.support.Neo4jEntityInformation;
+import org.neo4j.springframework.data.repository.support.SimpleNeo4jRepository;
+import org.neo4j.springframework.data.test.DriverMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Make sure custom base repositories can be used.
+ *
+ * @author Michael J. Simons
+ */
+@ExtendWith({ SpringExtension.class })
+public class CustomBaseRepositoryIT {
+
+	@Test
+	public void customBaseRepositoryShouldBeInUse(@Autowired MyPersonRepository repository) {
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> repository.findAll())
+			.withMessage("This implementation does not support `findAll`.");
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(
+		repositoryBaseClass = MyRepositoryImpl.class,
+		considerNestedRepositories = true,
+		includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MyPersonRepository.class)
+	)
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return DriverMocks.withOpenSessionAndTransaction();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(PersonWithAllConstructor.class.getPackage().getName());
+		}
+	}
+
+	interface MyPersonRepository extends Neo4jRepository<PersonWithAllConstructor, Long> {
+	}
+
+	static class MyRepositoryImpl<T, ID> extends SimpleNeo4jRepository<T, ID> {
+
+		MyRepositoryImpl(Neo4jOperations neo4jOperations, Neo4jEntityInformation<T, ID> entityInformation) {
+			super(neo4jOperations, entityInformation);
+
+			assertThat(neo4jOperations).isNotNull();
+			assertThat(entityInformation).isNotNull();
+			assertThat(entityInformation.getEntityMetaData().getUnderlyingClass())
+				.isEqualTo(PersonWithAllConstructor.class);
+		}
+
+		@Override
+		public List<T> findAll() {
+			throw new UnsupportedOperationException("This implementation does not support `findAll`.");
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/CustomReactiveBaseRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/CustomReactiveBaseRepositoryIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
+import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.neo4j.springframework.data.repository.support.Neo4jEntityInformation;
+import org.neo4j.springframework.data.repository.support.SimpleReactiveNeo4jRepository;
+import org.neo4j.springframework.data.test.DriverMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Make sure custom base repositories can be used in reactive configurations.
+ *
+ * @author Michael J. Simons
+ */
+@ExtendWith({ SpringExtension.class })
+public class CustomReactiveBaseRepositoryIT {
+
+	@Test
+	public void customBaseRepositoryShouldBeInUse(@Autowired MyPersonRepository repository) {
+
+		StepVerifier.create(repository.findAll()).expectErrorMatches(e ->
+			e instanceof UnsupportedOperationException && e.getMessage().equals(
+				"This implementation does not support `findAll`.")
+		);
+	}
+
+	@Configuration
+	@EnableReactiveNeo4jRepositories(
+		repositoryBaseClass = MyRepositoryImpl.class,
+		considerNestedRepositories = true,
+		includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MyPersonRepository.class)
+	)
+	@EnableTransactionManagement
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return DriverMocks.withOpenReactiveSessionAndTransaction();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(PersonWithAllConstructor.class.getPackage().getName());
+		}
+	}
+
+	interface MyPersonRepository extends ReactiveNeo4jRepository<PersonWithAllConstructor, Long> {
+	}
+
+	static class MyRepositoryImpl<T, ID> extends SimpleReactiveNeo4jRepository<T, ID> {
+
+		MyRepositoryImpl(ReactiveNeo4jOperations neo4jOperations,
+			Neo4jEntityInformation<T, ID> entityInformation) {
+			super(neo4jOperations, entityInformation);
+
+			assertThat(neo4jOperations).isNotNull();
+			assertThat(entityInformation).isNotNull();
+			assertThat(entityInformation.getEntityMetaData().getUnderlyingClass())
+				.isEqualTo(PersonWithAllConstructor.class);
+		}
+
+		@Override
+		public Flux<T> findAll() {
+			throw new UnsupportedOperationException("This implementation does not support `findAll`.");
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/test/DriverMocks.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/test/DriverMocks.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.test;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import reactor.core.publisher.Mono;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.TransactionConfig;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.reactive.RxTransaction;
+
+/**
+ * Some preconfigured driver mocks, mainly used to for Spring Integration tests where the behaviour of configuration
+ * and integration with Spring is tested and not with the database.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Elton John - Greatest Hits 1970-2002
+ * @since 1.0
+ */
+public final class DriverMocks {
+
+	/**
+	 * @return An instance usable in a test where an open session with an ongoing transaction is required.
+	 */
+	public static Driver withOpenSessionAndTransaction() {
+
+		Transaction transaction = mock(Transaction.class);
+		when(transaction.isOpen()).thenReturn(true);
+
+		Session session = mock(Session.class);
+		when(session.isOpen()).thenReturn(true);
+		when(session.beginTransaction(any(TransactionConfig.class))).thenReturn(transaction);
+
+		Driver driver = mock(Driver.class);
+		when(driver.session(any(SessionConfig.class))).thenReturn(session);
+		return driver;
+	}
+
+	public static Driver withOpenReactiveSessionAndTransaction() {
+
+		RxTransaction transaction = mock(RxTransaction.class);
+
+		RxSession session = mock(RxSession.class);
+		when(session.beginTransaction(any(TransactionConfig.class))).thenReturn(Mono.just(transaction));
+
+		Driver driver = mock(Driver.class);
+		when(driver.rxSession(any(SessionConfig.class))).thenReturn(session);
+		return driver;
+	}
+
+	private DriverMocks() {
+	}
+}


### PR DESCRIPTION
This commit makes the base class used for the repository proxies configurable. It brings together the work done in cad578377635ab15221eb99540105d6b5f6adbf3 and 3b5da3d33e95bceeace4a2285d7f1506f20ccf0d. Tests have been added to insure the integration with Spring Data works correctly. This closes #75.