### PR TITLE
Add template methods to allow String based Cypher queries

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jOperations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jOperations.java
@@ -45,7 +45,39 @@ public interface Neo4jOperations {
 	 */
 	long count(Class<?> domainType);
 
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param statement the Cypher {@link Statement} that returns the count.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	long count(Statement statement);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param statement  the Cypher {@link Statement} that returns the count.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
 	long count(Statement statement, Map<String, Object> parameters);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param cypherQuery the Cypher query that returns the count.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	long count(String cypherQuery);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param cypherQuery the Cypher query that returns the count.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	long count(String cypherQuery, Map<String, Object> parameters);
 
 	/**
 	 * Load all entities of a given type.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jOperations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jOperations.java
@@ -56,11 +56,69 @@ public interface Neo4jOperations {
 	 */
 	<T> List<T> findAll(Class<T> domainType);
 
+	/**
+	 * Load all entities of a given type by executing given statement.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> List<T> findAll(Statement statement, Class<T> domainType);
 
+	/**
+	 * Load all entities of a given type by executing given statement with parameters.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> List<T> findAll(Statement statement, Map<String, Object> parameters, Class<T> domainType);
 
+	/**
+	 * Load one entity of a given type by executing given statement with parameters.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> Optional<T> findOne(Statement statement, Map<String, Object> parameters, Class<T> domainType);
+
+	/**
+	 * Load all entities of a given type by executing given statement.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> List<T> findAll(String cypherQuery, Class<T> domainType);
+
+	/**
+	 * Load all entities of a given type by executing given statement with parameters.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param parameters       Map of parameters. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> List<T> findAll(String cypherQuery, Map<String, Object> parameters, Class<T> domainType);
+
+	/**
+	 * Load one entity of a given type by executing given statement with parameters.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param parameters       Map of parameters. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Optional<T> findOne(String cypherQuery, Map<String, Object> parameters, Class<T> domainType);
 
 	/**
 	 * Load an entity from the database.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -115,18 +115,29 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		Statement statement = cypherGenerator.prepareMatchOf(entityMetaData)
 			.returning(Functions.count(asterisk())).build();
 
-		PreparedQuery<Long> preparedQuery = PreparedQuery.queryFor(Long.class)
-			.withCypherQuery(renderer.render(statement))
-			.build();
-		return toExecutableQuery(preparedQuery)
-			.getRequiredSingleResult();
+		return count(statement);
+	}
+
+	@Override
+	public long count(Statement statement) {
+		return count(statement, emptyMap());
 	}
 
 	@Override
 	public long count(Statement statement, Map<String, Object> parameters) {
+		return count(renderer.render(statement), parameters);
+	}
+
+	@Override
+	public long count(String cypherQuery) {
+		return count(cypherQuery, emptyMap());
+	}
+
+	@Override
+	public long count(String cypherQuery, Map<String, Object> parameters) {
 
 		PreparedQuery<Long> preparedQuery = PreparedQuery.queryFor(Long.class)
-			.withCypherQuery(renderer.render(statement))
+			.withCypherQuery(cypherQuery)
 			.withParameters(parameters)
 			.build();
 		return toExecutableQuery(preparedQuery).getRequiredSingleResult();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
@@ -55,11 +55,69 @@ public interface ReactiveNeo4jOperations {
 	 */
 	<T> Flux<T> findAll(Class<T> domainType);
 
+	/**
+	 * Load all entities of a given type by executing given statement.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> Flux<T> findAll(Statement statement, Class<T> domainType);
 
+	/**
+	 * Load all entities of a given type by executing given statement with parameters.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> Flux<T> findAll(Statement statement, Map<String, Object> parameters, Class<T> domainType);
 
+	/**
+	 * Load one entity of a given type by executing given statement with parameters.
+	 *
+	 * @param statement  Cypher {@link Statement}. Must not be {@code null}.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @param domainType the type of the entities. Must not be {@code null}.
+	 * @param <T>        the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
 	<T> Mono<T> findOne(Statement statement, Map<String, Object> parameters, Class<T> domainType);
+
+	/**
+	 * Load all entities of a given type by executing given statement.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Flux<T> findAll(String cypherQuery, Class<T> domainType);
+
+	/**
+	 * Load all entities of a given type by executing given statement with parameters.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param parameters       Map of parameters. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Flux<T> findAll(String cypherQuery, Map<String, Object> parameters, Class<T> domainType);
+
+	/**
+	 * Load one entity of a given type by executing given statement with parameters.
+	 *
+	 * @param cypherQuery  Cypher query string. Must not be {@code null}.
+	 * @param parameters       Map of parameters. Must not be {@code null}.
+	 * @param domainType       the type of the entities. Must not be {@code null}.
+	 * @param <T>              the type of the entities. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Mono<T> findOne(String cypherQuery, Map<String, Object> parameters, Class<T> domainType);
 
 	/**
 	 * Load an entity from the database.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jOperations.java
@@ -44,7 +44,39 @@ public interface ReactiveNeo4jOperations {
 	 */
 	Mono<Long> count(Class<?> domainType);
 
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param statement the Cypher {@link Statement} that returns the count.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	Mono<Long> count(Statement statement);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param statement  the Cypher {@link Statement} that returns the count.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
 	Mono<Long> count(Statement statement, Map<String, Object> parameters);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param cypherQuery the Cypher query that returns the count.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	Mono<Long> count(String cypherQuery);
+
+	/**
+	 * Counts the number of entities of a given type.
+	 *
+	 * @param cypherQuery the Cypher query that returns the count.
+	 * @param parameters Map of parameters. Must not be {@code null}.
+	 * @return the number of instances stored in the database. Guaranteed to be not {@code null}.
+	 */
+	Mono<Long> count(String cypherQuery, Map<String, Object> parameters);
 
 	/**
 	 * Load all entities of a given type.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -114,17 +114,28 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		Statement statement = statementBuilder.prepareMatchOf(entityMetaData)
 			.returning(Functions.count(asterisk())).build();
 
-		PreparedQuery<Long> preparedQuery = PreparedQuery.queryFor(Long.class)
-			.withCypherQuery(renderer.render(statement))
-			.build();
-		return this.toExecutableQuery(preparedQuery).flatMap(ExecutableQuery::getSingleResult);
+		return count(statement);
+	}
+
+	@Override
+	public Mono<Long> count(Statement statement) {
+		return count(statement, emptyMap());
 	}
 
 	@Override
 	public Mono<Long> count(Statement statement, Map<String, Object> parameters) {
+		return count(renderer.render(statement), parameters);
+	}
 
+	@Override
+	public Mono<Long> count(String cypherQuery) {
+		return count(cypherQuery, emptyMap());
+	}
+
+	@Override
+	public Mono<Long> count(String cypherQuery, Map<String, Object> parameters) {
 		PreparedQuery<Long> preparedQuery = PreparedQuery.queryFor(Long.class)
-			.withCypherQuery(renderer.render(statement))
+			.withCypherQuery(cypherQuery)
 			.withParameters(parameters)
 			.build();
 		return this.toExecutableQuery(preparedQuery).flatMap(ExecutableQuery::getSingleResult);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/Neo4jOperationsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/Neo4jOperationsIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.core.Neo4jOperations;
+import org.neo4j.springframework.data.core.cypher.Cypher;
+import org.neo4j.springframework.data.core.cypher.Functions;
+import org.neo4j.springframework.data.core.cypher.Node;
+import org.neo4j.springframework.data.core.cypher.Statement;
+import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jExtension.Neo4jConnectionSupport;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Gerrit Meier
+ */
+@Neo4jIntegrationTest
+class Neo4jOperationsIT {
+	private static final String TEST_PERSON1_NAME = "Test";
+	private static final String TEST_PERSON2_NAME = "Test2";
+
+	protected static Neo4jConnectionSupport neo4jConnectionSupport;
+
+	@Autowired private Neo4jOperations neo4jOperations;
+	@Autowired private Driver driver;
+	private Long person1Id;
+	private Long person2Id;
+
+	/**
+	 * Shall be configured by test making use of database selection, so that the verification queries run in the correct database.
+	 *
+	 * @return The session config used for verification methods.
+	 */
+	SessionConfig getSessionConfig() {
+
+		return SessionConfig.defaultConfig();
+	}
+
+	@BeforeEach
+	void setupData() {
+
+		Transaction transaction = driver.session(getSessionConfig()).beginTransaction();
+		transaction.run("MATCH (n) detach delete n");
+
+		person1Id = transaction.run("CREATE (n:PersonWithAllConstructor) SET n.name = $name RETURN id(n)",
+			Values.parameters("name", TEST_PERSON1_NAME)
+		).next().get(0).asLong();
+		person2Id = transaction.run("CREATE (n:PersonWithAllConstructor) SET n.name = $name RETURN id(n)",
+			Values.parameters("name", TEST_PERSON2_NAME)
+		).next().get(0).asLong();
+
+		transaction.commit();
+		transaction.close();
+	}
+
+	@Test
+	void count() {
+		assertThat(neo4jOperations.count(PersonWithAllConstructor.class)).isEqualTo(2);
+	}
+
+	@Test
+	void countWithStatement() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node).returning(Functions.count(node)).build();
+
+		assertThat(neo4jOperations.count(statement, emptyMap())).isEqualTo(2);
+	}
+
+	@Test
+	void findAll() {
+		List<PersonWithAllConstructor> people = neo4jOperations.findAll(PersonWithAllConstructor.class);
+		assertThat(people).hasSize(2);
+	}
+
+	@Test
+	void findAllWithStatement() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node).returning(node).build();
+
+		List<PersonWithAllConstructor> people = neo4jOperations.findAll(statement, PersonWithAllConstructor.class);
+		assertThat(people).hasSize(2);
+	}
+
+	@Test
+	void findAllWithStatementAndParameters() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node)
+			.where(node.property("name").isEqualTo(Cypher.parameter("name")))
+			.returning(node).build();
+
+		List<PersonWithAllConstructor> people = neo4jOperations.findAll(statement,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class);
+
+		assertThat(people).hasSize(1);
+	}
+
+	@Test
+	void findOneWithStatementAndParameters() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node)
+			.where(node.property("name").isEqualTo(Cypher.parameter("name")))
+			.returning(node).build();
+
+		Optional<PersonWithAllConstructor> person = neo4jOperations.findOne(statement,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class);
+
+		assertThat(person).isPresent();
+	}
+
+	@Test
+	void findAllWithCypherQuery() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) return p";
+
+		List<PersonWithAllConstructor> people = neo4jOperations.findAll(cypherQuery, PersonWithAllConstructor.class);
+		assertThat(people).hasSize(2);
+	}
+
+	@Test
+	void findAllWithCypherQueryAndParameters() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
+
+		List<PersonWithAllConstructor> people = neo4jOperations.findAll(cypherQuery,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class);
+
+		assertThat(people).hasSize(1);
+	}
+
+	@Test
+	void findOneWithCypherQueryAndParameters() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
+
+		Optional<PersonWithAllConstructor> person = neo4jOperations.findOne(cypherQuery,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class);
+
+		assertThat(person).isPresent();
+	}
+
+	@Test
+	void findById() {
+		Optional<PersonWithAllConstructor> person = neo4jOperations.findById(person1Id, PersonWithAllConstructor.class);
+
+		assertThat(person).isPresent();
+	}
+
+	@Test
+	void findAllById() {
+		List<PersonWithAllConstructor> people = neo4jOperations.findAllById(Arrays.asList(person1Id, person2Id),
+			PersonWithAllConstructor.class);
+
+		assertThat(people).hasSize(2);
+	}
+
+	@Test
+	void save() {
+		ThingWithGeneratedId testThing = neo4jOperations.save(new ThingWithGeneratedId("testThing"));
+
+		assertThat(testThing.getTheId()).isNotNull();
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (t:ThingWithGeneratedId{name: 'testThing'}) return t");
+			Value resultValue = result.single().get("t");
+			assertThat(resultValue).isNotNull();
+			assertThat(resultValue.asMap().get("name")).isEqualTo("testThing");
+		}
+	}
+
+	@Test
+	void saveAll() {
+		String thing1Name = "testThing1";
+		String thing2Name = "testThing2";
+		ThingWithGeneratedId thing1 = new ThingWithGeneratedId(thing1Name);
+		ThingWithGeneratedId thing2 = new ThingWithGeneratedId(thing2Name);
+		List<ThingWithGeneratedId> savedThings = neo4jOperations.saveAll(Arrays.asList(thing1, thing2));
+
+		assertThat(savedThings).hasSize(2);
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Map<String, Object> paramMap = new HashMap<>();
+			paramMap.put("name1", thing1Name);
+			paramMap.put("name2", thing2Name);
+
+			Result result = session.run(
+				"MATCH (t:ThingWithGeneratedId) WHERE t.name = $name1 or t.name = $name2 return t",
+				paramMap);
+			List<Record> resultValues = result.list();
+			assertThat(resultValues).hasSize(2);
+			assertThat(resultValues).allMatch(record ->
+				record.asMap(Function.identity()).get("t").get("name").asString().startsWith("testThing"));
+		}
+	}
+
+	@Test
+	void deleteById() {
+		neo4jOperations.deleteById(person1Id, PersonWithAllConstructor.class);
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (p:PersonWithAllConstructor) return count(p) as count");
+			assertThat(result.single().get("count").asLong()).isEqualTo(1);
+		}
+	}
+
+	@Test
+	void deleteAllById() {
+		neo4jOperations.deleteAllById(Arrays.asList(person1Id, person2Id), PersonWithAllConstructor.class);
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (p:PersonWithAllConstructor) return count(p) as count");
+			assertThat(result.single().get("count").asLong()).isEqualTo(0);
+		}
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(PersonWithAllConstructor.class.getPackage().getName());
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/Neo4jOperationsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/Neo4jOperationsIT.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +107,31 @@ class Neo4jOperationsIT {
 		Node node = Cypher.node("PersonWithAllConstructor").named("n");
 		Statement statement = Cypher.match(node).returning(Functions.count(node)).build();
 
-		assertThat(neo4jOperations.count(statement, emptyMap())).isEqualTo(2);
+		assertThat(neo4jOperations.count(statement)).isEqualTo(2);
+	}
+
+	@Test
+	void countWithStatementAndParameters() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node)
+			.where(node.property("name").isEqualTo(Cypher.parameter("name")))
+			.returning(Functions.count(node)).build();
+
+		assertThat(neo4jOperations.count(statement, singletonMap("name", TEST_PERSON1_NAME))).isEqualTo(1);
+	}
+
+	@Test
+	void countWithCypherQuery() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) return count(p)";
+
+		assertThat(neo4jOperations.count(cypherQuery)).isEqualTo(2);
+	}
+
+	@Test
+	void countWithCypherQueryAndParameters() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return count(p)";
+
+		assertThat(neo4jOperations.count(cypherQuery, singletonMap("name", TEST_PERSON1_NAME))).isEqualTo(1);
 	}
 
 	@Test
