### PR TITLE
Add support for optimistic locking.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -190,6 +190,13 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 		if (nodeDescription.hasIdProperty()) {
 			parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
 		}
+		// in case of relationship properties ignore internal id property
+		if (nodeDescription.hasVersionProperty()) {
+			Long versionProperty = (Long) propertyAccessor.getProperty(nodeDescription.getRequiredVersionProperty());
+
+			// we incremented this upfront the persist operation so the matching version would be one "before"
+			parameters.put(NAME_OF_VERSION_PARAM, versionProperty - 1);
+		}
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
@@ -40,6 +40,7 @@ public interface NodeDescription<T> {
 	String NAME_OF_INTERNAL_ID = "__internalNeo4jId__";
 	String NAME_OF_IDS_RESULT = "__ids__";
 	String NAME_OF_ID_PARAM = "__id__";
+	String NAME_OF_VERSION_PARAM = "__version__";
 	String NAME_OF_PROPERTIES_PARAM = "__properties__";
 	String NAME_OF_ENTITY_LIST_PARAM = "__entities__";
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -26,6 +26,7 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.event.IdGeneratingBeforeBindCallback;
+import org.neo4j.springframework.data.repository.event.OptimisticLockingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -124,10 +125,14 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 	public void registerBeansForRoot(BeanDefinitionRegistry registry,
 		RepositoryConfigurationSource configurationSource) {
 
-		RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(IdGeneratingBeforeBindCallback.class);
-		rootBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		RootBeanDefinition idGenerationBeanDefinition = new RootBeanDefinition(IdGeneratingBeforeBindCallback.class);
+		idGenerationBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		String idGenerationBeanName = BeanDefinitionReaderUtils.generateBeanName(idGenerationBeanDefinition, registry);
+		registry.registerBeanDefinition(idGenerationBeanName, idGenerationBeanDefinition);
 
-		String beanName = BeanDefinitionReaderUtils.generateBeanName(rootBeanDefinition, registry);
-		registry.registerBeanDefinition(beanName, rootBeanDefinition);
+		RootBeanDefinition optimisticLockingBeanDefinition = new RootBeanDefinition(OptimisticLockingBeforeBindCallback.class);
+		optimisticLockingBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		String optimisticLockingBeanName = BeanDefinitionReaderUtils.generateBeanName(optimisticLockingBeanDefinition, registry);
+		registry.registerBeanDefinition(optimisticLockingBeanName, optimisticLockingBeanDefinition);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -26,6 +26,7 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.event.ReactiveIdGeneratingBeforeBindCallback;
+import org.neo4j.springframework.data.repository.event.ReactiveOptimisticLockingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.ReactiveNeo4jRepositoryFactoryBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -123,10 +124,17 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 	public void registerBeansForRoot(BeanDefinitionRegistry registry,
 		RepositoryConfigurationSource configurationSource) {
 
-		RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(ReactiveIdGeneratingBeforeBindCallback.class);
-		rootBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		RootBeanDefinition idGenerationBeanDefinition = new RootBeanDefinition(ReactiveIdGeneratingBeforeBindCallback.class);
+		idGenerationBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 
-		String beanName = BeanDefinitionReaderUtils.generateBeanName(rootBeanDefinition, registry);
-		registry.registerBeanDefinition(beanName, rootBeanDefinition);
+		String idGenerationBeanName = BeanDefinitionReaderUtils.generateBeanName(idGenerationBeanDefinition, registry);
+		registry.registerBeanDefinition(idGenerationBeanName, idGenerationBeanDefinition);
+
+		RootBeanDefinition optimisticLockingBeanDefinition = new RootBeanDefinition(
+			ReactiveOptimisticLockingBeforeBindCallback.class);
+		optimisticLockingBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+
+		String optimisticLockingBeanName = BeanDefinitionReaderUtils.generateBeanName(optimisticLockingBeanDefinition, registry);
+		registry.registerBeanDefinition(optimisticLockingBeanName, optimisticLockingBeanDefinition);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/OptimisticLockingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/OptimisticLockingBeforeBindCallback.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.springframework.core.Ordered;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+
+/**
+ * Callback to increment the value of the version property for a given entity.
+ *
+ * @author Gerrit Meier
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class OptimisticLockingBeforeBindCallback implements BeforeBindCallback<Object>, Ordered {
+
+	private final Neo4jMappingContext neo4jMappingContext;
+
+	public OptimisticLockingBeforeBindCallback(Neo4jMappingContext neo4jMappingContext) {
+		this.neo4jMappingContext = neo4jMappingContext;
+	}
+
+	@Override
+	public Object onBeforeBind(Object entity) {
+		Neo4jPersistentEntity<?> neo4jPersistentEntity =
+			(Neo4jPersistentEntity<?>) neo4jMappingContext.getRequiredNodeDescription(entity.getClass());
+
+		if (neo4jPersistentEntity.hasVersionProperty()) {
+			PersistentPropertyAccessor<Object> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(entity);
+			Neo4jPersistentProperty versionProperty = neo4jPersistentEntity.getRequiredVersionProperty();
+
+			if (!Long.class.isAssignableFrom(versionProperty.getType())) {
+				return entity;
+			}
+
+			Long versionPropertyValue = (Long) propertyAccessor.getProperty(versionProperty);
+
+			long newVersionValue = 0;
+			if (versionPropertyValue != null) {
+				newVersionValue = versionPropertyValue + 1;
+			}
+
+			propertyAccessor.setProperty(versionProperty, newVersionValue);
+		}
+		return entity;
+	}
+
+	@Override
+	public int getOrder() {
+		return AuditingBeforeBindCallback.NEO4J_AUDITING_ORDER + 11;
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveOptimisticLockingBeforeBindCallback.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/event/ReactiveOptimisticLockingBeforeBindCallback.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.event;
+
+import reactor.core.publisher.Mono;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
+import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.reactivestreams.Publisher;
+import org.springframework.core.Ordered;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+
+/**
+ * Callback to increment the value of the version property for a given entity.
+ *
+ * @author Gerrit Meier
+ * @since 1.0
+ */
+@API(status = API.Status.INTERNAL, since = "1.0")
+public final class ReactiveOptimisticLockingBeforeBindCallback implements ReactiveBeforeBindCallback<Object>, Ordered {
+
+	private final Neo4jMappingContext neo4jMappingContext;
+
+	public ReactiveOptimisticLockingBeforeBindCallback(Neo4jMappingContext neo4jMappingContext) {
+		this.neo4jMappingContext = neo4jMappingContext;
+	}
+
+	@Override
+	public Publisher<Object> onBeforeBind(Object entity) {
+
+		return Mono.fromSupplier(() -> {
+			Neo4jPersistentEntity<?> neo4jPersistentEntity =
+				(Neo4jPersistentEntity<?>) neo4jMappingContext.getRequiredNodeDescription(entity.getClass());
+
+			if (neo4jPersistentEntity.hasVersionProperty()) {
+				PersistentPropertyAccessor<Object> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(entity);
+				Neo4jPersistentProperty versionProperty = neo4jPersistentEntity.getRequiredVersionProperty();
+
+				if (!Long.class.isAssignableFrom(versionProperty.getType())) {
+					return entity;
+				}
+
+				Long versionPropertyValue = (Long) propertyAccessor.getProperty(versionProperty);
+
+				long newVersionValue = 0;
+				if (versionPropertyValue != null) {
+					newVersionValue = versionPropertyValue + 1;
+				}
+
+				propertyAccessor.setProperty(versionProperty, newVersionValue);
+			}
+			return entity;
+		});
+	}
+
+	@Override
+	public int getOrder() {
+		return ReactiveAuditingBeforeBindCallback.NEO4J_REACTIVE_AUDITING_ORDER + 11;
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/OptimisticLockingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/OptimisticLockingIT.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.VersionedThing;
+import org.neo4j.springframework.data.integration.shared.VersionedThingWithAssignedId;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Gerrit Meier
+ */
+@Neo4jIntegrationTest
+class OptimisticLockingIT {
+
+	private static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+	@Autowired private VersionedThingRepository repository;
+	@Autowired private VersionedThingWithAssignedIdRepository assignedIdRepository;
+	@Autowired private Driver driver;
+
+	@BeforeEach
+	void setup() {
+		Session session = driver.session(SessionConfig.defaultConfig());
+		Transaction transaction = session.beginTransaction();
+		transaction.run("MATCH (n) detach delete n");
+		transaction.commit();
+		session.close();
+	}
+
+	@Test
+	void shouldIncrementVersions() {
+		VersionedThing thing = repository.save(new VersionedThing("Thing1"));
+
+		assertThat(thing.getMyVersion()).isEqualTo(0L);
+
+		thing = repository.save(thing);
+
+		assertThat(thing.getMyVersion()).isEqualTo(1L);
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForMultipleSave() {
+		VersionedThing thing1 = new VersionedThing("Thing1");
+		VersionedThing thing2 = new VersionedThing("Thing2");
+		List<VersionedThing> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThing> versionedThings = repository.saveAll(thingsToSave);
+
+		assertThat(versionedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(0L));
+
+		versionedThings = repository.saveAll(versionedThings);
+
+		assertThat(versionedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(1L));
+
+	}
+
+	@Test
+	void shouldIncrementVersionsOnRelatedEntities() {
+		VersionedThing parentThing = new VersionedThing("Thing1");
+		VersionedThing childThing = new VersionedThing("Thing2");
+
+		parentThing.setOtherVersionedThings(singletonList(childThing));
+
+		VersionedThing thing = repository.save(parentThing);
+
+		assertThat(thing.getOtherVersionedThings().get(0).getMyVersion()).isEqualTo(0L);
+
+		thing = repository.save(thing);
+
+		assertThat(thing.getOtherVersionedThings().get(0).getMyVersion()).isEqualTo(1L);
+	}
+
+	@Test
+	void shouldFailIncrementVersions() {
+		VersionedThing thing = repository.save(new VersionedThing("Thing1"));
+
+		thing.setMyVersion(1L); // Version in DB is 0
+
+		assertThatExceptionOfType(OptimisticLockingFailureException.class).isThrownBy(() -> repository.save(thing));
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForMultipleSave() {
+		VersionedThing thing1 = new VersionedThing("Thing1");
+		VersionedThing thing2 = new VersionedThing("Thing2");
+		List<VersionedThing> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThing> versionedThings = repository.saveAll(thingsToSave);
+
+		versionedThings.get(0).setMyVersion(1L); // Version in DB is 0
+
+		assertThatExceptionOfType(OptimisticLockingFailureException.class)
+				.isThrownBy(() -> repository.saveAll(versionedThings));
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsOnRelatedEntities() {
+		VersionedThing parentThing = new VersionedThing("Thing1");
+		VersionedThing childThing = new VersionedThing("Thing2");
+		parentThing.setOtherVersionedThings(singletonList(childThing));
+
+		VersionedThing thing = repository.save(parentThing);
+
+		thing.getOtherVersionedThings().get(0).setMyVersion(1L); // Version in DB is 0
+
+		assertThatExceptionOfType(OptimisticLockingFailureException.class).isThrownBy(() -> repository.save(thing));
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing = assignedIdRepository.save(thing1);
+
+		assertThat(thing.getMyVersion()).isEqualTo(0L);
+
+		thing = assignedIdRepository.save(thing);
+
+		assertThat(thing.getMyVersion()).isEqualTo(1L);
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForMultipleSaveForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing2 = new VersionedThingWithAssignedId(42L, "Thing2");
+		List<VersionedThingWithAssignedId> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThingWithAssignedId> versionedThings = assignedIdRepository.saveAll(thingsToSave);
+
+		assertThat(versionedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(0L));
+
+		versionedThings = assignedIdRepository.saveAll(versionedThings);
+
+		assertThat(versionedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(1L));
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForAssignedIds() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing = assignedIdRepository.save(thing1);
+
+		thing.setMyVersion(1L); // Version in DB is 0
+
+		assertThatExceptionOfType(OptimisticLockingFailureException.class)
+				.isThrownBy(() -> assignedIdRepository.save(thing));
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForMultipleSaveForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing2 = new VersionedThingWithAssignedId(42L, "Thing2");
+		List<VersionedThingWithAssignedId> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThingWithAssignedId> versionedThings = assignedIdRepository.saveAll(thingsToSave);
+
+		versionedThings.get(0).setMyVersion(1L); // Version in DB is 0
+
+		assertThatExceptionOfType(OptimisticLockingFailureException.class)
+				.isThrownBy(() -> assignedIdRepository.saveAll(versionedThings));
+
+	}
+
+	public interface VersionedThingRepository extends Neo4jRepository<VersionedThing, Long> {
+
+	}
+
+	public interface VersionedThingWithAssignedIdRepository extends Neo4jRepository<VersionedThingWithAssignedId, Long> {
+
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(VersionedThing.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveOptimisticLockingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveOptimisticLockingIT.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.integration.shared.VersionedThing;
+import org.neo4j.springframework.data.integration.shared.VersionedThingWithAssignedId;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jExtension;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Gerrit Meier
+ */
+@Neo4jIntegrationTest
+class ReactiveOptimisticLockingIT {
+
+	private static Neo4jExtension.Neo4jConnectionSupport neo4jConnectionSupport;
+	@Autowired private VersionedThingRepository repository;
+	@Autowired private VersionedThingWithAssignedIdRepository assignedIdRepository;
+	@Autowired private Driver driver;
+
+	@BeforeEach
+	void setup() {
+		Session session = driver.session(SessionConfig.defaultConfig());
+		Transaction transaction = session.beginTransaction();
+		transaction.run("MATCH (n) detach delete n");
+		transaction.commit();
+		session.close();
+	}
+
+	@Test
+	void shouldIncrementVersions() {
+
+		// would love to verify version change null -> 0 and 0 -> 1 within one test
+		VersionedThing thing1 = repository.save(new VersionedThing("Thing1")).block();
+		StepVerifier.create(repository.save(thing1))
+			.assertNext(versionedThing -> assertThat(versionedThing.getMyVersion()).isEqualTo(1L))
+			.verifyComplete();
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForMultipleSave() {
+		VersionedThing thing1 = new VersionedThing("Thing1");
+		VersionedThing thing2 = new VersionedThing("Thing2");
+		List<VersionedThing> thingsToSave = Arrays.asList(thing1, thing2);
+
+		StepVerifier.create(repository.saveAll(thingsToSave))
+			.recordWith(ArrayList::new)
+			.expectNextCount(2)
+			.consumeRecordedWith(versionedThings ->
+				assertThat(versionedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(0L)))
+			.verifyComplete();
+
+	}
+
+	@Test
+	void shouldIncrementVersionsOnRelatedEntities() {
+		VersionedThing parentThing = new VersionedThing("Thing1");
+		VersionedThing childThing = new VersionedThing("Thing2");
+
+		parentThing.setOtherVersionedThings(singletonList(childThing));
+
+		StepVerifier.create(repository.save(parentThing))
+			.assertNext(versionedThing ->
+				assertThat(versionedThing.getOtherVersionedThings().get(0).getMyVersion()).isEqualTo(0L))
+			.verifyComplete();
+	}
+
+	@Test
+	void shouldFailIncrementVersions() {
+		VersionedThing thing = repository.save(new VersionedThing("Thing1")).block();
+		thing.setMyVersion(1L); // Version in DB is 0
+
+		StepVerifier.create(repository.save(thing))
+			.expectError(OptimisticLockingFailureException.class)
+			.verify();
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForMultipleSave() {
+		VersionedThing thing1 = new VersionedThing("Thing1");
+		VersionedThing thing2 = new VersionedThing("Thing2");
+
+		List<VersionedThing> things = Arrays.asList(thing1, thing2);
+		List<VersionedThing> savedThings = repository.saveAll(things).collectList().block();
+
+		savedThings.get(1).setMyVersion(1L); // Version in DB is 0
+
+		StepVerifier.create(repository.saveAll(savedThings))
+			.expectError(OptimisticLockingFailureException.class)
+			.verify();
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsOnRelatedEntities() {
+		VersionedThing thing = new VersionedThing("Thing1");
+		VersionedThing childThing = new VersionedThing("Thing2");
+		thing.setOtherVersionedThings(singletonList(childThing));
+		VersionedThing savedThing = repository.save(thing).block();
+		savedThing.getOtherVersionedThings().get(0).setMyVersion(1L); // Version in DB is 0
+
+		StepVerifier.create(repository.save(savedThing))
+			.expectError(OptimisticLockingFailureException.class)
+			.verify();
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing = assignedIdRepository.save(thing1).block();
+
+		assertThat(thing.getMyVersion()).isEqualTo(0L);
+
+		StepVerifier.create(assignedIdRepository.save(thing))
+			.assertNext(savedThing -> assertThat(savedThing.getMyVersion()).isEqualTo(1L))
+			.verifyComplete();
+
+	}
+
+	@Test
+	void shouldIncrementVersionsForMultipleSaveForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing2 = new VersionedThingWithAssignedId(42L, "Thing2");
+		List<VersionedThingWithAssignedId> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThingWithAssignedId> versionedThings = assignedIdRepository.saveAll(thingsToSave).collectList().block();
+
+		StepVerifier.create(assignedIdRepository.saveAll(versionedThings))
+			.recordWith(ArrayList::new)
+			.expectNextCount(2)
+			.consumeRecordedWith(savedThings ->
+				assertThat(savedThings).allMatch(versionedThing -> versionedThing.getMyVersion().equals(1L)))
+			.verifyComplete();
+
+
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForAssignedIds() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing = assignedIdRepository.save(thing1).block();
+
+		thing.setMyVersion(1L); // Version in DB is 0
+
+		StepVerifier.create(assignedIdRepository.save(thing))
+			.expectError(OptimisticLockingFailureException.class)
+			.verify();
+
+	}
+
+	@Test
+	void shouldFailIncrementVersionsForMultipleSaveForAssignedId() {
+		VersionedThingWithAssignedId thing1 = new VersionedThingWithAssignedId(4711L, "Thing1");
+		VersionedThingWithAssignedId thing2 = new VersionedThingWithAssignedId(42L, "Thing2");
+		List<VersionedThingWithAssignedId> thingsToSave = Arrays.asList(thing1, thing2);
+
+		List<VersionedThingWithAssignedId> versionedThings = assignedIdRepository.saveAll(thingsToSave).collectList().block();
+
+		versionedThings.get(0).setMyVersion(1L); // Version in DB is 0
+
+		StepVerifier.create(assignedIdRepository.saveAll(versionedThings))
+			.expectError(OptimisticLockingFailureException.class)
+			.verify();
+
+	}
+
+	public interface VersionedThingRepository extends ReactiveNeo4jRepository<VersionedThing, Long> {
+
+	}
+
+	public interface VersionedThingWithAssignedIdRepository extends ReactiveNeo4jRepository<VersionedThingWithAssignedId, Long> {
+
+	}
+
+	@Configuration
+	@EnableTransactionManagement
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(VersionedThing.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/VersionedThing.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/VersionedThing.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.List;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.neo4j.springframework.data.core.schema.Relationship;
+import org.springframework.data.annotation.Version;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class VersionedThing {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Version
+	private Long myVersion;
+
+	private final String name;
+
+	@Relationship("HAS")
+	private List<VersionedThing> otherVersionedThings;
+
+	public VersionedThing(String name) {
+		this.name = name;
+	}
+
+	public Long getMyVersion() {
+		return myVersion;
+	}
+
+	public void setMyVersion(Long myVersion) {
+		this.myVersion = myVersion;
+	}
+
+	public List<VersionedThing> getOtherVersionedThings() {
+		return otherVersionedThings;
+	}
+
+	public void setOtherVersionedThings(
+		List<VersionedThing> otherVersionedThings) {
+		this.otherVersionedThings = otherVersionedThings;
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/VersionedThingWithAssignedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/VersionedThingWithAssignedId.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.List;
+
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.neo4j.springframework.data.core.schema.Relationship;
+import org.springframework.data.annotation.Version;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node
+public class VersionedThingWithAssignedId {
+
+	@Id
+	private final Long id;
+
+	@Version
+	private Long myVersion;
+
+	private final String name;
+
+	@Relationship("HAS")
+	private List<VersionedThingWithAssignedId> otherVersionedThings;
+
+	public VersionedThingWithAssignedId(Long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Long getMyVersion() {
+		return myVersion;
+	}
+
+	public void setMyVersion(Long myVersion) {
+		this.myVersion = myVersion;
+	}
+
+	public List<VersionedThingWithAssignedId> getOtherVersionedThings() {
+		return otherVersionedThings;
+	}
+
+	public void setOtherVersionedThings(
+		List<VersionedThingWithAssignedId> otherVersionedThings) {
+		this.otherVersionedThings = otherVersionedThings;
+	}
+}


### PR DESCRIPTION
The version will get increased before the entities get persisted. This could lead to the situation that a failed save/update that ends in a `OptimisticLockingFailureException` already changed the entity.
For a clean implementation this was the downside I accepted to take.

There is still some (clean-up) work left to be done if we consider this as the way to go. Because of that I marked this PR as a draft for now.

Closes #87 