### PR TITLE
Base relationship depth limiting on self-references/loops

### DIFF
--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DeepRelationshipRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DeepRelationshipRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import org.neo4j.springframework.data.integration.shared.DeepRelationships;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+
+/**
+ * @author Gerrit Meier
+ */
+public interface DeepRelationshipRepository extends Neo4jRepository<DeepRelationships.Type1, Long> {
+}
+interface LoopingRelationshipRepository extends Neo4jRepository<DeepRelationships.LoopingType1, Long> {
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDeepRelationshipRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDeepRelationshipRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import org.neo4j.springframework.data.integration.shared.DeepRelationships;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
+
+/**
+ * @author Gerrit Meier
+ */
+public interface ReactiveDeepRelationshipRepository extends ReactiveNeo4jRepository<DeepRelationships.Type1, Long> {
+}
+interface ReactiveLoopingRelationshipRepository extends ReactiveNeo4jRepository<DeepRelationships.LoopingType1, Long> {
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -281,6 +281,80 @@ class ReactiveRepositoryIT {
 	}
 
 	@Test
+	void loadDeepRelationships(@Autowired ReactiveDeepRelationshipRepository deepRelationshipRepository) {
+
+		long type1Id;
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Record record = session
+				.run("CREATE "
+					+ "(t1:Type1)-[:NEXT_TYPE]->(t2:Type2)-[:NEXT_TYPE]->(:Type3)-[:NEXT_TYPE]->(t4:Type4)-"
+					+ "[:NEXT_TYPE]->(:Type5)-[:NEXT_TYPE]->(:Type6)-[:NEXT_TYPE]->(:Type7), "
+					+ "(t2)-[:SAME_TYPE]->"
+					+ "(:Type2)-[:SAME_TYPE]->(:Type2)-[:SAME_TYPE]->(:Type2)-[:SAME_TYPE]->"
+					+ "(:Type2)-[:SAME_TYPE]->(:Type2)-[:SAME_TYPE]->(:Type2)-[:SAME_TYPE]->"
+					+ "(:Type2) "
+					+ "RETURN t1").single();
+
+			type1Id = record.get("t1").asNode().id();
+		}
+
+		StepVerifier.create(deepRelationshipRepository.findById(type1Id))
+			.assertNext(type1 -> {
+				// ensures that the virtual limit for same relationships does not affect distinct relationships
+				assertThat(type1.nextType.nextType.nextType.nextType.nextType.nextType).isNotNull();
+
+				// check the magical virtual limit of 5 of same type relationships
+				DeepRelationships.Type2 type2 = type1.nextType;
+				assertThat(type2.sameType.sameType.sameType.sameType.sameType).isNotNull();
+				assertThat(type2.sameType.sameType.sameType.sameType.sameType.sameType).isNull();
+			})
+			.verifyComplete();
+
+	}
+
+	@Test
+	void loadLoopingDeepRelationships(@Autowired ReactiveLoopingRelationshipRepository loopingRelationshipRepository) {
+
+		long type1Id;
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Record record = session
+				.run("CREATE "
+					+ "(t1:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)-[:NEXT_TYPE]->(:LoopingType2)-[:NEXT_TYPE]->(:LoopingType3)-[:NEXT_TYPE]->"
+					+ "(:LoopingType1)"
+					+ "RETURN t1").single();
+
+			type1Id = record.get("t1").asNode().id();
+		}
+
+		StepVerifier.create(loopingRelationshipRepository.findById(type1Id))
+			.assertNext(type1 -> {
+				DeepRelationships.LoopingType1 iteration1 = type1.nextType.nextType.nextType;
+				assertThat(iteration1).isNotNull();
+				DeepRelationships.LoopingType1 iteration2 = iteration1.nextType.nextType.nextType;
+				assertThat(iteration2).isNotNull();
+				DeepRelationships.LoopingType1 iteration3 = iteration2.nextType.nextType.nextType;
+				assertThat(iteration3).isNotNull();
+				DeepRelationships.LoopingType1 iteration4 = iteration3.nextType.nextType.nextType;
+				assertThat(iteration4).isNotNull();
+				DeepRelationships.LoopingType1 iteration5 = iteration4.nextType.nextType.nextType;
+				assertThat(iteration5).isNotNull();
+				assertThat(iteration5.nextType).isNull();
+			})
+			.verifyComplete();
+	}
+
+	@Test
 	void findWithPageable() {
 		Sort sort = Sort.by("name");
 		int page = 0;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DeepRelationships.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DeepRelationships.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * @author Gerrit Meier
+ */
+public class DeepRelationships {
+
+	// Straight forward Type1 - Type7 with a self-reference in Type2
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type1 {
+		public Type2 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type2 {
+		public Type3 nextType;
+		public Type2 sameType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type3 {
+		public Type4 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type4 {
+		public Type5 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type5 {
+		public Type6 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type6 {
+		public Type7 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class Type7 {
+
+		@Id @GeneratedValue private Long id;
+	}
+
+	// Let's build a looped chain here:
+	// Type1->Type2->Type3->Type1->...
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class LoopingType1 {
+		public LoopingType2 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class LoopingType2 {
+		public LoopingType3 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+	/**
+	 * Some type
+	 */
+	@Node
+	public static class LoopingType3 {
+		public LoopingType1 nextType;
+		@Id @GeneratedValue private Long id;
+	}
+}


### PR DESCRIPTION
This PR does lower the restriction on the depth of relationships for graphs without self-references or relationship loops created via multiple hops.
In such cases there will still be a virtual limit of 5 repetitions until the Cypher creation algorithm stops and won't go any further.

closes #57 