### PR TITLE
Make sure all records are retrieved before consuming the result.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultReactiveNeo4jClient.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultReactiveNeo4jClient.java
@@ -33,8 +33,10 @@ import java.util.function.Supplier;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
-import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.reactive.RxQueryRunner;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jClient.*;
@@ -268,7 +270,11 @@ class DefaultReactiveNeo4jClient implements ReactiveNeo4jClient {
 
 			return doInQueryRunnerForMono(
 				targetDatabase,
-				runner -> prepareStatement().flatMap(t -> Mono.from(runner.run(t.getT1(), t.getT2()).consume())));
+				runner -> prepareStatement().flatMap(t -> {
+					RxResult rxResult = runner.run(t.getT1(), t.getT2());
+					return Flux.from(rxResult.records()).then(Mono.from(rxResult.consume()));
+				})
+			);
 		}
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultReactiveNeo4jClient.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/DefaultReactiveNeo4jClient.java
@@ -36,7 +36,6 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.reactive.RxQueryRunner;
 import org.neo4j.driver.reactive.RxResult;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.driver.reactive.RxTransaction;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.Neo4jClient.*;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/ReactiveNeo4jClientTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/ReactiveNeo4jClientTest.java
@@ -348,6 +348,7 @@ class ReactiveNeo4jClientTest {
 
 			when(transaction.run(anyString(), anyMap())).thenReturn(result);
 			when(transaction.commit()).thenReturn(Mono.empty());
+			when(result.records()).thenReturn(Flux.empty());
 			when(result.consume()).thenReturn(Mono.just(resultSummary));
 
 			ReactiveNeo4jClient client = ReactiveNeo4jClient.create(driver);
@@ -420,6 +421,7 @@ class ReactiveNeo4jClientTest {
 
 		when(transaction.run(anyString(), anyMap())).thenReturn(result);
 		when(transaction.commit()).thenReturn(Mono.empty());
+		when(result.records()).thenReturn(Flux.empty());
 		when(result.consume()).thenReturn(Mono.just(resultSummary));
 
 		ReactiveNeo4jClient client = ReactiveNeo4jClient.create(driver);


### PR DESCRIPTION
This avoids issues when the query lead to an exception, as the publisher still tries to consume all the records on rollback, which of course will fail as the error is still in the pipeline.