@@ -134,7 +157,7 @@ class Neo4jOperationsIT {
 			.returning(node).build();
 
 		List<PersonWithAllConstructor> people = neo4jOperations.findAll(statement,
-			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			singletonMap("name", TEST_PERSON1_NAME),
 			PersonWithAllConstructor.class);
 
 		assertThat(people).hasSize(1);
@@ -148,7 +171,7 @@ class Neo4jOperationsIT {
 			.returning(node).build();
 
 		Optional<PersonWithAllConstructor> person = neo4jOperations.findOne(statement,
-			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			singletonMap("name", TEST_PERSON1_NAME),
 			PersonWithAllConstructor.class);
 
 		assertThat(person).isPresent();
@@ -167,7 +190,7 @@ class Neo4jOperationsIT {
 		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
 
 		List<PersonWithAllConstructor> people = neo4jOperations.findAll(cypherQuery,
-			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			singletonMap("name", TEST_PERSON1_NAME),
 			PersonWithAllConstructor.class);
 
 		assertThat(people).hasSize(1);
@@ -178,7 +201,7 @@ class Neo4jOperationsIT {
 		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
 
 		Optional<PersonWithAllConstructor> person = neo4jOperations.findOne(cypherQuery,
-			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			singletonMap("name", TEST_PERSON1_NAME),
 			PersonWithAllConstructor.class);
 
 		assertThat(person).isPresent();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveNeo4jOperationsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveNeo4jOperationsIT.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.reactive;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.neo4j.springframework.data.test.Neo4jExtension.*;
+
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
+import org.neo4j.springframework.data.core.cypher.Cypher;
+import org.neo4j.springframework.data.core.cypher.Functions;
+import org.neo4j.springframework.data.core.cypher.Node;
+import org.neo4j.springframework.data.core.cypher.Statement;
+import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+import org.neo4j.springframework.data.test.Neo4jExtension.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Gerrit Meier
+ */
+@Neo4jIntegrationTest
+@Tag(NEEDS_REACTIVE_SUPPORT)
+class ReactiveNeo4jOperationsIT {
+	private static final String TEST_PERSON1_NAME = "Test";
+	private static final String TEST_PERSON2_NAME = "Test2";
+
+	protected static Neo4jConnectionSupport neo4jConnectionSupport;
+
+	@Autowired private ReactiveNeo4jOperations neo4jOperations;
+	@Autowired private Driver driver;
+	private Long person1Id;
+	private Long person2Id;
+
+	/**
+	 * Shall be configured by test making use of database selection, so that the verification queries run in the correct database.
+	 *
+	 * @return The session config used for verification methods.
+	 */
+	SessionConfig getSessionConfig() {
+
+		return SessionConfig.defaultConfig();
+	}
+
+	@BeforeEach
+	void setupData() {
+
+		Transaction transaction = driver.session(getSessionConfig()).beginTransaction();
+		transaction.run("MATCH (n) detach delete n");
+
+		person1Id = transaction.run("CREATE (n:PersonWithAllConstructor) SET n.name = $name RETURN id(n)",
+			Values.parameters("name", TEST_PERSON1_NAME)
+		).next().get(0).asLong();
+		person2Id = transaction.run("CREATE (n:PersonWithAllConstructor) SET n.name = $name RETURN id(n)",
+			Values.parameters("name", TEST_PERSON2_NAME)
+		).next().get(0).asLong();
+
+		transaction.commit();
+		transaction.close();
+	}
+
+	@Test
+	void count() {
+		StepVerifier.create(neo4jOperations.count(PersonWithAllConstructor.class))
+			.assertNext(count -> assertThat(count).isEqualTo(2))
+			.verifyComplete();
+	}
+
+	@Test
+	void countWithStatement() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node).returning(Functions.count(node)).build();
+
+		StepVerifier.create(neo4jOperations.count(statement, emptyMap()))
+			.assertNext(count -> assertThat(count).isEqualTo(2))
+			.verifyComplete();
+	}
+
+	@Test
+	void findAll() {
+		StepVerifier.create(neo4jOperations.findAll(PersonWithAllConstructor.class))
+			.expectNextCount(2)
+			.verifyComplete();
+	}
+
+	@Test
+	void findAllWithStatement() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node).returning(node).build();
+
+		StepVerifier.create(neo4jOperations.findAll(statement, PersonWithAllConstructor.class))
+			.expectNextCount(2)
+			.verifyComplete();
+	}
+
+	@Test
+	void findAllWithStatementAndParameters() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node)
+			.where(node.property("name").isEqualTo(Cypher.parameter("name")))
+			.returning(node).build();
+
+		StepVerifier.create(neo4jOperations.findAll(statement,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findOneWithStatementAndParameters() {
+		Node node = Cypher.node("PersonWithAllConstructor").named("n");
+		Statement statement = Cypher.match(node)
+			.where(node.property("name").isEqualTo(Cypher.parameter("name")))
+			.returning(node).build();
+
+		StepVerifier.create(neo4jOperations.findOne(statement,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findAllWithCypherQuery() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) return p";
+
+		StepVerifier.create(neo4jOperations.findAll(cypherQuery, PersonWithAllConstructor.class))
+			.expectNextCount(2)
+			.verifyComplete();
+	}
+
+	@Test
+	void findAllWithCypherQueryAndParameters() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
+
+		StepVerifier.create(neo4jOperations.findAll(cypherQuery,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findOneWithCypherQueryAndParameters() {
+		String cypherQuery = "MATCH (p:PersonWithAllConstructor) WHERE p.name = $name return p";
+
+		StepVerifier.create(neo4jOperations.findOne(cypherQuery,
+			Collections.singletonMap("name", TEST_PERSON1_NAME),
+			PersonWithAllConstructor.class))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findById() {
+		StepVerifier.create(neo4jOperations.findById(person1Id, PersonWithAllConstructor.class))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findAllById() {
+		StepVerifier.create(neo4jOperations.findAllById(Arrays.asList(person1Id, person2Id),
+			PersonWithAllConstructor.class))
+			.expectNextCount(2)
+			.verifyComplete();
+	}
+
+	@Test
+	void save() {
+		StepVerifier.create(neo4jOperations.save(new ThingWithGeneratedId("testThing")))
+			.expectNextCount(1)
+			.verifyComplete();
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (t:ThingWithGeneratedId{name: 'testThing'}) return t");
+			Value resultValue = result.single().get("t");
+			assertThat(resultValue).isNotNull();
+			assertThat(resultValue.asMap().get("name")).isEqualTo("testThing");
+		}
+	}
+
+	@Test
+	void saveAll() {
+		String thing1Name = "testThing1";
+		String thing2Name = "testThing2";
+		ThingWithGeneratedId thing1 = new ThingWithGeneratedId(thing1Name);
+		ThingWithGeneratedId thing2 = new ThingWithGeneratedId(thing2Name);
+
+		StepVerifier.create(neo4jOperations.saveAll(Arrays.asList(thing1, thing2)))
+			.expectNextCount(2)
+			.verifyComplete();
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Map<String, Object> paramMap = new HashMap<>();
+			paramMap.put("name1", thing1Name);
+			paramMap.put("name2", thing2Name);
+
+			Result result = session.run(
+				"MATCH (t:ThingWithGeneratedId) WHERE t.name = $name1 or t.name = $name2 return t",
+				paramMap);
+			List<Record> resultValues = result.list();
+			assertThat(resultValues).hasSize(2);
+			assertThat(resultValues).allMatch(record ->
+				record.asMap(Function.identity()).get("t").get("name").asString().startsWith("testThing"));
+		}
+	}
+
+	@Test
+	void deleteById() {
+		StepVerifier.create(neo4jOperations.deleteById(person1Id, PersonWithAllConstructor.class))
+			.verifyComplete();
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (p:PersonWithAllConstructor) return count(p) as count");
+			assertThat(result.single().get("count").asLong()).isEqualTo(1);
+		}
+	}
+
+	@Test
+	void deleteAllById() {
+		StepVerifier
+			.create(neo4jOperations.deleteAllById(Arrays.asList(person1Id, person2Id), PersonWithAllConstructor.class))
+			.verifyComplete();
+
+		try (Session session = driver.session(getSessionConfig())) {
+			Result result = session.run("MATCH (p:PersonWithAllConstructor) return count(p) as count");
+			assertThat(result.single().get("count").asLong()).isEqualTo(0);
+		}
+	}
+
+	@Configuration
+	@EnableReactiveNeo4jRepositories(considerNestedRepositories = true)
+	@EnableTransactionManagement
+	static class Config extends AbstractReactiveNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		@Override
+		protected Collection<String> getMappingBasePackages() {
+			return singletonList(PersonWithAllConstructor.class.getPackage().getName());
+		}
+	}
+}


### PR DESCRIPTION
Overload `findAll` and `findOne` methods with a `String` in contrast to the already existing `Statement`.
This PR also adds integration tests for the `(Reactive)Neo4jOperations/Template`.

closes #142 
closes #115