### PR TITLE
Convert repository method parameters.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/convert/Neo4jConverter.java
@@ -58,7 +58,6 @@ public interface Neo4jConverter extends EntityReader<Object, Record>, EntityWrit
 	 * @param type  The type information describing the target type.
 	 * @return A driver compatible value object.
 	 */
-	@Nullable
 	Value writeValueFromProperty(@Nullable Object value, TypeInformation<?> type);
 
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
@@ -41,6 +41,7 @@ import org.springframework.data.geo.Metrics;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
+import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.util.Assert;
 
 /**
@@ -144,8 +145,8 @@ abstract class Neo4jQuerySupport {
 		}
 
 		// Good hook to check the NodeManager whether the thing is an entity and we replace the value with a known id.
-
-		return parameter;
+		return mappingContext.getConverter()
+			.writeValueFromProperty(parameter, ClassTypeInformation.from(parameter.getClass()));
 	}
 
 	private Map<String, Object> convertRange(Range range) {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/PersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/PersonRepository.java
@@ -32,8 +32,10 @@ import org.neo4j.springframework.data.integration.shared.PersonProjection;
 import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
 import org.neo4j.springframework.data.integration.shared.PersonWithNoConstructor;
 import org.neo4j.springframework.data.integration.shared.PersonWithWither;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.query.Query;
+import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
@@ -191,6 +193,10 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 	List<PersonWithAllConstructor> findAllByThingsIsNotEmpty();
 
 	List<PersonWithAllConstructor> findAllByNullableExists();
+
+	List<PersonWithAllConstructor> findAllByPlace(GeographicPoint2d p);
+
+	List<PersonWithAllConstructor> findAllByPlace(ThingWithGeneratedId p);
 
 	List<PersonWithAllConstructor> findAllByPlaceNear(Point p);
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -58,9 +58,11 @@ import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
 import org.neo4j.springframework.data.test.Neo4jExtension.Neo4jConnectionSupport;
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
 import org.neo4j.springframework.data.types.CartesianPoint2d;
+import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.domain.ExampleMatcher.StringMatcher;
@@ -1604,6 +1606,21 @@ class RepositoryIT {
 	void findBySimplePropertyByEqualsWithNullShouldWork() {
 		int emptyResultSize = 0;
 		assertThat(repository.findAllBySameValue(null)).hasSize(emptyResultSize);
+	}
+
+	@Test
+	void findByPropertyThatNeedsConversion() {
+		List<PersonWithAllConstructor> people = repository
+			.findAllByPlace(new GeographicPoint2d(NEO4J_HQ.y(), NEO4J_HQ.x()));
+
+		assertThat(people).hasSize(1);
+	}
+
+	@Test
+	void findByPropertyFailsIfNoConverterIsAvailable() {
+		assertThatExceptionOfType(ConverterNotFoundException.class)
+			.isThrownBy(() -> repository.findAllByPlace(new ThingWithGeneratedId("hello")))
+			.withMessageStartingWith("No converter found capable of converting from type");
 	}
 
 	@Test

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactivePersonRepository.java
@@ -24,8 +24,10 @@ import reactor.core.publisher.Mono;
 import org.neo4j.springframework.data.integration.shared.DtoPersonProjection;
 import org.neo4j.springframework.data.integration.shared.PersonProjection;
 import org.neo4j.springframework.data.integration.shared.PersonWithAllConstructor;
+import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
 import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.neo4j.springframework.data.repository.query.Query;
+import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +64,10 @@ public interface ReactivePersonRepository extends ReactiveNeo4jRepository<Person
 	Flux<DtoPersonProjection> findByFirstName(String firstName);
 
 	Flux<PersonWithAllConstructor> findByNameStartingWith(String name, Pageable pageable);
+
+	Flux<PersonWithAllConstructor> findAllByPlace(GeographicPoint2d p);
+
+	Flux<PersonWithAllConstructor> findAllByPlace(ThingWithGeneratedId p);
 
 	@Query("MATCH (n:PersonWithAllConstructor) where n.name = $name return n{.name}")
 	Mono<PersonProjection> findByNameWithCustomQueryAndMapProjection(@Param("name") String name);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -59,10 +59,12 @@ import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepos
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
 import org.neo4j.springframework.data.test.Neo4jExtension.*;
 import org.neo4j.springframework.data.types.CartesianPoint2d;
+import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.domain.PageRequest;
@@ -951,6 +953,20 @@ class ReactiveRepositoryIT {
 
 		StepVerifier.create(repository.findAllBySameValue(TEST_PERSON_SAMEVALUE)).expectNextMatches(personList::contains)
 				.expectNextMatches(personList::contains).verifyComplete();
+	}
+
+	@Test
+	void findByPropertyThatNeedsConversion() {
+		StepVerifier.create(repository.findAllByPlace(new GeographicPoint2d(NEO4J_HQ.y(), NEO4J_HQ.x())))
+			.expectNextCount(1)
+			.verifyComplete();
+	}
+
+	@Test
+	void findByPropertyFailsIfNoConverterIsAvailable() {
+		assertThatExceptionOfType(ConverterNotFoundException.class)
+			.isThrownBy(() -> repository.findAllByPlace(new ThingWithGeneratedId("hello")))
+			.withMessageStartingWith("No converter found capable of converting from type");
 	}
 
 	@Test

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/RepositoryQueryTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/RepositoryQueryTest.java
@@ -220,7 +220,6 @@ final class RepositoryQueryTest {
 		void shouldDetectInvalidAnnotation() {
 
 			Neo4jQueryMethod method = neo4jQueryMethod("annotatedQueryWithoutTemplate");
-
 			assertThatExceptionOfType(MappingException.class)
 				.isThrownBy(
 					() -> StringBasedNeo4jQuery.create(mock(Neo4jOperations.class), mock(Neo4jMappingContext.class),
@@ -234,9 +233,12 @@ final class RepositoryQueryTest {
 			Neo4jQueryMethod method = RepositoryQueryTest
 				.neo4jQueryMethod("annotatedQueryWithValidTemplate", String.class, String.class);
 
-			StringBasedNeo4jQuery repositoryQuery = StringBasedNeo4jQuery.create(mock(Neo4jOperations.class),
+			StringBasedNeo4jQuery repositoryQuery = spy(StringBasedNeo4jQuery.create(mock(Neo4jOperations.class),
 				mock(Neo4jMappingContext.class), QueryMethodEvaluationContextProvider.DEFAULT,
-				method);
+				method));
+
+			// skip conversion
+			doAnswer(invocation -> invocation.getArgument(0)).when(repositoryQuery).convertParameter(any());
 
 			Map<String, Object> resolveParameters = repositoryQuery
 				.bindParameters(new Neo4jParameterAccessor(
@@ -254,9 +256,12 @@ final class RepositoryQueryTest {
 				.neo4jQueryMethod("findByDontDoThisInRealLiveNamed", org.neo4j.driver.types.Point.class, String.class,
 					String.class);
 
-			StringBasedNeo4jQuery repositoryQuery = StringBasedNeo4jQuery.create(mock(Neo4jOperations.class),
+			StringBasedNeo4jQuery repositoryQuery = spy(StringBasedNeo4jQuery.create(mock(Neo4jOperations.class),
 				mock(Neo4jMappingContext.class), QueryMethodEvaluationContextProvider.DEFAULT,
-				method);
+				method));
+
+			// skip conversion
+			doAnswer(invocation -> invocation.getArgument(0)).when(repositoryQuery).convertParameter(any());
 
 			Point thePoint = Values.point(4223, 1, 2).asPoint();
 			Map<String, Object> resolveParameters = repositoryQuery.bindParameters(


### PR DESCRIPTION
Use the conversion mechanism for all repository method parameters before handing the query and parameters over to the Java driver.

closes #139 