### PR TITLE
Decouple default callbacks from repository configuration.

### DIFF
--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jImperativeDataConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jImperativeDataConfiguration.java
@@ -22,6 +22,7 @@ import static org.springframework.boot.autoconfigure.data.RepositoryType.*;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration;
+import org.neo4j.springframework.data.config.Neo4jDefaultCallbacksRegistrar;
 import org.neo4j.springframework.data.core.Neo4jClient;
 import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.neo4j.springframework.data.core.Neo4jOperations;
@@ -39,6 +40,7 @@ import org.springframework.boot.autoconfigure.data.ConditionalOnRepositoryType;
 import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -53,6 +55,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @ConditionalOnRepositoryType(store = "neo4j", type = IMPERATIVE)
 @AutoConfigureAfter(Neo4jDriverAutoConfiguration.class)
 @AutoConfigureBefore(Neo4jImperativeRepositoriesConfiguration.class)
+@Import(Neo4jDefaultCallbacksRegistrar.class)
 class Neo4jImperativeDataConfiguration {
 
 	@Bean("databaseSelectionProvider")

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveDataConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveDataConfiguration.java
@@ -24,8 +24,8 @@ import reactor.core.publisher.Flux;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration;
-import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
+import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
 import org.neo4j.springframework.data.core.ReactiveNeo4jTemplate;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
@@ -39,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.ConditionalOnRepositoryType;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
 import org.springframework.transaction.ReactiveTransactionManager;
 
@@ -53,6 +54,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 @ConditionalOnRepositoryType(store = "neo4j", type = REACTIVE)
 @AutoConfigureAfter(Neo4jDriverAutoConfiguration.class)
 @AutoConfigureBefore(Neo4jReactiveRepositoriesConfiguration.class)
+@Import(Neo4jReactiveDataConfiguration.class)
 class Neo4jReactiveDataConfiguration {
 
 	@Bean("reactiveDatabaseSelectionProvider")

--- a/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveDataConfiguration.java
+++ b/spring-data-neo4j-rx-spring-boot-starter-parent/spring-data-neo4j-rx-spring-boot-autoconfigure/src/main/java/org/neo4j/springframework/boot/autoconfigure/data/Neo4jReactiveDataConfiguration.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Flux;
 
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.springframework.boot.autoconfigure.Neo4jDriverAutoConfiguration;
+import org.neo4j.springframework.data.config.Neo4jDefaultReactiveCallbacksRegistrar;
 import org.neo4j.springframework.data.core.ReactiveDatabaseSelectionProvider;
 import org.neo4j.springframework.data.core.ReactiveNeo4jClient;
 import org.neo4j.springframework.data.core.ReactiveNeo4jOperations;
@@ -54,7 +55,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 @ConditionalOnRepositoryType(store = "neo4j", type = REACTIVE)
 @AutoConfigureAfter(Neo4jDriverAutoConfiguration.class)
 @AutoConfigureBefore(Neo4jReactiveRepositoriesConfiguration.class)
-@Import(Neo4jReactiveDataConfiguration.class)
+@Import(Neo4jDefaultReactiveCallbacksRegistrar.class)
 class Neo4jReactiveDataConfiguration {
 
 	@Bean("reactiveDatabaseSelectionProvider")

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractNeo4jConfig.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractNeo4jConfig.java
@@ -28,6 +28,7 @@ import org.neo4j.springframework.data.core.DatabaseSelectionProvider;
 import org.neo4j.springframework.data.repository.config.Neo4jRepositoryConfigurationExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -40,6 +41,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 @Configuration
 @API(status = API.Status.STABLE, since = "1.0")
+@Import(Neo4jDefaultCallbacksRegistrar.class)
 public abstract class AbstractNeo4jConfig extends Neo4jConfigurationSupport {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractReactiveNeo4jConfig.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/AbstractReactiveNeo4jConfig.java
@@ -28,6 +28,7 @@ import org.neo4j.springframework.data.core.transaction.ReactiveNeo4jTransactionM
 import org.neo4j.springframework.data.repository.config.ReactiveNeo4jRepositoryConfigurationExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.ReactiveTransactionManager;
 
@@ -41,6 +42,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
  */
 @Configuration
 @API(status = API.Status.STABLE, since = "1.0")
+@Import(Neo4jDefaultReactiveCallbacksRegistrar.class)
 public abstract class AbstractReactiveNeo4jConfig extends Neo4jConfigurationSupport {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jDefaultCallbacksRegistrar.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jDefaultCallbacksRegistrar.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.config;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.repository.event.IdGeneratingBeforeBindCallback;
+import org.neo4j.springframework.data.repository.event.OptimisticLockingBeforeBindCallback;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+
+/**
+ * This brings in the default callbacks required for the default implementation of {@link org.neo4j.springframework.data.core.Neo4jOperations} to work.
+ * The offered support configuration class {@link AbstractNeo4jConfig} imports this and so does the Spring Boot autoconfiguration.
+ *
+ * @author Michael J. Simons
+ * @soundtrack AC/DC - High Voltage
+ * @since 1.0
+ */
+@API(status = API.Status.STABLE, since = "1.0")
+public final class Neo4jDefaultCallbacksRegistrar implements ImportBeanDefinitionRegistrar {
+
+	@Override
+	public void registerBeanDefinitions(
+		AnnotationMetadata importingClassMetadata,
+		BeanDefinitionRegistry registry,
+		BeanNameGenerator beanNameGenerator
+	) {
+		// Id Generator
+		RootBeanDefinition beanDefinition = new RootBeanDefinition(IdGeneratingBeforeBindCallback.class);
+		beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+		registry.registerBeanDefinition(beanName, beanDefinition);
+
+		// Optimistic locking support
+		beanDefinition = new RootBeanDefinition(OptimisticLockingBeforeBindCallback.class);
+		beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+		registry.registerBeanDefinition(beanName, beanDefinition);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jDefaultReactiveCallbacksRegistrar.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/config/Neo4jDefaultReactiveCallbacksRegistrar.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.config;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.repository.event.ReactiveIdGeneratingBeforeBindCallback;
+import org.neo4j.springframework.data.repository.event.ReactiveOptimisticLockingBeforeBindCallback;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+
+/**
+ * This brings in the default callbacks required for the default implementation of {@link org.neo4j.springframework.data.core.Neo4jOperations} to work.
+ * The offered support configuration class {@link AbstractNeo4jConfig} imports this and so does the Spring Boot autoconfiguration.
+ *
+ * @author Michael J. Simons
+ * @soundtrack AC/DC - High Voltage
+ * @since 1.0
+ */
+@API(status = API.Status.STABLE, since = "1.0")
+public final class Neo4jDefaultReactiveCallbacksRegistrar implements ImportBeanDefinitionRegistrar {
+
+	@Override
+	public void registerBeanDefinitions(
+		AnnotationMetadata importingClassMetadata,
+		BeanDefinitionRegistry registry,
+		BeanNameGenerator beanNameGenerator
+	) {
+		// Id Generator
+		RootBeanDefinition beanDefinition = new RootBeanDefinition(ReactiveIdGeneratingBeforeBindCallback.class);
+		beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+		registry.registerBeanDefinition(beanName, beanDefinition);
+
+		// Optimistic locking support
+		beanDefinition = new RootBeanDefinition(ReactiveOptimisticLockingBeforeBindCallback.class);
+		beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+		registry.registerBeanDefinition(beanName, beanDefinition);
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -104,7 +104,8 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		this.neo4jClient = neo4jClient;
 		this.neo4jMappingContext = neo4jMappingContext;
 		this.cypherGenerator = CypherGenerator.INSTANCE;
-		this.eventSupport = new Neo4jEvents(null);
+		this.eventSupport = new Neo4jEvents(EntityCallbacks.create());
+
 		this.databaseSelectionProvider = databaseSelectionProvider;
 	}
 
@@ -540,18 +541,14 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 	 */
 	final class Neo4jEvents {
 
-		private final @Nullable EntityCallbacks entityCallbacks;
+		private final EntityCallbacks entityCallbacks;
 
-		Neo4jEvents(@Nullable EntityCallbacks entityCallbacks) {
+		Neo4jEvents(EntityCallbacks entityCallbacks) {
 			this.entityCallbacks = entityCallbacks;
 		}
 
 		public <T> T maybeCallBeforeBind(T object) {
-			if (entityCallbacks != null) {
-				return entityCallbacks.callback(BeforeBindCallback.class, object);
-			}
-
-			return object;
+			return entityCallbacks.callback(BeforeBindCallback.class, object);
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -103,7 +103,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		this.neo4jClient = neo4jClient;
 		this.neo4jMappingContext = neo4jMappingContext;
 		this.statementBuilder = CypherGenerator.INSTANCE;
-		this.eventSupport = new ReactiveNeo4jEvents(null);
+		this.eventSupport = new ReactiveNeo4jEvents(ReactiveEntityCallbacks.create());
 		this.databaseSelectionProvider = databaseSelectionProvider;
 	}
 
@@ -560,19 +560,14 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 	 */
 	final class ReactiveNeo4jEvents {
 
-		private final @Nullable ReactiveEntityCallbacks entityCallbacks;
+		private final ReactiveEntityCallbacks entityCallbacks;
 
-		ReactiveNeo4jEvents(@Nullable ReactiveEntityCallbacks entityCallbacks) {
+		ReactiveNeo4jEvents(ReactiveEntityCallbacks entityCallbacks) {
 			this.entityCallbacks = entityCallbacks;
 		}
 
 		<T> Mono<T> maybeCallBeforeBind(T object) {
-
-			if (entityCallbacks != null) {
-				return entityCallbacks.callback(ReactiveBeforeBindCallback.class, object);
-			}
-
-			return Mono.just(object);
+			return entityCallbacks.callback(ReactiveBeforeBindCallback.class, object);
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -25,15 +25,9 @@ import java.util.Collections;
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
-import org.neo4j.springframework.data.repository.event.IdGeneratingBeforeBindCallback;
-import org.neo4j.springframework.data.repository.event.OptimisticLockingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactoryBean;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -114,25 +108,5 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 			source.getAttribute("neo4jTemplateRef").orElse(DEFAULT_NEO4J_TEMPLATE_BEAN_NAME));
 		builder.addPropertyReference("neo4jMappingContext",
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)
-	 */
-	@Override
-	public void registerBeansForRoot(BeanDefinitionRegistry registry,
-		RepositoryConfigurationSource configurationSource) {
-
-		RootBeanDefinition idGenerationBeanDefinition = new RootBeanDefinition(IdGeneratingBeforeBindCallback.class);
-		idGenerationBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-		String idGenerationBeanName = BeanDefinitionReaderUtils.generateBeanName(idGenerationBeanDefinition, registry);
-		registry.registerBeanDefinition(idGenerationBeanName, idGenerationBeanDefinition);
-
-		RootBeanDefinition optimisticLockingBeanDefinition = new RootBeanDefinition(OptimisticLockingBeforeBindCallback.class);
-		optimisticLockingBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-		String optimisticLockingBeanName = BeanDefinitionReaderUtils.generateBeanName(optimisticLockingBeanDefinition, registry);
-		registry.registerBeanDefinition(optimisticLockingBeanName, optimisticLockingBeanDefinition);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -25,15 +25,9 @@ import java.util.Collections;
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
-import org.neo4j.springframework.data.repository.event.ReactiveIdGeneratingBeforeBindCallback;
-import org.neo4j.springframework.data.repository.event.ReactiveOptimisticLockingBeforeBindCallback;
 import org.neo4j.springframework.data.repository.support.ReactiveNeo4jRepositoryFactoryBean;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -113,28 +107,5 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 			source.getAttribute("neo4jTemplateRef").orElse(DEFAULT_NEO4J_TEMPLATE_BEAN_NAME));
 		builder.addPropertyReference("neo4jMappingContext",
 			source.getAttribute("neo4jMappingContextRef").orElse(DEFAULT_MAPPING_CONTEXT_BEAN_NAME));
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#registerBeansForRoot(org.springframework.beans.factory.support.BeanDefinitionRegistry, org.springframework.data.repository.config.RepositoryConfigurationSource)
-	 */
-	@Override
-	public void registerBeansForRoot(BeanDefinitionRegistry registry,
-		RepositoryConfigurationSource configurationSource) {
-
-		RootBeanDefinition idGenerationBeanDefinition = new RootBeanDefinition(ReactiveIdGeneratingBeforeBindCallback.class);
-		idGenerationBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-
-		String idGenerationBeanName = BeanDefinitionReaderUtils.generateBeanName(idGenerationBeanDefinition, registry);
-		registry.registerBeanDefinition(idGenerationBeanName, idGenerationBeanDefinition);
-
-		RootBeanDefinition optimisticLockingBeanDefinition = new RootBeanDefinition(
-			ReactiveOptimisticLockingBeforeBindCallback.class);
-		optimisticLockingBeanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
-
-		String optimisticLockingBeanName = BeanDefinitionReaderUtils.generateBeanName(optimisticLockingBeanDefinition, registry);
-		registry.registerBeanDefinition(optimisticLockingBeanName, optimisticLockingBeanDefinition);
 	}
 }


### PR DESCRIPTION
This commit introduces a pair of registrars for the default imperative and reactive callbacks (Id generation and auditing) so that a user might use the templates without enabling repositories. The registrar are meant to be public API, so that they are available in both our configuration support as well as in the Spring Boot starter (and maybe scenarios a user thinks off).