### PR TITLE
Fix query generation for relationships.

### DIFF
--- a/docs/object-mapping/mapping.adoc
+++ b/docs/object-mapping/mapping.adoc
@@ -117,12 +117,11 @@ In such a case, the type of the relationship to the other domain class is given 
 
 In general there is no limitation of relationships / hops for creating the queries.
 SDN/RX parses the whole reachable graph from your modelled nodes.
-Given the nature of graphs it is possible to have self-referencing, in terms of same label, relationships or
-cycles that contain multiple relationships in your model.
+It is possible to have self-referencing entities and self-referencing concrete instances.
 
-In this cases we have a strict limit of *2* repetitions of walking the same path through the graph.
+If these entities or instances for a cycle we have a strict limit of *2* repetitions of walking the same path through the graph.
 E.g. You model a social network of `(:Person)-[:HAS_FRIEND]->(:Person)-[:HAS_FRIEND]...` you will only get the friends of the second degree.
-If you need a more specific mapping for your domain we advise you to make use of custom queries.
+If you need a more specific mapping for your domain we advise you to use custom queries.
 
 === A complete example
 

--- a/docs/object-mapping/mapping.adoc
+++ b/docs/object-mapping/mapping.adoc
@@ -113,6 +113,17 @@ We support dynamic relationships.
 Dynamic relationships are represented as a `Map<String, AnnotatedDomainClass>`.
 In such a case, the type of the relationship to the other domain class is given by the maps key and must not be configured through the `@Relationship`.
 
