### PR TITLE
Provide String.asParam for Kotlin.

### DIFF
--- a/spring-data-neo4j-rx/src/main/kotlin/org/neo4j/springframework/data/core/cypher/Parameters.kt
+++ b/spring-data-neo4j-rx/src/main/kotlin/org/neo4j/springframework/data/core/cypher/Parameters.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher
+
+// A couple of extension methods that escapes $parameterNames inside multiline strings.
+// See ParameterTest.kt for an example how to use them.
+
+/**
+ * Extension on [String] returning the string itself prefixed with an escaped `$`.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+inline fun String.asParam() = "\$" + this
+
+/**
+ * Extension on [String]'s companion object returning the string passed to it prefixed with an escaped `$`.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+infix fun String.Companion.asParam(s: String) = "\$" + s

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/core/cypher/ParametersTest.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/core/cypher/ParametersTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * @author Michael J. Simons
+ */
+class ParametersTest {
+
+    @Test
+    fun `named parameters in multiline strings shouldn't be that hard`() {
+
+        """
+            MATCH (n:Something {n.name: ${"someParameter".asParam()}}
+            WHERE n.someProperty = ${String asParam "someOther"}
+        """.trimIndent().apply {
+
+            assertThat(this).isEqualTo("MATCH (n:Something {n.name: \$someParameter}\nWHERE n.someProperty = \$someOther")
+        };
+    }
+}

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/Neo4jClientKotlinInteropIT.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/Neo4jClientKotlinInteropIT.kt
@@ -27,6 +27,7 @@ import org.neo4j.driver.Driver
 import org.neo4j.driver.Values
 import org.neo4j.springframework.data.config.AbstractNeo4jConfig
 import org.neo4j.springframework.data.core.Neo4jClient
+import org.neo4j.springframework.data.core.cypher.asParam
 import org.neo4j.springframework.data.core.fetchAs
 import org.neo4j.springframework.data.core.mappedBy
 import org.neo4j.springframework.data.test.Neo4jExtension
@@ -57,15 +58,15 @@ class Neo4jClientKotlinInteropIT @Autowired constructor(
 
         driver.session().use {
             val bands = mapOf(
-                    Pair("Queen", listOf("Brian", "Roger", "John", "Freddie")),
-                    Pair("Die Ärzte", listOf("Farin", "Rod", "Bela"))
+                    "Queen" to listOf("Brian", "Roger", "John", "Freddie"),
+                    "Die Ärzte" to listOf("Farin", "Rod", "Bela")
             )
 
             bands.forEach { b, m ->
                 val summary = it.run("""
-                    CREATE (b:Band {name: ${'$'}band}) 
+                    CREATE (b:Band {name: ${"band".asParam()}}) 
                     WITH b
-                    UNWIND ${'$'}names AS name CREATE (n:Member {name: name}) <- [:HAS_MEMBER] - (b)
+                    UNWIND ${"names".asParam()} AS name CREATE (n:Member {name: name}) <- [:HAS_MEMBER] - (b)
                     """.trimIndent(), Values.parameters("band", b, "names", m)).consume()
                 assertThat(summary.counters().nodesCreated()).isGreaterThan(0)
             }

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/reactive/ReactiveNeo4jClientKotlinInteropIT.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/reactive/ReactiveNeo4jClientKotlinInteropIT.kt
@@ -32,6 +32,7 @@ import org.neo4j.driver.types.TypeSystem
 import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient
 import org.neo4j.springframework.data.core.awaitOneOrNull
+import org.neo4j.springframework.data.core.cypher.asParam
 import org.neo4j.springframework.data.core.fetchAll
 import org.neo4j.springframework.data.core.fetchAs
 import org.neo4j.springframework.data.core.mappedBy
@@ -65,15 +66,15 @@ class ReactiveNeo4jClientKotlinInteropIT @Autowired constructor(
     fun prepareData() {
         driver.session().use {
             val bands = mapOf(
-                    Pair("Queen", listOf("Brian", "Roger", "John", "Freddie")),
-                    Pair("Die Ärzte", listOf("Farin", "Rod", "Bela"))
+                    "Queen" to listOf("Brian", "Roger", "John", "Freddie"),
+                    "Die Ärzte" to listOf("Farin", "Rod", "Bela")
             )
 
             bands.forEach { b, m ->
                 val summary = it.run("""
-                    CREATE (b:Band {name: ${'$'}band}) 
+                    CREATE (b:Band {name: ${"band".asParam()}}) 
                     WITH b
-                    UNWIND ${'$'}names AS name CREATE (n:Member {name: name}) <- [:HAS_MEMBER] - (b)
+                    UNWIND ${"names".asParam()} AS name CREATE (n:Member {name: name}) <- [:HAS_MEMBER] - (b)
                     """.trimIndent(), Values.parameters("band", b, "names", m)).consume()
                 assertThat(summary.counters().nodesCreated()).isGreaterThan(0)
             }


### PR DESCRIPTION
This allows a somewhat less hard way to escape the `$` inside multiline queries (see the client interop tests for example).