### PR TITLE
Prevent NPE when non existing properties are mapped onto primitive fields.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -143,14 +143,12 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 	@Nullable
 	public Object readValueForProperty(@Nullable Value value, TypeInformation<?> type) {
 
-		if (value == null || value == Values.NULL) {
-			return null;
-		}
+		boolean valueIsLiteralNullOrNullValue = value == null || value == Values.NULL;
 
 		try {
 			Class<?> rawType = type.getType();
 
-			if (isCollection(type)) {
+			if (!valueIsLiteralNullOrNullValue && isCollection(type)) {
 				Collection<Object> target = CollectionFactory.createCollection(rawType,
 					type.getComponentType().getType(), value.size());
 				value.values().forEach(
@@ -158,7 +156,7 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 				return target;
 			}
 
-			return conversionService.convert(value, rawType);
+			return conversionService.convert(valueIsLiteralNullOrNullValue ? null : value, rawType);
 		} catch (Exception e) {
 			String msg = String.format("Could not convert %s into %s", value, type.toString());
 			throw new TypeMismatchDataAccessException(msg, e);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
@@ -144,6 +144,7 @@ public abstract class Neo4jConversionsITBase {
 	protected static long ID_OF_CYPHER_TYPES_NODE;
 	protected static long ID_OF_ADDITIONAL_TYPES_NODE;
 	protected static long ID_OF_SPATIAL_TYPES_NODE;
+	protected static long ID_OF_NON_EXISTING_PRIMITIVES_NODE;
 
 	@BeforeAll
 	static void prepareData() {
@@ -153,6 +154,9 @@ public abstract class Neo4jConversionsITBase {
 				Map<String, Object> parameters;
 
 				w.run("MATCH (n) detach delete n");
+
+				ID_OF_NON_EXISTING_PRIMITIVES_NODE = w.run("CREATE (n:NonExistingPrimitives) RETURN id(n) AS id")
+					.single().get("id").asLong();
 
 				parameters = new HashMap<>();
 				parameters.put("aByteArray", "A thing".getBytes());

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithNonExistingPrimitives.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithNonExistingPrimitives.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node("NonExistingPrimitives")
+public class ThingWithNonExistingPrimitives {
+
+	@Id @GeneratedValue
+	private Long id;
+
+	private boolean someBoolean;
+
+	public boolean isSomeBoolean() {
+		return someBoolean;
+	}
+
+	public void setSomeBoolean(boolean someBoolean) {
+		this.someBoolean = someBoolean;
+	}
+}


### PR DESCRIPTION
We go with the default Spring behaviour here and through a corresponding mapping exception and refuse to convert `null` into any default.