+=== Relationship query limit
+
+In general there is no limitation of relationships / hops for creating the queries.
+SDN/RX parses the whole reachable graph from your modelled nodes.
+Given the nature of graphs it is possible to have self-referencing, in terms of same label, relationships or
+cycles that contain multiple relationships in your model.
+
+In this cases we have a strict limit of *2* repetitions of walking the same path through the graph.
+E.g. You model a social network of `(:Person)-[:HAS_FRIEND]->(:Person)-[:HAS_FRIEND]...` you will only get the friends of the second degree.
+If you need a more specific mapping for your domain we advise you to make use of custom queries.
+
 === A complete example
 
 Putting all those together, we can create a simple domain.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -63,7 +61,6 @@ public enum CypherGenerator {
 
 	private static final String RELATIONSHIP_NAME = "relProps";
 
-	// for now the query depth is a hard static limit
 	private static final int RELATIONSHIP_DEPTH_LIMIT = 2;
 
 	/**
@@ -333,34 +330,37 @@ public enum CypherGenerator {
 		List<RelationshipDescription> processedRelationships = new ArrayList<>();
 
 		return projectPropertiesAndRelationships(nodeDescription, NAME_OF_ROOT_NODE, includeField,
-			processedRelationships, new ConcurrentHashMap<>());
+			processedRelationships);
 	}
 
 	private MapProjection projectAllPropertiesAndRelationships(NodeDescription<?> nodeDescription, String nodeName,
-		List<RelationshipDescription> processedRelationships, Map<RelationshipDescription, Integer> depthMap) {
+		List<RelationshipDescription> processedRelationships) {
 
 		Predicate<String> includeAllFields = (field) -> true;
-		return projectPropertiesAndRelationships(nodeDescription, nodeName, includeAllFields, processedRelationships,
-			depthMap);
+		return projectPropertiesAndRelationships(nodeDescription, nodeName, includeAllFields, processedRelationships);
 	}
 
 	private MapProjection projectPropertiesAndRelationships(NodeDescription<?> nodeDescription,
 		String nodeName,
 		Predicate<String> includeProperty,
-		List<RelationshipDescription> processedRelationships,
-		Map<RelationshipDescription, Integer> depthMap) {
+		List<RelationshipDescription> processedRelationships) {
 
 		List<Object> contentOfProjection = new ArrayList<>();
 		contentOfProjection.addAll(projectNodeProperties(nodeDescription, nodeName, includeProperty));
 		contentOfProjection.addAll(
-			generateListsOfRelationships(nodeDescription, nodeName, includeProperty, processedRelationships, depthMap)
+			generateListsFor(nodeDescription.getRelationships(), nodeName, includeProperty, processedRelationships)
 		);
 
 		return Cypher.anyNode(nodeName).project(contentOfProjection);
 	}
 
+	/**
+	 * Creates a list of objects that represents a very basic of {@code MapEntry<String, Object>} with the exception that
+	 * this list can also contain two "keys" in a row. The {@link MapProjection} will take care to handle them as
+	 * self-reflecting fields. Example with self-reflection and explicit value: {@code n {.id, name: n.name}}.
+	 */
 	private List<Object> projectNodeProperties(NodeDescription<?> nodeDescription, String nodeName,
-		Predicate<String> includeField) {
+			Predicate<String> includeField) {
 
 		List<Object> nodePropertiesProjection = new ArrayList<>();
 		for (GraphPropertyDescription property : nodeDescription.getGraphProperties()) {
@@ -379,14 +379,15 @@ public enum CypherGenerator {
 		return nodePropertiesProjection;
 	}
 
-	private List<Object> generateListsOfRelationships(NodeDescription<?> nodeDescription,
-		String nameOfStartNode, Predicate<String> includeField,
-		List<RelationshipDescription> processedRelationships,
-		Map<RelationshipDescription, Integer> depthMap) {
+	/**
+	 * @see org.neo4j.springframework.data.core.schema.CypherGenerator#projectNodeProperties
+	 */
+	private List<Object> generateListsFor(Collection<RelationshipDescription> relationships,
+		String nodeName, Predicate<String> includeField,
+		List<RelationshipDescription> processedRelationships) {
 
-		List<Object> generatedLists = new ArrayList<>();
+		List<Object> mapProjectionLists = new ArrayList<>();
 
-		Collection<RelationshipDescription> relationships = nodeDescription.getRelationships();
 		for (RelationshipDescription relationshipDescription : relationships) {
 
 			String fieldName = relationshipDescription.getFieldName();
@@ -396,71 +397,73 @@ public enum CypherGenerator {
 
 			// if we already processed the other way before, do not try to jump in the infinite loop
 			// unless it is a root node relationship
-			if (!nameOfStartNode.equals(NAME_OF_ROOT_NODE) && relationshipDescription.hasRelationshipObverse()
+			if (!nodeName.equals(NAME_OF_ROOT_NODE) && relationshipDescription.hasRelationshipObverse()
 				&& processedRelationships.contains(relationshipDescription.getRelationshipObverse())) {
 				continue;
 			}
 
 			if (Collections.frequency(processedRelationships, relationshipDescription) > RELATIONSHIP_DEPTH_LIMIT) {
-				return generatedLists;
+				return mapProjectionLists;
 			}
 
-			String relationshipType = relationshipDescription.getType();
-			String relationshipTargetName = relationshipDescription.generateRelatedNodesCollectionName();
-			String targetPrimaryLabel = relationshipDescription.getTarget().getPrimaryLabel();
-			String[] targetAdditionalLabels = relationshipDescription.getTarget().getAdditionalLabels();
-
-			Node startNode = anyNode(nameOfStartNode);
-			String relationshipFieldName = concatFieldName(nameOfStartNode, fieldName);
-			Node endNode = node(targetPrimaryLabel, targetAdditionalLabels).named(relationshipFieldName);
-			NodeDescription<?> endNodeDescription = relationshipDescription.getTarget();
-
-			processedRelationships.add(relationshipDescription);
-
-			if (relationshipDescription.isDynamic()) {
-				Relationship relationship = relationshipDescription
-					.isOutgoing()
-					? startNode.relationshipTo(endNode)
-					: startNode.relationshipFrom(endNode);
-				relationship = relationship.named(relationshipTargetName);
-
-				generatedLists.add(relationshipTargetName);
-				generatedLists.add(listBasedOn(relationship)
-					.returning(
-						projectAllPropertiesAndRelationships(endNodeDescription,
-							relationshipFieldName, new ArrayList<>(processedRelationships), depthMap)
-							.and(NAME_OF_RELATIONSHIP_TYPE, Functions.type(relationship))));
-			} else {
-				Relationship relationship = relationshipDescription.isOutgoing()
-					? startNode.relationshipTo(endNode, relationshipType)
-					: startNode.relationshipFrom(endNode, relationshipType);
-
-				MapProjection mapProjection = projectAllPropertiesAndRelationships(endNodeDescription,
-					relationshipFieldName, new ArrayList<>(processedRelationships), depthMap);
-
-				if (relationshipDescription.hasRelationshipProperties()) {
-					relationship = relationship.named(RelationshipDescription.NAME_OF_RELATIONSHIP);
-					mapProjection = mapProjection.and(relationship);
-				}
-
-				generatedLists.add(relationshipTargetName);
-				generatedLists.add(listBasedOn(relationship)
-					.returning(mapProjection));
-			}
+			generateListFor(relationshipDescription, nodeName, processedRelationships, fieldName, mapProjectionLists);
 		}
 
-		return generatedLists;
+		return mapProjectionLists;
 	}
 
-	private int currentRelationshipDepth(RelationshipDescription relationshipDescription, Map<RelationshipDescription, Integer> depthMap) {
-		return depthMap
-			.getOrDefault(relationshipDescription, 1);
+	private void generateListFor(RelationshipDescription relationshipDescription, String nodeName,
+		List<RelationshipDescription> processedRelationships, String fieldName, List<Object> mapProjectionLists) {
+
+		String relationshipType = relationshipDescription.getType();
+		String relationshipTargetName = relationshipDescription.generateRelatedNodesCollectionName();
+		String targetPrimaryLabel = relationshipDescription.getTarget().getPrimaryLabel();
+		String[] targetAdditionalLabels = relationshipDescription.getTarget().getAdditionalLabels();
+
+		Node startNode = anyNode(nodeName);
+		String relationshipFieldName = concatFieldName(nodeName, fieldName);
+		Node endNode = node(targetPrimaryLabel, targetAdditionalLabels).named(relationshipFieldName);
+		NodeDescription<?> endNodeDescription = relationshipDescription.getTarget();
+
+		processedRelationships.add(relationshipDescription);
+
+		if (relationshipDescription.isDynamic()) {
+			Relationship relationship = relationshipDescription
+				.isOutgoing()
+				? startNode.relationshipTo(endNode)
+				: startNode.relationshipFrom(endNode);
+			relationship = relationship.named(relationshipTargetName);
+
+			addMapProjection(relationshipTargetName,
+				listBasedOn(relationship)
+					.returning(
+						projectAllPropertiesAndRelationships(endNodeDescription,
+							relationshipFieldName, new ArrayList<>(processedRelationships))
+							.and(NAME_OF_RELATIONSHIP_TYPE, Functions.type(relationship))),
+				mapProjectionLists);
+
+		} else {
+			Relationship relationship = relationshipDescription.isOutgoing()
+				? startNode.relationshipTo(endNode, relationshipType)
+				: startNode.relationshipFrom(endNode, relationshipType);
+
+			MapProjection mapProjection = projectAllPropertiesAndRelationships(endNodeDescription,
+				relationshipFieldName, new ArrayList<>(processedRelationships));
+
+			if (relationshipDescription.hasRelationshipProperties()) {
+				relationship = relationship.named(RelationshipDescription.NAME_OF_RELATIONSHIP);
+				mapProjection = mapProjection.and(relationship);
+			}
+
+			addMapProjection(relationshipTargetName,
+				listBasedOn(relationship).returning(mapProjection),
+				mapProjectionLists);
+		}
 	}
 
-	private void increaseRelationshipDepth(RelationshipDescription relationshipDescription, Map<RelationshipDescription, Integer> depthMap) {
-		int newDepth = currentRelationshipDepth(relationshipDescription, depthMap) + 1;
-
-		depthMap.put(relationshipDescription, newDepth);
+	private void addMapProjection(String name, Object projection, List<Object> projectionList) {
+		projectionList.add(name);
+		projectionList.add(projection);
 	}
 
 	@NotNull

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -330,7 +330,7 @@ class RepositoryIT {
 		// ensures that the virtual limit for same relationships does not affect distinct relationships
 		assertThat(type1.nextType.nextType.nextType.nextType.nextType.nextType).isNotNull();
 
-		// check the magical virtual limit of 5 of same type relationships
+		// assert that same type relationships not cause stack overflow
 		DeepRelationships.Type2 type2 = type1.nextType;
 		assertThat(type2.sameType.sameType.sameType).isNotNull();
 		assertThat(type2.sameType.sameType.sameType.sameType).isNull();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -332,8 +332,8 @@ class RepositoryIT {
 
 		// check the magical virtual limit of 5 of same type relationships
 		DeepRelationships.Type2 type2 = type1.nextType;
-		assertThat(type2.sameType.sameType.sameType.sameType.sameType).isNotNull();
-		assertThat(type2.sameType.sameType.sameType.sameType.sameType.sameType).isNull();
+		assertThat(type2.sameType.sameType.sameType).isNotNull();
+		assertThat(type2.sameType.sameType.sameType.sameType).isNull();
 
 	}
 
@@ -369,11 +369,7 @@ class RepositoryIT {
 		assertThat(iteration2).isNotNull();
 		DeepRelationships.LoopingType1 iteration3 = iteration2.nextType.nextType.nextType;
 		assertThat(iteration3).isNotNull();
-		DeepRelationships.LoopingType1 iteration4 = iteration3.nextType.nextType.nextType;
-		assertThat(iteration4).isNotNull();
-		DeepRelationships.LoopingType1 iteration5 = iteration4.nextType.nextType.nextType;
-		assertThat(iteration5).isNotNull();
-		assertThat(iteration5.nextType).isNull();
+		assertThat(iteration3.nextType).isNull();
 
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -314,8 +314,8 @@ class ReactiveRepositoryIT {
 
 				// check the magical virtual limit of 5 of same type relationships
 				DeepRelationships.Type2 type2 = type1.nextType;
-				assertThat(type2.sameType.sameType.sameType.sameType.sameType).isNotNull();
-				assertThat(type2.sameType.sameType.sameType.sameType.sameType.sameType).isNull();
+				assertThat(type2.sameType.sameType.sameType).isNotNull();
+				assertThat(type2.sameType.sameType.sameType.sameType).isNull();
 			})
 			.verifyComplete();
 	}
@@ -351,12 +351,7 @@ class ReactiveRepositoryIT {
 				DeepRelationships.LoopingType1 iteration2 = iteration1.nextType.nextType.nextType;
 				assertThat(iteration2).isNotNull();
 				DeepRelationships.LoopingType1 iteration3 = iteration2.nextType.nextType.nextType;
-				assertThat(iteration3).isNotNull();
-				DeepRelationships.LoopingType1 iteration4 = iteration3.nextType.nextType.nextType;
-				assertThat(iteration4).isNotNull();
-				DeepRelationships.LoopingType1 iteration5 = iteration4.nextType.nextType.nextType;
-				assertThat(iteration5).isNotNull();
-				assertThat(iteration5.nextType).isNull();
+				assertThat(iteration3.nextType).isNull();
 			})
 			.verifyComplete();
 	}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveRepositoryIT.java
@@ -312,7 +312,7 @@ class ReactiveRepositoryIT {
 				// ensures that the virtual limit for same relationships does not affect distinct relationships
 				assertThat(type1.nextType.nextType.nextType.nextType.nextType.nextType).isNotNull();
 
-				// check the magical virtual limit of 5 of same type relationships
+				// assert that same type relationships not cause stack overflow
 				DeepRelationships.Type2 type2 = type1.nextType;
 				assertThat(type2.sameType.sameType.sameType).isNotNull();
 				assertThat(type2.sameType.sameType.sameType.sameType).isNull();
@@ -366,6 +366,7 @@ class ReactiveRepositoryIT {
 		StepVerifier.create(repository.findByNameStartingWith("Test", PageRequest.of(page, limit, sort)))
 			.assertNext(person -> assertThat(person).isEqualTo(person1))
 			.verifyComplete();
+
 
 		sort = Sort.by("name");
 		page = 1;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Pet.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Pet.java
@@ -55,6 +55,9 @@ public class Pet {
 	@Relationship("Has")
 	private List<Pet> friends;
 
+	@Relationship(value = "Hated_by", direction = Relationship.Direction.INCOMING)
+	private List<Pet> otherPets;
+
 	@Relationship("Has")
 	private List<ThingWithAssignedId> things;
 

--- a/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
+++ b/spring-data-neo4j-rx/src/test/kotlin/org/neo4j/springframework/data/integration/imperative/ImmutableRelationshipsIT.kt
@@ -101,14 +101,13 @@ class ImmutableRelationshipsIT @Autowired constructor(
 
         val p1 = ImmutableKotlinPerson("Person1", emptyList())
         val p2 = ImmutableKotlinPerson("Person2", listOf(p1))
-        val p3 = ImmutableKotlinPerson("Person3", listOf(p2))
-        val p4 = ImmutableKotlinPerson("Person4", listOf(p1, p3))
+        val p3 = ImmutableKotlinPerson("Person3", listOf(p1, p2))
 
-        personRepository.save(p4)
+        personRepository.save(p3)
 
         val people = personRepository.findAll()
 
-        assertThat(people).hasSize(4)
+        assertThat(people).hasSize(3)
     }
 
     @Configuration


### PR DESCRIPTION
This commit does ensure that every path from a certain start node
will get processed until the end of the mapped graph or stops
after it has visited a self-reference or cycle more than 2 times.