### PR TITLE
Make Spring Boot autoconfiguration aware of custom EnableNeo4jRepositories.

### DIFF
--- a/examples/reactive-web/src/main/resources/application.properties
+++ b/examples/reactive-web/src/main/resources/application.properties
@@ -20,5 +20,7 @@ org.neo4j.driver.uri=neo4j://localhost:7687
 org.neo4j.driver.authentication.username=neo4j
 org.neo4j.driver.authentication.password=secret
 
+spring.data.neo4j.repositories.type=reactive
+
 logging.level.org.neo4j.springframework.data=DEBUG
 

--- a/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryIT.java
+++ b/examples/reactive-web/src/test/java/org/neo4j/springframework/data/examples/spring_boot/RepositoryIT.java
@@ -31,17 +31,20 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.springframework.boot.test.autoconfigure.Neo4jTestHarnessAutoConfiguration;
-import org.neo4j.springframework.boot.test.autoconfigure.data.DataNeo4jTest;
+import org.neo4j.springframework.boot.test.autoconfigure.data.AutoConfigureDataNeo4j;
 import org.neo4j.springframework.data.examples.spring_boot.domain.MovieRepository;
 import org.neo4j.springframework.data.examples.spring_boot.domain.PersonRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -52,7 +55,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = RepositoryIT.SYS_PROPERTY_NEO4J_VERSION, matches = "4\\.0.*")
-@DataNeo4jTest(excludeAutoConfiguration = Neo4jTestHarnessAutoConfiguration.class)
+@ExtendWith(SpringExtension.class)
+@EnableAutoConfiguration(exclude = Neo4jTestHarnessAutoConfiguration.class)
+@AutoConfigureDataNeo4j
 @ContextConfiguration(initializers = RepositoryIT.Initializer.class)
 class RepositoryIT {
 
@@ -62,7 +67,7 @@ class RepositoryIT {
 
 	@Container
 	private static Neo4jContainer<?> neo4jContainer =
-		new Neo4jContainer<>(Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_REPOSITORY)).orElse("neo4j") + ":" + System.getenv(SYS_PROPERTY_NEO4J_VERSION))
+		new Neo4jContainer<>(Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_REPOSITORY)).orElse("neo4j") + ":" + Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_VERSION)).orElse("4.0.0"))
 		.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT",
 			Optional.ofNullable(System.getenv(SYS_PROPERTY_NEO4J_ACCEPT_COMMERCIAL_EDITION)).orElse("no"));
 

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jImperativeRepositoriesConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jImperativeRepositoriesConfiguration.java
@@ -20,14 +20,14 @@ package org.neo4j.springframework.boot.autoconfigure.data;
 
 import static org.springframework.boot.autoconfigure.data.RepositoryType.*;
 
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
+import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.data.ConditionalOnRepositoryType;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.neo4j.springframework.data.repository.Neo4jRepository;
-import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
-import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
 
 /**
  * @author Michael J. Simons

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveRepositoriesConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveRepositoriesConfiguration.java
@@ -20,12 +20,15 @@ package org.neo4j.springframework.boot.autoconfigure.data;
 
 import reactor.core.publisher.Flux;
 
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+import org.neo4j.springframework.data.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
+import org.neo4j.springframework.data.repository.support.ReactiveNeo4jRepositoryFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.data.ConditionalOnRepositoryType;
 import org.springframework.boot.autoconfigure.data.RepositoryType;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 
 /**
  * @author Michael J. Simons
@@ -33,6 +36,8 @@ import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ Flux.class, ReactiveNeo4jRepository.class })
+@ConditionalOnMissingBean({ ReactiveNeo4jRepositoryFactoryBean.class,
+	ReactiveNeo4jRepositoryConfigurationExtension.class })
 @ConditionalOnRepositoryType(store = "neo4j", type = RepositoryType.REACTIVE)
 @Import(Neo4jReactiveRepositoriesConfigureRegistrar.class)
 class Neo4jReactiveRepositoriesConfiguration {

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/bikes/ReactiveBikeRepository.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/bikes/ReactiveBikeRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.autoconfigure.data.bikes;
+
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Ärzte - Le Frisur
+ */
+public interface ReactiveBikeRepository extends ReactiveNeo4jRepository<BikeNode, Long> {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/more_bikes/OtherBikeRepository.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/more_bikes/OtherBikeRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.autoconfigure.data.more_bikes;
+
+import org.neo4j.springframework.boot.autoconfigure.data.bikes.BikeNode;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Ärzte - Le Frisur
+ */
+public interface OtherBikeRepository extends Neo4jRepository<BikeNode, Long> {
+}

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/more_bikes/OtherReactiveBikeRepository.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/test/java/org/neo4j/springframework/boot/autoconfigure/data/more_bikes/OtherReactiveBikeRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.boot.autoconfigure.data.more_bikes;
+
+import org.neo4j.springframework.boot.autoconfigure.data.bikes.BikeNode;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Ärzte - Le Frisur
+ */
+public interface OtherReactiveBikeRepository extends ReactiveNeo4jRepository<BikeNode, Long> {
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableReactiveNeo4jRepositories.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/EnableReactiveNeo4jRepositories.java
@@ -52,8 +52,8 @@ public @interface EnableReactiveNeo4jRepositories {
 
 	/**
 	 * Alias for the {@link #basePackages()} attribute. Allows for more concise annotation declarations e.g.:
-	 * {@code @EnableNeo4jRepositories("org.my.pkg")} instead of
-	 * {@code @EnableNeo4jRepositories(basePackages="org.my.pkg")}.
+	 * {@code @EnableReactiveNeo4jRepositories("org.my.pkg")} instead of
+	 * {@code @EnableReactiveNeo4jRepositories(basePackages="org.my.pkg")}.
 	 */
 	@AliasFor("basePackages")
 	String[] value() default {};


### PR DESCRIPTION
This makes both the imperative and reactive variants of the autoconfiguration aware of existing, custom `@EnableNeo4jRepositories` respectivly `@EnableReactiveNeo4jRepositories` by adding a `@ConditionalOnMissingBean` checking for the presence of the corresponding factories.

This fixes #133.