### PR TITLE
Document Cypher DSL as experimental API.

### DIFF
--- a/docs/appendix/cypherdsl.adoc
+++ b/docs/appendix/cypherdsl.adoc
@@ -4,7 +4,7 @@
 WARNING: The Cypher-DSL is considered _EXPERIMENTAL_ at the time of writing.
          This means you can and should use it and that we are looking actively for feedback, issues and problems.
          We will try to keep breaking changes to a minimum, but we reserve the right to modify public methods, parameters
-         and behaviour in case we need those chances for SDN/RX itself.
+         and behaviour in case we need those changes for SDN/RX itself.
          All public classes inside `org.neo4j.springframework.data.core.cypher` are annotated with `@API(status = EXPERIMENTAL, since = "1.0")`,
          We will switching to stable some time after a 1.0 release.
 
@@ -31,14 +31,14 @@ Those are the basic interfaces implemented by the Neo4j templates of the same na
 Both the imperative and the reactive framework allow the retrieval and counting of entities with a `org.neo4j.springframework.data.core.cypher.Statement`,
 for example through `Neo4jTemplate#findAll(Statement, Class<T>)` and similar.
 
-An instanceof of a `org.neo4j.springframework.data.core.cypher.Statement` is provided at the end of Query building step.
+An instance of a `org.neo4j.springframework.data.core.cypher.Statement` is provided at the end of query building step.
 
 A `Statement` represents an in-memory https://en.wikipedia.org/wiki/Abstract_syntax_tree[Abstract syntax tree] and can be
 transformed and rendered as such.
 
-We are still on a JDK 8 baseline and cannot hide our renderer in an internal module, marked as @API(status = INTERNAL, since = "1.0")`.
+We are still on a JDK 8 baseline and cannot hide our renderer in an internal module, marked as `@API(status = INTERNAL, since = "1.0")`.
 You can get an instance of the default renderer via `org.neo4j.springframework.data.core.cypher.renderer.Renderer#getDefaultRenderer()`
-and than use the `render`  method to get a string representation of the statement.
+and than use the `render` method to get a string representation of the statement.
 
 This string representation can be used with the <<neo4j-client>>.
 
@@ -46,18 +46,19 @@ We do however give no guarantees to the render API until it is marked as `EXPERI
 
 == How to use it
 
-You use the Cypher-DSL as you would write Cypher: It allows to write down even complex Cypher queries from top to bottom in a type safe, compile time checked way.
+You use the Cypher-DSL as you would write Cypher:
+It allows to write down even complex Cypher queries from top to bottom in a type safe, compile time checked way.
 
 The examples to follow are using JDK 11.
 We find the `var` keyword especially appealing in such a DSL as the types returned by the DSL much less important than
 the further building methods they offer.
 
 IMPORTANT: The AST parts and intermediate build steps are immutable. That is, the methods create new intermediate steps.
-           For example, you cannot reuse an `ExposesLimit` step, but have to use the returned object from it's `skip` method.
+           For example, you cannot reuse an `ExposesLimit` step, but have to use the returned object from its `skip` method.
 
 === Examples
 
-The following examples are 1:1 copies of the queries you'll find in the Neo4j browser after running `:play movies`.
+The following examples are 1:1 copies of the queries you will find in the Neo4j browser after running `:play movies`.
 
 They use the following imports:
 
@@ -74,9 +75,9 @@ To match and return all the movie, build your statement like this:
 ----
 include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e1]
 ----
-<.> Declare a variable storing your node labled `Movie` and named `m`, so that you can
-<.> reuse it in both the match and the return part
-<.> The `build` method becomes only available when a compilable Cypher statement can be rendered
+<.> Declare a variable storing your node labeled `Movie` and named `m`, so that you can
+<.> reuse it in both the match and the return part.
+<.> The `build` method becomes only available when a compilable Cypher statement can be rendered.
 
 ==== Find
 

--- a/docs/appendix/cypherdsl.adoc
+++ b/docs/appendix/cypherdsl.adoc
@@ -1,0 +1,149 @@
+[[cypher-dsl]]
+= The Cypher-DSL
+
+WARNING: The Cypher-DSL is considered _EXPERIMENTAL_ at the time of writing.
+         This means you can and should use it and that we are looking actively for feedback, issues and problems.
+         We will try to keep breaking changes to a minimum, but we reserve the right to modify public methods, parameters
+         and behaviour in case we need those chances for SDN/RX itself.
+         All public classes inside `org.neo4j.springframework.data.core.cypher` are annotated with `@API(status = EXPERIMENTAL, since = "1.0")`,
+         We will switching to stable some time after a 1.0 release.
+
+== Purpose
+
+The Cypher-DSL has been developed with the needs of SDN/RX in mind:
+We wanted to avoid string concatenations in our query generation and decided do go with a builder approach, much like we
+find with https://www.jooq.org[jOOQ] or in the relational module of https://github.com/spring-projects/spring-data-jdbc/tree/1.1.6.RELEASE/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql[Spring Data JDBC], but for Cypher.
+
+What we don't have - and don't need for our mapping purpose - at the moment is a code generator that reads the database schema
+and generates static classes representing labels and relationship types.
+That is still up to the mapping framework (in our case SDN/RX).
+We however have a type safe API for Cypher that allows only generating valid Cypher constructs.
+
+We worked closely with the https://www.opencypher.org[OpenCypher spec] here and you find a lot of these concepts in the API.
+
+The Cypher-DSL can also be seen in the same area as the https://docs.spring.io/spring-data/mongodb/docs/current/api/org/springframework/data/mongodb/core/query/Criteria.html[Criteria API] of Spring Data Mongo.
+
+== Where to use it
+
+The Cypher-DSL is publicly visible in the `Neo4jOperations` respectively `ReactiveNeo4jOperations`.
+Those are the basic interfaces implemented by the Neo4j templates of the same names (Read more about the templates <<template-support,here>>).
+
+Both the imperative and the reactive framework allow the retrieval and counting of entities with a `org.neo4j.springframework.data.core.cypher.Statement`,
+for example through `Neo4jTemplate#findAll(Statement, Class<T>)` and similar.
+
+An instanceof of a `org.neo4j.springframework.data.core.cypher.Statement` is provided at the end of Query building step.
+
+A `Statement` represents an in-memory https://en.wikipedia.org/wiki/Abstract_syntax_tree[Abstract syntax tree] and can be
+transformed and rendered as such.
+
+We are still on a JDK 8 baseline and cannot hide our renderer in an internal module, marked as @API(status = INTERNAL, since = "1.0")`.
+You can get an instance of the default renderer via `org.neo4j.springframework.data.core.cypher.renderer.Renderer#getDefaultRenderer()`
+and than use the `render`  method to get a string representation of the statement.
+
+This string representation can be used with the <<neo4j-client>>.
+
+We do however give no guarantees to the render API until it is marked as `EXPERIMENTAL` or `STABLE`.
+
+== How to use it
+
+You use the Cypher-DSL as you would write Cypher: It allows to write down even complex Cypher queries from top to bottom in a type safe, compile time checked way.
+
+The examples to follow are using JDK 11.
+We find the `var` keyword especially appealing in such a DSL as the types returned by the DSL much less important than
+the further building methods they offer.
+
+IMPORTANT: The AST parts and intermediate build steps are immutable. That is, the methods create new intermediate steps.
+           For example, you cannot reuse an `ExposesLimit` step, but have to use the returned object from it's `skip` method.
+
+=== Examples
+
+The following examples are 1:1 copies of the queries you'll find in the Neo4j browser after running `:play movies`.
+
+They use the following imports:
+
+.Imports needed for the examples to compile
+[source, java]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-imports]
+----
+
+To match and return all the movie, build your statement like this:
+
+.Simple match
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e1]
+----
+<.> Declare a variable storing your node labled `Movie` and named `m`, so that you can
+<.> reuse it in both the match and the return part
+<.> The `build` method becomes only available when a compilable Cypher statement can be rendered
+
+==== Find
+
+Match all nodes with a given set of properties:
+
+.Find the actor named "Tom Hanks"...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e2]
+----
+
+Limit the number of returned things and return only one attribute
+
+.Find 10 people...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e4]
+----
+
+Create complex conditions
+
+.Find movies released in the 1990s...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e5]
+----
+
+==== Query
+
+Build relationships
+
+.List all Tom Hanks movies...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e6]
+----
+
+.Who directed "Cloud Atlas"?
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e7]
+----
+
+.Tom Hanks' co-actors...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e8]
+----
+
+.How people are related to "Cloud Atlas"...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-e9]
+----
+
+==== Solve
+
+.Movies and actors up to 4 "hops" away from Kevin Bacon
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-bacon]
+----
+
+==== Recommend
+
+.Extend Tom Hanks co-actors, to find co-co-actors who haven't worked with Tom Hanks...
+[source, java,indent=0]
+----
+include::../../examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java[tag=cypher-dsl-r]
+----

--- a/docs/faq/faq.adoc
+++ b/docs/faq/faq.adoc
@@ -42,7 +42,7 @@ NOTE: Be careful that you don't mix up entities retrieved from one database with
       entities than expected when changing the database name in between calls.
       Or worse, you could inevitable store the wrong entities in the wrong database.
 
-== Do I need specific configuration so that transactions work seemles with a Neo4j Causal Cluster?
+== Do I need specific configuration so that transactions work seamless with a Neo4j Causal Cluster?
 
 No, you don't.
 SDN/RX uses Neo4j Causal Cluster bookmarks internally without any configuration on your side required.

--- a/examples/docs/pom.xml
+++ b/examples/docs/pom.xml
@@ -165,7 +165,7 @@
 				</property>
 			</activation>
 			<properties>
-				<changelist>-beta04</changelist>
+				<changelist>-SNAPSHOT</changelist>
 			</properties>
 		</profile>
 	</profiles>

--- a/examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java
+++ b/examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java
@@ -1,0 +1,196 @@
+package org.neo4j.doc.springframework.data.docs.repositories.cypherdsl;
+
+// tag::cypher-dsl-imports[]
+import static org.assertj.core.api.Assertions.*;
+import static org.neo4j.springframework.data.core.cypher.Conditions.*;
+import static org.neo4j.springframework.data.core.cypher.Cypher.*;
+import static org.neo4j.springframework.data.core.cypher.Functions.*;
+
+// end::cypher-dsl-imports[]
+
+import org.junit.jupiter.api.Test;
+// tag::cypher-dsl-imports[]
+import org.neo4j.springframework.data.core.cypher.Cypher;
+import org.neo4j.springframework.data.core.cypher.renderer.Renderer;
+// end::cypher-dsl-imports[]
+
+/**
+ * Examples for the Cypher DSL.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Rage - Lingua Mortis
+ * @since 1.0
+ */
+class CypherDSLExamplesTest {
+
+	private static final Renderer cypherRenderer = Renderer.getDefaultRenderer();
+
+	@Test
+	void findAllMovies() {
+
+		// tag::cypher-dsl-e1[]
+		var m = node("Movie").named("m"); // <.>
+		var statement = Cypher.match(m) // <.>
+			.returning(m)
+			.build(); // <.>
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (m:`Movie`) RETURN m");
+		// end::cypher-dsl-e1[]
+	}
+
+	@Test
+	void playMovieGraphFind() {
+
+		// tag::cypher-dsl-e2[]
+		var tom = anyNode().named("tom").properties("name", literalOf("Tom Hanks"));
+		var statement = Cypher
+			.match(tom).returning(tom)
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (tom {name: 'Tom Hanks'}) RETURN tom");
+		// end::cypher-dsl-e2[]
+
+		// tag::cypher-dsl-e3[]
+		var cloudAtlas = anyNode().named("cloudAtlas").properties("title", literalOf("Cloud Atlas"));
+		statement = Cypher
+			.match(cloudAtlas).returning(cloudAtlas)
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (cloudAtlas {title: 'Cloud Atlas'}) RETURN cloudAtlas");
+		// end::cypher-dsl-e3[]
+
+		// tag::cypher-dsl-e4[]
+		var people = node("Person").named("people");
+		statement = Cypher
+			.match(people)
+			.returning(people.property("name"))
+			.limit(10)
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (people:`Person`) RETURN people.name LIMIT 10");
+		// end::cypher-dsl-e4[]
+
+		// tag::cypher-dsl-e5[]
+		var nineties = node("Movie").named("nineties");
+		var released = nineties.property("released");
+		statement = Cypher
+			.match(nineties)
+			.where(released.gte(literalOf(1990)).and(released.lt(literalOf(2000))))
+			.returning(nineties.property("title"))
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo(
+				"MATCH (nineties:`Movie`) WHERE (nineties.released >= 1990 AND nineties.released < 2000) RETURN nineties.title");
+		// end::cypher-dsl-e5[]
+	}
+
+	@Test
+	void playMovieGraphQuery() {
+
+		// tag::cypher-dsl-e6[]
+		var tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		var tomHanksMovies = anyNode("tomHanksMovies");
+		var statement = Cypher
+			.match(tom.relationshipTo(tomHanksMovies, "ACTED_IN"))
+			.returning(tom, tomHanksMovies)
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo(
+				"MATCH (tom:`Person` {name: 'Tom Hanks'})-[:`ACTED_IN`]->(tomHanksMovies) RETURN tom, tomHanksMovies");
+		// end::cypher-dsl-e6[]
+
+		// tag::cypher-dsl-e7[]
+		var cloudAtlas = anyNode("cloudAtlas").properties("title", literalOf("Cloud Atlas"));
+		var directors = anyNode("directors");
+		statement = Cypher
+			.match(cloudAtlas.relationshipFrom(directors, "DIRECTED"))
+			.returning(directors.property("name"))
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (cloudAtlas {title: 'Cloud Atlas'})<-[:`DIRECTED`]-(directors) RETURN directors.name");
+		// end::cypher-dsl-e7[]
+
+		// tag::cypher-dsl-e8[]
+		tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		var movie = anyNode("m");
+		var coActors = anyNode("coActors");
+		var people = node("Person").named("people");
+		statement = Cypher
+			.match(tom.relationshipTo(movie, "ACTED_IN").relationshipFrom(coActors, "ACTED_IN"))
+			.returning(coActors.property("name"))
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo(
+				"MATCH (tom:`Person` {name: 'Tom Hanks'})-[:`ACTED_IN`]->(m)<-[:`ACTED_IN`]-(coActors) RETURN coActors.name");
+		// end::cypher-dsl-e8[]
+
+		// tag::cypher-dsl-e9[]
+		cloudAtlas = node("Movie").properties("title", literalOf("Cloud Atlas"));
+		people = node("Person").named("people");
+		var relatedTo = people.relationshipBetween(cloudAtlas).named("relatedTo");
+		statement = Cypher
+			.match(relatedTo)
+			.returning(people.property("name"), type(relatedTo), relatedTo.getRequiredSymbolicName())
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo(
+				"MATCH (people:`Person`)-[relatedTo]-(:`Movie` {title: 'Cloud Atlas'}) RETURN people.name, type(relatedTo), relatedTo");
+		// end::cypher-dsl-e9[]
+	}
+
+	@Test
+	void playMovieGraphSolve() {
+
+		// tag::cypher-dsl-bacon[]
+		var bacon = node("Person").named("bacon").properties("name", literalOf("Kevin Bacon"));
+		var hollywood = anyNode("hollywood");
+		var statement = Cypher
+			.match(bacon.relationshipBetween(hollywood).length(1, 4))
+			.returningDistinct(hollywood)
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("MATCH (bacon:`Person` {name: 'Kevin Bacon'})-[*1..4]-(hollywood) RETURN DISTINCT hollywood");
+		// end::cypher-dsl-bacon[]
+	}
+
+	@Test
+	void playMovieGraphRecommend() {
+
+		// tag::cypher-dsl-r[]
+		var tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		var coActors = anyNode("coActors");
+		var cocoActors = anyNode("cocoActors");
+		var strength = count(asterisk()).as("Strength");
+		var statement = Cypher
+			.match(
+				tom.relationshipTo(anyNode("m"), "ACTED_IN").relationshipFrom(coActors, "ACTED_IN"),
+				coActors.relationshipTo(anyNode("m2"), "ACTED_IN").relationshipFrom(cocoActors, "ACTED_IN")
+			)
+			.where(not(tom.relationshipTo(anyNode(), "ACTED_IN").relationshipFrom(cocoActors, "ACTED_IN")))
+			.and(tom.isNotEqualTo(cocoActors))
+			.returning(
+				cocoActors.property("name").as("Recommended"),
+				strength
+			).orderBy(strength.asName().descending())
+			.build();
+
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo(""
+				+ "MATCH "
+				+ "(tom:`Person` {name: 'Tom Hanks'})-[:`ACTED_IN`]->(m)<-[:`ACTED_IN`]-(coActors), "
+				+ "(coActors)-[:`ACTED_IN`]->(m2)<-[:`ACTED_IN`]-(cocoActors) "
+				+ "WHERE (NOT (tom)-[:`ACTED_IN`]->()<-[:`ACTED_IN`]-(cocoActors) AND tom <> cocoActors) "
+				+ "RETURN cocoActors.name AS Recommended, count(*) AS Strength ORDER BY Strength DESC");
+		// end::cypher-dsl-r[]
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.*;
 import static org.neo4j.springframework.data.core.RelationshipStatementHolder.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 import static org.neo4j.springframework.data.core.schema.CypherGenerator.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -24,7 +24,7 @@ import static org.neo4j.springframework.data.core.DatabaseSelection.*;
 import static org.neo4j.springframework.data.core.RelationshipStatementHolder.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 import static org.neo4j.springframework.data.core.schema.CypherGenerator.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 import static org.neo4j.springframework.data.core.support.Relationships.*;
 
 import reactor.core.publisher.Flux;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Aliased.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Aliased.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -29,11 +31,20 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface Aliased {
 
 	/**
 	 * @return the alias.
 	 */
 	String getAlias();
+
+	/**
+	 * Turns this alias into a symbolic name that can be used as an {@link Expression}.
+	 *
+	 * @return A new symbolic name
+	 */
+	default SymbolicName asName() {
+		return SymbolicName.create(this.getAlias());
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/AliasedExpression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/AliasedExpression.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import org.apiguardian.api.API;
@@ -30,7 +31,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class AliasedExpression implements Aliased, Expression {
 
 	private final Expression delegate;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Asterisk.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Asterisk.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -26,7 +28,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Asterisk extends Literal<String> {
 
 	public static final Asterisk INSTANCE = new Asterisk();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/BooleanFunctionCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/BooleanFunctionCondition.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class BooleanFunctionCondition implements Condition {
 
 	private final FunctionInvocation delegate;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/BooleanLiteral.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/BooleanLiteral.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -27,7 +29,7 @@ import org.apiguardian.api.API;
  * @soundtrack Bad Religion - Age Of Unreason
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class BooleanLiteral extends Literal<Boolean> {
 
 	static BooleanLiteral TRUE = new BooleanLiteral(true);

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Comparison.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Comparison.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import org.apiguardian.api.API;
@@ -32,7 +33,7 @@ import org.springframework.util.Assert;
  * @author Gerrit Meier
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Comparison implements Condition {
 
 	static Comparison create(Operator operator, Expression expression) {
@@ -63,7 +64,7 @@ public final class Comparison implements Condition {
 		return expression instanceof Condition ? new NestedExpression(expression) : expression;
 	}
 
-	private final Expression left;
+	private @Nullable final Expression left;
 	private final Operator comparator;
 	private @Nullable final Expression right;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/CompoundCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/CompoundCondition.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Operator.*;
 
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = INTERNAL, since = "1.0")
 public final class CompoundCondition implements Condition {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Condition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Condition.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -26,7 +28,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface Condition extends Expression {
 
 	default Condition and(Condition condition) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Conditions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Conditions.java
@@ -127,7 +127,7 @@ public final class Conditions {
 	 public static Condition not(PatternElement patternElement) {
 
 		Assert.notNull(patternElement, "Pattern to negate must not be null.");
-		return new FilteredPattern(patternElement);
+		return new ExcludedPattern(patternElement);
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Conditions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Conditions.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.springframework.util.Assert;
 
@@ -29,7 +31,7 @@ import org.springframework.util.Assert;
  * @author Gerrit Meier
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Conditions {
 
 	/**
@@ -116,10 +118,16 @@ public final class Conditions {
 	 * @param condition The condition to negate. Must not be null.
 	 * @return The negated condition.
 	 */
-	static Condition not(Condition condition) {
+	public static Condition not(Condition condition) {
 
 		Assert.notNull(condition, "Condition to negate must not be null.");
 		return condition.not();
+	}
+
+	 public static Condition not(PatternElement patternElement) {
+
+		Assert.notNull(patternElement, "Pattern to negate must not be null.");
+		return new FilteredPattern(patternElement);
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Create.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Create.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @soundtrack Die Ärzte - Seitenhirsch
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Create implements UpdatingClause {
 
 	private final Pattern pattern;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +42,7 @@ import org.springframework.util.Assert;
  * @author Gerrit Meier
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Cypher {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Cypher.java
@@ -90,6 +90,13 @@ public final class Cypher {
 	}
 
 	/**
+	 * @return A node matching any node with the symbolic the given {@code symbolicName}.
+	 */
+	public static Node anyNode(SymbolicName symbolicName) {
+		return Node.create().named(symbolicName);
+	}
+
+	/**
 	 * Dereferences a property for a symbolic name, most likely pointing to a property container like a node or a relationship.
 	 *
 	 * @param containerName The symbolic name of a property container

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Delete.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Delete.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Delete implements UpdatingClause {
 
 	private final ExpressionList deleteItems;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExcludedPattern.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExcludedPattern.java
@@ -24,17 +24,17 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
 /**
- * Used to create patterns filtered via {@literal not}.
+ * Used to create patterns excluded in a where clause via {@literal not}.
  *
  * @author Michael J. Simons
  * @since 1.0
  */
 @API(status = INTERNAL, since = "1.0")
-final class FilteredPattern implements Condition {
+final class ExcludedPattern implements Condition {
 
 	private final PatternElement patternElement;
 
-	FilteredPattern(PatternElement patternElement) {
+	ExcludedPattern(PatternElement patternElement) {
 		this.patternElement = patternElement;
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesRelationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesRelationships.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -27,7 +29,7 @@ import org.apiguardian.api.API;
  * @param <T> Typically a {@link Relationship} or {@link RelationshipChain}
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface ExposesRelationships<T> {
 	/**
 	 * Starts building an outgoing relationship to the {@code other} {@link Node node}.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expression.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 
 import org.apiguardian.api.API;
@@ -30,7 +31,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface Expression extends Visitable {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expressions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Expressions.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.Arrays;
 
 import org.apiguardian.api.API;
@@ -28,17 +30,18 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public final class Expressions {
+@API(status = INTERNAL, since = "1.0")
+final class Expressions {
 
 	/**
 	 * @param expression Possibly named with a non-empty symbolic name.
+	 * @param <T> The type being returned
 	 * @return The name of the expression if the expression is named or the expression itself.
 	 */
-	static Expression nameOrExpression(Expression expression) {
+	static <T> T nameOrExpression(T expression) {
 
 		if (expression instanceof Named) {
-			return ((Named) expression).getSymbolicName().map(Expression.class::cast).orElse(expression);
+			return ((Named) expression).getSymbolicName().map(v -> (T) v).orElse(expression);
 		} else {
 			return expression;
 		}
@@ -46,6 +49,11 @@ public final class Expressions {
 
 	static Expression[] createSymbolicNames(String[] variables) {
 		return Arrays.stream(variables).map(SymbolicName::create).toArray(Expression[]::new);
+	}
+
+	static Expression[] createSymbolicNames(Named[] variables) {
+		return Arrays.stream(variables).map(Named::getRequiredSymbolicName)
+			.toArray(Expression[]::new);
 	}
 
 	private Expressions() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FilteredPattern.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FilteredPattern.java
@@ -18,15 +18,32 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
-import org.neo4j.springframework.data.core.cypher.support.Visitable;
+import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
 /**
- * A shared, internally used interface for {@link MapExpression map expressions}.
+ * Used to create patterns filtered via {@literal not}.
  *
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public interface MapEntry extends Visitable {
+@API(status = INTERNAL, since = "1.0")
+final class FilteredPattern implements Condition {
+
+	private final PatternElement patternElement;
+
+	FilteredPattern(PatternElement patternElement) {
+		this.patternElement = patternElement;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		Operator.NOT.accept(visitor);
+		patternElement.accept(visitor);
+		visitor.leave(this);
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FunctionInvocation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/FunctionInvocation.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -29,7 +31,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class FunctionInvocation implements Expression {
 
 	private final String functionName;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Functions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Functions.java
@@ -106,9 +106,8 @@ public final class Functions {
 	 * Creates a function invocation for the {@code count()} function.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-count">count</a>.
 	 *
-	 * @param expression An expression describing the things to count. Can be a node, relationship, alias or
-	 *                   a symbolic name
-	 * @return A function call for {@code count()} for one node
+	 * @param expression An expression describing the things to count.
+	 * @return A function call for {@code count()} for an expression like {@link Cypher#asterisk()} etc.
 	 */
 	public static FunctionInvocation count(Expression expression) {
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Functions.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Functions.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.springframework.util.Assert;
 
@@ -27,7 +29,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Functions {
 
 	private static final String F_ID = "id";
@@ -43,7 +45,7 @@ public final class Functions {
 
 		Assert.notNull(node, "The node parameter is required.");
 
-		return new FunctionInvocation(F_ID, node);
+		return new FunctionInvocation(F_ID, node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -56,23 +58,22 @@ public final class Functions {
 	public static FunctionInvocation id(Relationship relationship) {
 
 		Assert.notNull(relationship, "The relationship parameter is required.");
-		Assert.isTrue(relationship.getSymbolicName().isPresent(), "The relationship needs to be named.");
 
-		return new FunctionInvocation(F_ID, relationship);
+		return new FunctionInvocation(F_ID, relationship.getRequiredSymbolicName());
 	}
 
-	public static FunctionInvocation id(SymbolicName symbolicName) {
+	/**
+	 * Creates a function invocation for {@code id{}}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-labels">labels</a>.
+	 *
+	 * @param node The node for which the labels should be retrieved
+	 * @return A function call for {@code labels()} on a node.
+	 */
+	public static FunctionInvocation labels(Node node) {
 
-		Assert.notNull(symbolicName, "The symbolic name is required.");
+		Assert.notNull(node, "The node parameter is required.");
 
-		return new FunctionInvocation(F_ID, symbolicName);
-	}
-
-	public static FunctionInvocation labels(SymbolicName symbolicName) {
-
-		Assert.notNull(symbolicName, "The symbolic name is required.");
-
-		return new FunctionInvocation("labels", symbolicName);
+		return new FunctionInvocation("labels", node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -85,9 +86,20 @@ public final class Functions {
 	public static FunctionInvocation type(Relationship relationship) {
 
 		Assert.notNull(relationship, "The relationship parameter is required.");
-		Assert.isTrue(relationship.getSymbolicName().isPresent(), "The relationship needs to be named.");
 
-		return new FunctionInvocation("type", relationship);
+		return new FunctionInvocation("type", relationship.getRequiredSymbolicName());
+	}
+
+	/**
+	 * @param node The named node to be counted
+	 * @return A function call for {@code count()} for one named node
+	 * @see #count(Expression)
+	 */
+	public static FunctionInvocation count(Node node) {
+
+		Assert.notNull(node, "The node parameter is required.");
+
+		return count(node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -96,7 +108,7 @@ public final class Functions {
 	 *
 	 * @param expression An expression describing the things to count. Can be a node, relationship, alias or
 	 *                   a symbolic name
-	 * @return A function call for {@code count()} for one  expression
+	 * @return A function call for {@code count()} for one node
 	 */
 	public static FunctionInvocation count(Expression expression) {
 
@@ -195,6 +207,18 @@ public final class Functions {
 		Assert.notNull(parameterMap, "The parameter map is required.");
 
 		return new FunctionInvocation("point", parameterMap);
+	}
+
+	/**
+	 * @param variable The named thing to collect
+	 * @return A function call for {@code collect()}
+	 * @see #collect(Expression)
+	 */
+	public static FunctionInvocation collect(Named variable) {
+
+		Assert.notNull(variable, "The variable parameter is required.");
+
+		return Functions.collect(variable.getRequiredSymbolicName());
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/HasLabelCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/HasLabelCondition.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +33,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class HasLabelCondition implements Condition {
 
 	private final SymbolicName nodeName;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/KeyValueMapEntry.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/KeyValueMapEntry.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 import org.springframework.lang.Nullable;
@@ -29,8 +31,8 @@ import org.springframework.lang.Nullable;
  * @soundtrack Rammstein - RAMMSTEIN
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public final class KeyValueMapEntry implements MapEntry {
+@API(status = EXPERIMENTAL, since = "1.0")
+public final class KeyValueMapEntry implements Expression {
 
 	private @Nullable final String key;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Limit.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Limit.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -28,7 +30,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Limit implements Visitable {
 
 	static Limit create(Number value) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ListExpression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ListExpression.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -29,7 +31,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @soundtrack Queen - Jazz
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class ListExpression implements Expression {
 
 	static ListExpression create(Expression... expressions) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ListLiteral.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ListLiteral.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.stream.Collectors.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.stream.StreamSupport;
 
@@ -29,7 +30,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class ListLiteral extends Literal<Iterable<Literal<?>>> {
 
 	ListLiteral(Iterable<Literal<?>> content) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Literal.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Literal.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.springframework.lang.Nullable;
 
@@ -28,7 +30,7 @@ import org.springframework.lang.Nullable;
  * @param <T> type of content
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public abstract class Literal<T> implements Expression {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapExpression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapExpression.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import java.util.ArrayList;
@@ -41,13 +42,13 @@ import org.springframework.util.Assert;
  * @soundtrack Rammstein - RAMMSTEIN
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public final class MapExpression<S extends MapExpression<S>> extends TypedSubtree<MapEntry, S> implements Expression {
+@API(status = INTERNAL, since = "1.0")
+public final class MapExpression<S extends MapExpression<S>> extends TypedSubtree<Expression, S> implements Expression {
 
 	static MapExpression<?> create(Object... input) {
 
 		Assert.isTrue(input.length % 2 == 0, "Need an even number of input parameters");
-		List<MapEntry> newContent = new ArrayList<>(input.length / 2);
+		List<Expression> newContent = new ArrayList<>(input.length / 2);
 		Set<String> knownKeys = new HashSet<>();
 
 		for (int i = 0; i < input.length; i += 2) {
@@ -63,23 +64,23 @@ public final class MapExpression<S extends MapExpression<S>> extends TypedSubtre
 		return new MapExpression<>(newContent);
 	}
 
-	static MapExpression<?> withEntries(List<MapEntry> entries) {
+	static MapExpression<?> withEntries(List<Expression> entries) {
 		return new MapExpression<>(entries);
 	}
 
-	private MapExpression(List<MapEntry> children) {
+	private MapExpression(List<Expression> children) {
 		super(children);
 	}
 
-	MapExpression<?> addEntries(List<MapEntry> entries) {
-		List<MapEntry> newContent = new ArrayList<>(super.children.size() + entries.size());
+	MapExpression<?> addEntries(List<Expression> entries) {
+		List<Expression> newContent = new ArrayList<>(super.children.size() + entries.size());
 		newContent.addAll(super.children);
 		newContent.addAll(entries);
 		return new MapExpression<>(newContent);
 	}
 
 	@Override
-	protected Visitable prepareVisit(MapEntry child) {
-		return child instanceof Expression ? nameOrExpression((Expression) child) : child;
+	protected Visitable prepareVisit(Expression child) {
+		return nameOrExpression(child);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MapProjection.java
@@ -18,6 +18,9 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+import static org.neo4j.springframework.data.core.cypher.Expressions.*;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +35,7 @@ import org.springframework.util.Assert;
  *
  * @author Michael J. Simons
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class MapProjection implements Expression {
 
 	private SymbolicName name;
@@ -67,8 +70,8 @@ public final class MapProjection implements Expression {
 		visitor.leave(this);
 	}
 
-	private static List<MapEntry> createNewContent(Object... content) {
-		final List<MapEntry> newContent = new ArrayList<>(content.length);
+	private static List<Expression> createNewContent(Object... content) {
+		final List<Expression> newContent = new ArrayList<>(content.length);
 		final Set<String> knownKeys = new HashSet<>();
 
 		String lastKey = null;
@@ -80,9 +83,9 @@ public final class MapProjection implements Expression {
 			if (i + 1 >= content.length) {
 				next = null;
 			} else {
-				next = content[i + 1];
+				next = nameOrExpression(content[i + 1]);
 			}
-			Object current = content[i];
+			Object current = nameOrExpression(content[i]);
 
 			if (current instanceof String) {
 				if (next instanceof Expression) {
@@ -106,13 +109,13 @@ public final class MapProjection implements Expression {
 				lastExpression = new PropertyLookup("*");
 			}
 
-			final MapEntry entry;
+			final Expression entry;
 			if (lastKey != null) {
 				Assert.isTrue(!knownKeys.contains(lastKey), "Duplicate key '" + lastKey + "'");
 				entry = new KeyValueMapEntry(lastKey, lastExpression);
 				knownKeys.add(lastKey);
-			} else if (lastExpression instanceof MapEntry) {
-				entry = (MapEntry) lastExpression;
+			} else if (lastExpression instanceof SymbolicName || lastExpression instanceof PropertyLookup) {
+				entry = lastExpression;
 			} else {
 				throw new IllegalArgumentException(lastExpression + " of type " + lastExpression.getClass()
 					+ " cannot be used with an implicit name as map entry.");

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Match.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Match.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -29,7 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Match implements ReadingClause {
 
 	private final boolean optional;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Merge.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Merge.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @soundtrack Die Ärzte - Seitenhirsch
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Merge implements UpdatingClause {
 
 	private final Pattern pattern;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MultiPartQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/MultiPartQuery.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,7 +34,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @soundtrack Ferris MC - Ferris MC's Audiobiographie
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class MultiPartQuery implements SingleQuery {
 
 	private final List<MultiPartElement> parts;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Named.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Named.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -28,8 +30,12 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface Named {
 
 	Optional<SymbolicName> getSymbolicName();
+
+	default SymbolicName getRequiredSymbolicName() {
+		return getSymbolicName().orElseThrow(() -> new IllegalStateException("No name present."));
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NestedExpression.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NestedExpression.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import org.apiguardian.api.API;
@@ -27,7 +28,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class NestedExpression implements Expression {
 
 	private final Expression delegate;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -104,6 +104,18 @@ public final class Node implements PatternElement, Named, ExposesRelationships<R
 	}
 
 	/**
+	 * Creates a copy of this node with a new symbolic name.
+	 *
+	 * @param newSymbolicName the new symbolic name.
+	 * @return The new node.
+	 */
+	public Node named(SymbolicName newSymbolicName) {
+
+		Assert.notNull(newSymbolicName, "Symbolic name is required.");
+		return new Node(newSymbolicName, properties, labels);
+	}
+
+	/**
 	 * Creates a a copy of this node with additional properties. Creates a node without properties when no properties
 	 * * are passed to this method.
 	 *

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.stream.Collectors.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,8 +39,8 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public final class Node implements PatternElement, Named, Expression, ExposesRelationships<Relationship> {
+@API(status = EXPERIMENTAL, since = "1.0")
+public final class Node implements PatternElement, Named, ExposesRelationships<Relationship> {
 
 	static Node create(String primaryLabel, String... additionalLabels) {
 
@@ -137,7 +138,7 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 	 * @param entries A list of entries for the projection
 	 * @return A map projection.
 	 */
-	public MapProjection project(List<?> entries) {
+	public MapProjection project(List<Object> entries) {
 		return project(entries.toArray());
 	}
 
@@ -151,7 +152,7 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 	 * @return A map projection.
 	 */
 	public MapProjection project(Object... entries) {
-		return MapProjection.create(this.getSymbolicName().orElseThrow(() -> new IllegalStateException("Cannot project a node without a symbolic name.")), entries);
+		return MapProjection.create(this.getRequiredSymbolicName(), entries);
 	}
 
 	/**
@@ -222,5 +223,40 @@ public final class Node implements PatternElement, Named, Expression, ExposesRel
 			"symbolicName=" + symbolicName +
 			", labels=" + labels +
 			'}';
+	}
+
+	public Condition isEqualTo(Node otherNode) {
+
+		return this.getRequiredSymbolicName().isEqualTo(otherNode.getRequiredSymbolicName());
+	}
+
+	public Condition isNotEqualTo(Node otherNode) {
+
+		return this.getRequiredSymbolicName().isNotEqualTo(otherNode.getRequiredSymbolicName());
+	}
+
+	public Condition isNull() {
+
+		return this.getRequiredSymbolicName().isNull();
+	}
+
+	public Condition isNotNull() {
+
+		return this.getRequiredSymbolicName().isNotNull();
+	}
+
+	public SortItem descending() {
+
+		return this.getRequiredSymbolicName().descending();
+	}
+
+	public SortItem ascending() {
+
+		return this.getRequiredSymbolicName().ascending();
+	}
+
+	public AliasedExpression as(String alias) {
+
+		return this.getRequiredSymbolicName().as(alias);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NodeLabel.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NodeLabel.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @soundtrack Richard Gibbs - Battlestar Galactica OST
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class NodeLabel implements Visitable {
 
 	private final String value;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NodeLabels.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NodeLabels.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -30,7 +32,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 final class NodeLabels implements Visitable {
 
 	private final List<NodeLabel> values;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NotCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NotCondition.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class NotCondition implements Condition {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NullLiteral.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NullLiteral.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -27,7 +29,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class NullLiteral extends Literal<Void> {
 
 	static final NullLiteral INSTANCE = new NullLiteral();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NumberLiteral.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/NumberLiteral.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -25,7 +27,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class NumberLiteral extends Literal<Number> {
 
 	NumberLiteral(Number content) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operation.java
@@ -65,7 +65,7 @@ public final class Operation implements Expression {
 		Assert.notEmpty(nodeLabels, "The labels cannot be empty.");
 
 		List<NodeLabel> listOfNodeLabels = Arrays.stream(nodeLabels).map(NodeLabel::new).collect(toList());
-		return new Operation(op1.getSymbolicName().get(), operator, new NodeLabels(listOfNodeLabels));
+		return new Operation(op1.getRequiredSymbolicName(), operator, new NodeLabels(listOfNodeLabels));
 	}
 
 	private final Expression left;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operation.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operation.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.stream.Collectors.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -35,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Operation implements Expression {
 
 	/**
@@ -64,7 +65,7 @@ public final class Operation implements Expression {
 		Assert.notEmpty(nodeLabels, "The labels cannot be empty.");
 
 		List<NodeLabel> listOfNodeLabels = Arrays.stream(nodeLabels).map(NodeLabel::new).collect(toList());
-		return new Operation(op1, operator, new NodeLabels(listOfNodeLabels));
+		return new Operation(op1.getSymbolicName().get(), operator, new NodeLabels(listOfNodeLabels));
 	}
 
 	private final Expression left;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operations.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operations.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -26,7 +28,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 final class Operations {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Operator.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public enum Operator implements Visitable {
 
 	// Mathematical operators

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Order.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Order.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -31,7 +33,7 @@ import org.neo4j.springframework.data.core.cypher.support.TypedSubtree;
  * @param <S> The order's entry type
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Order<S extends Order<S>> extends TypedSubtree<SortItem, S> {
 
 	Order(List<SortItem> sortItems) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Parameter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Parameter.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.springframework.util.Assert;
 
@@ -27,7 +29,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Parameter implements Expression {
 
 	private final String name;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pattern.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pattern.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -33,7 +35,7 @@ import org.neo4j.springframework.data.core.cypher.support.TypedSubtree;
  * @param <S> The pattern's entry type
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Pattern<S extends Pattern<S>> extends TypedSubtree<PatternElement, S> {
 
 	Pattern(List<PatternElement> patternElements) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternComprehension.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.neo4j.springframework.data.core.cypher.Expressions.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,6 +57,15 @@ public final class PatternComprehension implements Expression {
 	 * Provides the final step of defining a pattern comprehension.
 	 */
 	public interface OngoingDefinitionWithPattern {
+
+		/**
+		 * @param variables the elements to be returned from the pattern
+		 * @return The final definition of the pattern comprehension
+		 * @see #returning(Expression...)
+		 */
+		default PatternComprehension returning(Named... variables) {
+			return returning(createSymbolicNames(variables));
+		}
 
 		/**
 		 * @param listDefinition Defines the elements to be returned from the pattern

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternElement.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PatternElement.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
@@ -25,6 +27,6 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface PatternElement extends Visitable {
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pipe.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Pipe.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -26,7 +28,7 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 final class Pipe extends Literal<String> {
 
 	public static final Pipe INSTANCE = new Pipe();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Properties.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Properties.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Properties implements Visitable {
 
 	private final MapExpression<?> properties;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 import org.springframework.util.Assert;
@@ -28,7 +30,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Property implements Expression {
 
 	static Property create(Node parentContainer, String name) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PropertyLookup.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/PropertyLookup.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 
 /**
@@ -26,8 +28,8 @@ import org.apiguardian.api.API;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
-public final class PropertyLookup implements MapEntry, Expression {
+@API(status = EXPERIMENTAL, since = "1.0")
+public final class PropertyLookup implements Expression {
 
 	private final String propertyKeyName;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -133,6 +133,18 @@ public final class Relationship implements
 	}
 
 	/**
+	 * Creates a copy of this relationship with a new symbolic name.
+	 *
+	 * @param newSymbolicName the new symbolic name.
+	 * @return The new relationship.
+	 */
+	public Relationship named(SymbolicName newSymbolicName) {
+
+		// Sanity check of newSymbolicName delegated to the details.
+		return new Relationship(this.left, this.details.named(newSymbolicName), this.right);
+	}
+
+	/**
 	 * Creates a new relationship with a new minimum length
 	 *
 	 * @param minimum the new minimum

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.stream.Collectors.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,9 +37,9 @@ import org.springframework.util.Assert;
  * @author Philipp Tölle
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Relationship implements
-	PatternElement, Named, Expression, MapEntry,
+	PatternElement, Named,
 	ExposesRelationships<RelationshipChain> {
 
 	/**
@@ -244,8 +245,6 @@ public final class Relationship implements
 	 * @return A map projection.
 	 */
 	public MapProjection project(Object... entries) {
-		return MapProjection.create(this.getSymbolicName()
-				.orElseThrow(() -> new IllegalStateException("Cannot project a relationship without a symbolic name.")),
-			entries);
+		return MapProjection.create(this.getRequiredSymbolicName(), entries);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipChain.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipChain.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.support.Visitable.*;
 
 import java.util.LinkedList;
@@ -33,7 +34,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class RelationshipChain implements PatternElement, ExposesRelationships<RelationshipChain> {
 
 	private final LinkedList<Relationship> relationships = new LinkedList<>();

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -34,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Philipp Tölle
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class RelationshipDetail implements Visitable {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipDetail.java
@@ -75,8 +75,13 @@ public final class RelationshipDetail implements Visitable {
 	RelationshipDetail named(String newSymbolicName) {
 
 		Assert.hasText(newSymbolicName, "Symbolic name is required.");
-		return new RelationshipDetail(this.direction, SymbolicName.create(newSymbolicName), this.types, this.length,
-			this.properties);
+		return named(SymbolicName.create(newSymbolicName));
+	}
+
+	RelationshipDetail named(SymbolicName newSymbolicName) {
+
+		Assert.notNull(newSymbolicName, "Symbolic name is required.");
+		return new RelationshipDetail(this.direction, newSymbolicName, this.types, this.length, this.properties);
 	}
 
 	RelationshipDetail with(@Nullable Properties newProperties) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipLength.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipLength.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class RelationshipLength implements Visitable {
 
 	private final Integer minimum;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipTypes.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipTypes.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -29,7 +31,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class RelationshipTypes implements Visitable {
 
 	private final List<String> values;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Remove.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Remove.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Remove implements UpdatingClause {
 
 	private final ExpressionList setItems;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Return.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Return.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Return implements Visitable {
 
 	private final boolean distinct;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ReturnBody.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ReturnBody.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -31,7 +33,7 @@ import org.springframework.lang.Nullable;
  * @soundtrack Ferris MC - Ferris MC's Audiobiographie
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class ReturnBody implements Visitable {
 
 	private final ExpressionList returnItems;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Set.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Set.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -27,7 +29,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Set implements UpdatingClause {
 
 	private final ExpressionList setItems;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SinglePartQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SinglePartQuery.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class SinglePartQuery implements SingleQuery {
 
 	private final List<Visitable> precedingClauses;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Skip.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Skip.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -28,7 +30,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Skip implements Visitable {
 
 	static Skip create(Number value) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SortItem.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SortItem.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import java.util.Optional;
@@ -32,7 +33,7 @@ import org.springframework.lang.Nullable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class SortItem implements Visitable {
 
 	private final Expression expression;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Statement.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Statement.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 
@@ -31,7 +33,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface Statement extends Visitable {
 
 	static StatementBuilder builder() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
 import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import org.apiguardian.api.API;
@@ -28,7 +29,7 @@ import org.springframework.lang.Nullable;
  * @author Gerrit Meier
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public interface StatementBuilder {
 
 	/**
@@ -285,6 +286,10 @@ public interface StatementBuilder {
 			return returning(createSymbolicNames(variables));
 		}
 
+		default OngoingReadingAndReturn returning(Named... variables) {
+			return returning(createSymbolicNames(variables));
+		}
+
 		/**
 		 * Create a match that returns one or more expressions.
 		 *
@@ -297,6 +302,9 @@ public interface StatementBuilder {
 			return returningDistinct(createSymbolicNames(variables));
 		}
 
+		default OngoingReadingAndReturn returningDistinct(Named... variables) {
+			return returningDistinct(createSymbolicNames(variables));
+		}
 
 		/**
 		 * Create a match that returns the distinct set of one or more expressions.
@@ -314,7 +322,21 @@ public interface StatementBuilder {
 	 */
 	interface ExposesWith {
 
+		/**
+		 * @param variables The variables to pass on to the next part
+		 * @return A match that can be build now
+		 * @see #with(Expression...)
+		 */
 		default OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
+			return with(createSymbolicNames(variables));
+		}
+
+		/**
+		 * @param variables The variables to pass on to the next part
+		 * @return A match that can be build now
+		 * @see #with(Expression...)
+		 */
+		default OrderableOngoingReadingAndWithWithoutWhere with(Named... variables) {
 			return with(createSymbolicNames(variables));
 		}
 
@@ -326,7 +348,21 @@ public interface StatementBuilder {
 		 */
 		OrderableOngoingReadingAndWithWithoutWhere with(Expression... expressions);
 
+		/**
+		 * @param variables The variables to pass on to the next part
+		 * @return A match that can be build now
+		 * @see #withDistinct(Expression...)
+		 */
 		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(String... variables) {
+			return withDistinct(createSymbolicNames(variables));
+		}
+
+		/**
+		 * @param variables The variables to pass on to the next part
+		 * @return A match that can be build now
+		 * @see #withDistinct(Expression...)
+		 */
+		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(Named... variables) {
 			return withDistinct(createSymbolicNames(variables));
 		}
 
@@ -470,6 +506,10 @@ public interface StatementBuilder {
 			return delete(createSymbolicNames(variables));
 		}
 
+		default <T extends OngoingUpdate & BuildableStatement> T delete(Named... variables) {
+			return delete(createSymbolicNames(variables));
+		}
+
 		/**
 		 * Creates a delete step with one or more expressions to be deleted.
 		 *
@@ -478,7 +518,11 @@ public interface StatementBuilder {
 		 */
 		<T extends OngoingUpdate & BuildableStatement> T delete(Expression... expressions);
 
-		default OrderableOngoingReadingAndWithWithoutWhere detachDelete(String... variables) {
+		default <T extends OngoingUpdate & BuildableStatement> T detachDelete(String... variables) {
+			return detachDelete(createSymbolicNames(variables));
+		}
+
+		default <T extends OngoingUpdate & BuildableStatement> T detachDelete(Named... variables) {
 			return detachDelete(createSymbolicNames(variables));
 		}
 
@@ -505,6 +549,10 @@ public interface StatementBuilder {
 		 * @return An ongoing match and update
 		 */
 		<T extends OngoingMatchAndUpdate & BuildableStatement> T set(Expression... expressions);
+
+		default <T extends OngoingMatchAndUpdate & BuildableStatement> T set(Named variable, Expression expression) {
+			return set(variable.getSymbolicName().orElseThrow(() -> new IllegalArgumentException("No name present on the named item.")), expression);
+		}
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StringLiteral.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StringLiteral.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.regex.Pattern.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -35,7 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class StringLiteral extends Literal<CharSequence> {
 
 	private static final Pattern RESERVED_CHARS = Pattern.compile("([" + quote("\\'\"") + "])");

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
@@ -20,6 +20,8 @@ package org.neo4j.springframework.data.core.cypher;
 
 import static org.apiguardian.api.API.Status.*;
 
+import java.util.Objects;
+
 import org.apiguardian.api.API;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
@@ -39,20 +41,21 @@ import org.springframework.util.Assert;
 @API(status = EXPERIMENTAL, since = "1.0")
 public final class SymbolicName implements Expression {
 
-	private final String name;
+	private final String value;
 
 	static SymbolicName create(String name) {
 
+		Assert.hasText(name, "Name must not be empty.");
 		Assert.isTrue(Cypher.isIdentifier(name), "Name must be a valid identifier.");
 		return new SymbolicName(name);
 	}
 
-	private SymbolicName(String name) {
-		this.name = name;
+	private SymbolicName(String value) {
+		this.value = value;
 	}
 
-	public String getName() {
-		return name;
+	public String getValue() {
+		return value;
 	}
 
 	@NonNull
@@ -62,13 +65,30 @@ public final class SymbolicName implements Expression {
 		if (otherValue.isEmpty()) {
 			return this;
 		}
-		return SymbolicName.create(this.name + otherValue);
+		return SymbolicName.create(this.value + otherValue);
 	}
 
 	@Override
 	public String toString() {
 		return "SymbolicName{" +
-			"name='" + name + '\'' +
+			"name='" + value + '\'' +
 			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SymbolicName that = (SymbolicName) o;
+		return value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(value);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
@@ -18,11 +18,13 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.springframework.util.Assert;
 
 /**
- * A symbolic name to identify nodes and relationships.
+ * A symbolic name to identify nodes, relationships and aliased items.
  * <p>
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/SchemaName.html">SchemaName</a>
  * <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/SymbolicName.html">SymbolicName</a>
@@ -33,7 +35,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class SymbolicName implements Expression {
 
 	private final String name;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/SymbolicName.java
@@ -21,6 +21,7 @@ package org.neo4j.springframework.data.core.cypher;
 import static org.apiguardian.api.API.Status.*;
 
 import org.apiguardian.api.API;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -52,6 +53,16 @@ public final class SymbolicName implements Expression {
 
 	public String getName() {
 		return name;
+	}
+
+	@NonNull
+	public SymbolicName concat(String otherValue) {
+
+		Assert.notNull(otherValue, "Value to concat must not be null.");
+		if (otherValue.isEmpty()) {
+			return this;
+		}
+		return SymbolicName.create(this.name + otherValue);
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/UnionPart.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/UnionPart.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.Statement.SingleQuery;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
@@ -29,7 +31,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class UnionPart implements Visitable {
 
 	private final boolean all;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/UnionQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/UnionQuery.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.core.cypher;
 
 import static java.util.stream.Collectors.*;
+import static org.apiguardian.api.API.Status.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ import org.springframework.util.Assert;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class UnionQuery implements RegularQuery {
 
 	static UnionQuery create(boolean unionAll, List<SingleQuery> queries) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Unwind.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Unwind.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @soundtrack Queen - Jazz
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Unwind implements ReadingClause {
 
 	private final Expression expressionToUnwind;
@@ -38,7 +40,7 @@ public final class Unwind implements ReadingClause {
 	Unwind(Expression expressionToUnwind, String variable) {
 
 		if (expressionToUnwind instanceof Aliased) {
-			this.expressionToUnwind = SymbolicName.create(((Aliased) expressionToUnwind).getAlias());
+			this.expressionToUnwind = ((Aliased) expressionToUnwind).asName();
 		} else {
 			this.expressionToUnwind = expressionToUnwind;
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Where.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Where.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -28,7 +30,7 @@ import org.neo4j.springframework.data.core.cypher.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class Where implements Visitable {
 
 	private final Condition condition;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/With.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/With.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
+import static org.apiguardian.api.API.Status.*;
+
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.support.Visitable;
 import org.neo4j.springframework.data.core.cypher.support.Visitor;
@@ -30,7 +32,7 @@ import org.springframework.lang.Nullable;
  * @soundtrack Ferris MC - Ferris MC's Audiobiographie
  * @since 1.0
  */
-@API(status = API.Status.INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.0")
 public final class With implements Visitable {
 
 	private final boolean distinct;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/Renderer.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/Renderer.java
@@ -18,6 +18,9 @@
  */
 package org.neo4j.springframework.data.core.cypher.renderer;
 
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.Statement;
 
 /**
@@ -25,6 +28,7 @@ import org.neo4j.springframework.data.core.cypher.Statement;
  * @author Michael J. Simons
  * @since 1.0
  */
+@API(status = INTERNAL, since = "1.0")
 public interface Renderer {
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/renderer/RenderingVisitor.java
@@ -284,7 +284,7 @@ class RenderingVisitor extends ReflectiveVisitor {
 
 		// This is only relevant for nodes in relationships.
 		// Otherwise all the labels would be rendered again.
-		node.getSymbolicName().map(SymbolicName::getName).ifPresent(symbolicName -> {
+		node.getSymbolicName().map(SymbolicName::getValue).ifPresent(symbolicName -> {
 			skipNodeContent = visitedNamed.contains(node);
 			visitedNamed.add(node);
 
@@ -312,7 +312,7 @@ class RenderingVisitor extends ReflectiveVisitor {
 	}
 
 	void enter(SymbolicName symbolicName) {
-		builder.append(symbolicName.getName());
+		builder.append(symbolicName.getValue());
 	}
 
 	void enter(RelationshipDetail details) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -19,7 +19,7 @@
 package org.neo4j.springframework.data.core.mapping;
 
 import static java.util.stream.Collectors.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 import static org.neo4j.springframework.data.core.schema.RelationshipDescription.*;
 
 import java.util.ArrayList;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Constants.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Constants.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.schema;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.cypher.Cypher;
+import org.neo4j.springframework.data.core.cypher.SymbolicName;
+
+/**
+ * A pool of constants used in our Cypher generation. These constants may change without further notice.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Milky Chance - Sadnecessary
+ * @since 1.0
+ */
+@API(status = INTERNAL, since = "1.0")
+public final class Constants {
+
+	public static final SymbolicName NAME_OF_ROOT_NODE = Cypher.name("n");
+
+	public static final String NAME_OF_INTERNAL_ID = "__internalNeo4jId__";
+	public static final String NAME_OF_LABELS = "__nodeLabels__";
+	public static final String NAME_OF_IDS_RESULT = "__ids__";
+	public static final String NAME_OF_ID_PARAM = "__id__";
+	public static final String NAME_OF_VERSION_PARAM = "__version__";
+	public static final String NAME_OF_PROPERTIES_PARAM = "__properties__";
+	public static final String NAME_OF_ENTITY_LIST_PARAM = "__entities__";
+
+	public static final String FROM_ID_PARAMETER_NAME = "fromId";
+
+	private Constants() {
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
@@ -19,7 +19,7 @@
 package org.neo4j.springframework.data.core.schema;
 
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 import static org.neo4j.springframework.data.core.schema.RelationshipDescription.*;
 
 import java.util.ArrayList;
@@ -29,13 +29,13 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
-import org.jetbrains.annotations.NotNull;
-import org.neo4j.springframework.data.core.cypher.*;
 import org.neo4j.springframework.data.core.cypher.Node;
 import org.neo4j.springframework.data.core.cypher.Relationship;
+import org.neo4j.springframework.data.core.cypher.*;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -54,12 +54,10 @@ public enum CypherGenerator {
 
 	INSTANCE;
 
-	public static final String FROM_ID_PARAMETER_NAME = "fromId";
+	private static final SymbolicName START_NODE_NAME = Cypher.name("startNode");
+	private static final SymbolicName END_NODE_NAME = Cypher.name("endNode");
 
-	private static final String START_NODE_NAME = "startNode";
-	private static final String END_NODE_NAME = "endNode";
-
-	private static final String RELATIONSHIP_NAME = "relProps";
+	private static final SymbolicName RELATIONSHIP_NAME = Cypher.name("relProps");
 
 	private static final int RELATIONSHIP_DEPTH_LIMIT = 2;
 
@@ -95,7 +93,7 @@ public enum CypherGenerator {
 		IdDescription idDescription = nodeDescription.getIdDescription();
 
 		List<Expression> expressions = new ArrayList<>();
-		expressions.add(rootNode.getSymbolicName().get());
+		expressions.add(NAME_OF_ROOT_NODE);
 		if (idDescription.isInternallyGeneratedId()) {
 			expressions.add(Functions.id(rootNode).as(NAME_OF_INTERNAL_ID));
 		}
@@ -226,7 +224,7 @@ public enum CypherGenerator {
 			.build();
 	}
 
-	@NotNull
+	@NonNull
 	public Statement createRelationshipCreationQuery(Neo4jPersistentEntity<?> neo4jPersistentEntity,
 		RelationshipDescription relationship, @Nullable String dynamicRelationshipType, Long relatedInternalId) {
 
@@ -249,7 +247,7 @@ public enum CypherGenerator {
 			.build();
 	}
 
-	@NotNull
+	@NonNull
 	public Statement createRelationshipWithPropertiesCreationQuery(Neo4jPersistentEntity<?> neo4jPersistentEntity,
 		RelationshipDescription relationship, Long relatedInternalId) {
 
@@ -279,15 +277,11 @@ public enum CypherGenerator {
 				? relOutgoing
 				: relIncoming
 			)
-			.set((relationship.isOutgoing()
-					? relOutgoing
-					: relIncoming).getSymbolicName().get(),
-				relationshipProperties
-			)
+			.set(RELATIONSHIP_NAME, relationshipProperties)
 			.build();
 	}
 
-	@NotNull
+	@NonNull
 	public Statement createRelationshipRemoveQuery(Neo4jPersistentEntity<?> neo4jPersistentEntity,
 		RelationshipDescription relationshipDescription, Neo4jPersistentEntity relatedNode) {
 
@@ -333,7 +327,8 @@ public enum CypherGenerator {
 			processedRelationships);
 	}
 
-	private MapProjection projectAllPropertiesAndRelationships(NodeDescription<?> nodeDescription, String nodeName,
+	private MapProjection projectAllPropertiesAndRelationships(NodeDescription<?> nodeDescription,
+		SymbolicName nodeName,
 		List<RelationshipDescription> processedRelationships) {
 
 		Predicate<String> includeAllFields = (field) -> true;
@@ -341,7 +336,7 @@ public enum CypherGenerator {
 	}
 
 	private MapProjection projectPropertiesAndRelationships(NodeDescription<?> nodeDescription,
-		String nodeName,
+		SymbolicName nodeName,
 		Predicate<String> includeProperty,
 		List<RelationshipDescription> processedRelationships) {
 
@@ -359,8 +354,8 @@ public enum CypherGenerator {
 	 * this list can also contain two "keys" in a row. The {@link MapProjection} will take care to handle them as
 	 * self-reflecting fields. Example with self-reflection and explicit value: {@code n {.id, name: n.name}}.
 	 */
-	private List<Object> projectNodeProperties(NodeDescription<?> nodeDescription, String nodeName,
-			Predicate<String> includeField) {
+	private List<Object> projectNodeProperties(NodeDescription<?> nodeDescription, SymbolicName nodeName,
+		Predicate<String> includeField) {
 
 		List<Object> nodePropertiesProjection = new ArrayList<>();
 		Node node = anyNode(nodeName);
@@ -387,7 +382,7 @@ public enum CypherGenerator {
 	 * @see org.neo4j.springframework.data.core.schema.CypherGenerator#projectNodeProperties
 	 */
 	private List<Object> generateListsFor(Collection<RelationshipDescription> relationships,
-		String nodeName, Predicate<String> includeField,
+		SymbolicName nodeName, Predicate<String> includeField,
 		List<RelationshipDescription> processedRelationships) {
 
 		List<Object> mapProjectionLists = new ArrayList<>();
@@ -416,7 +411,7 @@ public enum CypherGenerator {
 		return mapProjectionLists;
 	}
 
-	private void generateListFor(RelationshipDescription relationshipDescription, String nodeName,
+	private void generateListFor(RelationshipDescription relationshipDescription, SymbolicName nodeName,
 		List<RelationshipDescription> processedRelationships, String fieldName, List<Object> mapProjectionLists) {
 
 		String relationshipType = relationshipDescription.getType();
@@ -425,7 +420,7 @@ public enum CypherGenerator {
 		List<String> targetAdditionalLabels = relationshipDescription.getTarget().getAdditionalLabels();
 
 		Node startNode = anyNode(nodeName);
-		String relationshipFieldName = concatFieldName(nodeName, fieldName);
+		SymbolicName relationshipFieldName = nodeName.concat("_" + fieldName);
 		Node endNode = node(targetPrimaryLabel, targetAdditionalLabels).named(relationshipFieldName);
 		NodeDescription<?> endNodeDescription = relationshipDescription.getTarget();
 
@@ -468,11 +463,6 @@ public enum CypherGenerator {
 	private void addMapProjection(String name, Object projection, List<Object> projectionList) {
 		projectionList.add(name);
 		projectionList.add(projection);
-	}
-
-	@NotNull
-	private String concatFieldName(String nameOfStartNode, String fieldName) {
-		return nameOfStartNode + "_" + fieldName;
 	}
 
 	private static Condition conditionOrNoCondition(@Nullable Condition condition) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
@@ -95,7 +95,7 @@ public enum CypherGenerator {
 		IdDescription idDescription = nodeDescription.getIdDescription();
 
 		List<Expression> expressions = new ArrayList<>();
-		expressions.add(rootNode);
+		expressions.add(rootNode.getSymbolicName().get());
 		if (idDescription.isInternallyGeneratedId()) {
 			expressions.add(Functions.id(rootNode).as(NAME_OF_INTERNAL_ID));
 		}
@@ -279,9 +279,9 @@ public enum CypherGenerator {
 				? relOutgoing
 				: relIncoming
 			)
-			.set(relationship.isOutgoing()
+			.set((relationship.isOutgoing()
 					? relOutgoing
-					: relIncoming,
+					: relIncoming).getSymbolicName().get(),
 				relationshipProperties
 			)
 			.build();
@@ -363,6 +363,7 @@ public enum CypherGenerator {
 			Predicate<String> includeField) {
 
 		List<Object> nodePropertiesProjection = new ArrayList<>();
+		Node node = anyNode(nodeName);
 		for (GraphPropertyDescription property : nodeDescription.getGraphPropertiesInHierarchy()) {
 			if (!includeField.test(property.getFieldName())) {
 				continue;
@@ -370,14 +371,14 @@ public enum CypherGenerator {
 
 			if (property.isInternalIdProperty()) {
 				nodePropertiesProjection.add(NAME_OF_INTERNAL_ID);
-				nodePropertiesProjection.add(Functions.id(Cypher.name(nodeName)));
+				nodePropertiesProjection.add(Functions.id(node));
 			} else {
 				nodePropertiesProjection.add(property.getPropertyName());
 			}
 		}
 
 		nodePropertiesProjection.add(NAME_OF_LABELS);
-		nodePropertiesProjection.add(Functions.labels(Cypher.name(nodeName)));
+		nodePropertiesProjection.add(Functions.labels(node));
 
 		return nodePropertiesProjection;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
@@ -24,10 +24,9 @@ import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.neo4j.springframework.data.core.cypher.Cypher;
 import org.neo4j.springframework.data.core.cypher.Expression;
 import org.neo4j.springframework.data.core.cypher.Functions;
-import org.neo4j.springframework.data.core.cypher.SymbolicName;
+import org.neo4j.springframework.data.core.cypher.Node;
 import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -96,12 +95,12 @@ public final class IdDescription {
 		this.idGeneratorRef = idGeneratorRef != null && idGeneratorRef.isEmpty() ? null : idGeneratorRef;
 		this.graphPropertyName = graphPropertyName;
 		this.idExpression = Lazy.of(() -> {
-			final SymbolicName rootNode = Cypher.name(NAME_OF_ROOT_NODE);
+			final Node rootNode = anyNode(NAME_OF_ROOT_NODE);
 			if (this.isInternallyGeneratedId()) {
 				return Functions.id(rootNode);
 			} else {
 				return this.getOptionalGraphPropertyName()
-					.map(propertyName -> property(rootNode.getName(), propertyName)).get();
+					.map(propertyName -> property(NAME_OF_ROOT_NODE, propertyName)).get();
 			}
 		});
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
@@ -19,7 +19,7 @@
 package org.neo4j.springframework.data.core.schema;
 
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 
 import java.util.Optional;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/NodeDescription.java
@@ -37,15 +37,6 @@ import org.springframework.lang.Nullable;
 @API(status = API.Status.INTERNAL, since = "1.0")
 public interface NodeDescription<T> {
 
-	String NAME_OF_ROOT_NODE = "n";
-	String NAME_OF_INTERNAL_ID = "__internalNeo4jId__";
-	String NAME_OF_LABELS = "__nodeLabels__";
-	String NAME_OF_IDS_RESULT = "__ids__";
-	String NAME_OF_ID_PARAM = "__id__";
-	String NAME_OF_VERSION_PARAM = "__version__";
-	String NAME_OF_PROPERTIES_PARAM = "__properties__";
-	String NAME_OF_ENTITY_LIST_PARAM = "__entities__";
-
 	/**
 	 * @return The primary label of this entity inside Neo4j.
 	 */

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherAdapterUtils.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.repository.query;
 
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 
 import java.util.function.Function;
 
@@ -26,7 +27,6 @@ import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.cypher.Cypher;
 import org.neo4j.springframework.data.core.cypher.SortItem;
 import org.neo4j.springframework.data.core.cypher.StatementBuilder;
-import org.neo4j.springframework.data.core.cypher.SymbolicName;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 import org.neo4j.springframework.data.core.schema.NodeDescription;
 import org.springframework.data.domain.Pageable;
@@ -49,14 +49,12 @@ public final class CypherAdapterUtils {
 	 * @return A stream if sort items. Will be empty when sort is unsorted.
 	 */
 	public static Function<Sort.Order, SortItem> sortAdapterFor(NodeDescription<?> nodeDescription) {
-		SymbolicName rootNode = Cypher.name(NodeDescription.NAME_OF_ROOT_NODE);
-
 		return order -> {
 			String property = nodeDescription.getGraphProperty(order.getProperty())
 				.map(GraphPropertyDescription::getPropertyName)
 				.orElseThrow(() -> new IllegalStateException(
 					String.format("Cannot order by the unknown graph property: '%s'", order.getProperty())));
-			SortItem sortItem = Cypher.sort(property(rootNode, property));
+			SortItem sortItem = Cypher.sort(property(NAME_OF_ROOT_NODE, property));
 
 			// Spring's Sort.Order defaults to ascending, so we just need to change this if we have descending order.
 			if (order.isDescending()) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -21,7 +21,7 @@ package org.neo4j.springframework.data.repository.query;
 import static java.util.stream.Collectors.*;
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
 import static org.neo4j.springframework.data.core.cypher.Functions.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 import static org.neo4j.springframework.data.repository.query.CypherAdapterUtils.*;
 import static org.neo4j.springframework.data.repository.query.PartValidator.*;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Predicate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/Predicate.java
@@ -19,7 +19,7 @@
 package org.neo4j.springframework.data.repository.support;
 
 import static org.neo4j.springframework.data.core.cypher.Cypher.*;
-import static org.neo4j.springframework.data.core.schema.NodeDescription.*;
+import static org.neo4j.springframework.data.core.schema.Constants.*;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,11 +32,9 @@ import org.apache.commons.logging.LogFactory;
 import org.neo4j.springframework.data.core.convert.Neo4jConverter;
 import org.neo4j.springframework.data.core.cypher.Condition;
 import org.neo4j.springframework.data.core.cypher.Conditions;
-import org.neo4j.springframework.data.core.cypher.Cypher;
 import org.neo4j.springframework.data.core.cypher.Expression;
 import org.neo4j.springframework.data.core.cypher.Functions;
 import org.neo4j.springframework.data.core.cypher.StatementBuilder;
-import org.neo4j.springframework.data.core.cypher.SymbolicName;
 import org.neo4j.springframework.data.core.mapping.Neo4jMappingContext;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentEntity;
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
@@ -65,7 +63,6 @@ final class Predicate {
 
 		Neo4jPersistentEntity probeNodeDescription = mappingContext.getRequiredPersistentEntity(example.getProbeType());
 
-		SymbolicName rootNode = Cypher.name(NAME_OF_ROOT_NODE);
 		Collection<GraphPropertyDescription> graphProperties = probeNodeDescription.getGraphProperties();
 		DirectFieldAccessFallbackBeanWrapper beanWrapper = new DirectFieldAccessFallbackBeanWrapper(example.getProbe());
 		ExampleMatcher matcher = example.getMatcher();
@@ -92,7 +89,7 @@ final class Predicate {
 
 			if (!optionalValue.isPresent()) {
 				if (!internalId && matcherAccessor.getNullHandler().equals(ExampleMatcher.NullHandler.INCLUDE)) {
-					predicate.add(mode, property(rootNode, propertyName).isNull());
+					predicate.add(mode, property(NAME_OF_ROOT_NODE, propertyName).isNull());
 				}
 				continue;
 			}
@@ -105,7 +102,7 @@ final class Predicate {
 				predicate
 					.add(mode, predicate.neo4jPersistentEntity.getIdExpression().isEqualTo(literalOf(optionalValue.get())));
 			} else {
-				Expression property = property(rootNode, propertyName);
+				Expression property = property(NAME_OF_ROOT_NODE, propertyName);
 				Expression parameter = parameter(propertyName);
 				Condition condition = property.isEqualTo(parameter);
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherIT.java
@@ -68,11 +68,11 @@ class CypherIT {
 				Node unnamedNode = Cypher.node("ANode");
 				Node namedNode = Cypher.node("AnotherNode").named("o");
 				Statement statement = Cypher.match(unnamedNode, namedNode)
-					.returning(unnamedNode.as("theNode"), namedNode.as("theOtherNode"))
+					.returning(namedNode.as("theOtherNode"))
 					.build();
 
 				assertThat(cypherRenderer.render(statement))
-					.isEqualTo("MATCH (:`ANode`), (o:`AnotherNode`) RETURN (:`ANode`) AS theNode, o AS theOtherNode");
+					.isEqualTo("MATCH (:`ANode`), (o:`AnotherNode`) RETURN o AS theOtherNode");
 			}
 
 			@Test
@@ -1981,7 +1981,7 @@ class CypherIT {
 				assertThatIllegalStateException().isThrownBy(() -> {
 					Node n = Cypher.node("Person");
 					n.project("something");
-				}).withMessage("Cannot project a node without a symbolic name.");
+				}).withMessage("No name present.");
 			}
 		}
 
@@ -2034,7 +2034,7 @@ class CypherIT {
 					Node m = Cypher.node("Movie").named("m");
 					Relationship rel = n.relationshipTo(m, "ACTED_IN");
 					rel.project("something");
-				}).withMessage("Cannot project a relationship without a symbolic name.");
+				}).withMessage("No name present.");
 			}
 		}
 
@@ -2154,12 +2154,12 @@ class CypherIT {
 			Relationship r_l2 = l1.relationshipFrom(p2, "LIVES_AT").named("r_l2");
 
 			statement = Cypher.match(n)
-				.returning(n,
+				.returning(n.getRequiredSymbolicName(),
 					listOf(
 						listBasedOn(r_f1).returning(r_f1, o1),
 						listBasedOn(r_e1).returning(r_e1, o1),
 						listBasedOn(r_l1).returning(
-							r_l1, l1,
+							r_l1.getRequiredSymbolicName(), l1.getRequiredSymbolicName(),
 							// The building of the statement works with and without the outer list,
 							// I'm not sure if it would be necessary for the result, but as I took the query from
 							// Neo4j-OGM, I'd like to keep it
@@ -2219,7 +2219,7 @@ class CypherIT {
 				)
 				.withDistinct(resume, locStart, app, offer)
 				.match(offer.relationshipTo(startN, "FOR"))
-				.where(Functions.id(name("start_n")).in(parameter("start_ids")))
+				.where(Functions.id(startN).in(parameter("start_ids")))
 				.returningDistinct(resume, locStart, app, offer, startN).build();
 
 			assertThat(cypherRenderer.render(statement))

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/CypherTest.java
@@ -58,7 +58,7 @@ class CypherTest {
 			} else if (segment instanceof PropertyLookup) {
 				assertThat(segment).extracting(s -> ((PropertyLookup) s).getPropertyKeyName()).isEqualTo("b");
 			} else if (segment instanceof SymbolicName) {
-				assertThat(segment).extracting("name").isEqualTo("a");
+				assertThat(segment).extracting("value").isEqualTo("a");
 			} else {
 				fail("Unexpected segment: " + segment.getClass());
 			}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/FunctionsTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/cypher/FunctionsTest.java
@@ -48,7 +48,7 @@ class FunctionsTest {
 		@Test
 		void shouldCreateCorrectInvocation() {
 
-			FunctionInvocation invocation = Functions.id(node("Test"));
+			FunctionInvocation invocation = Functions.id(node("Test").named("n"));
 			assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, "id");
 		}
 	}
@@ -59,7 +59,7 @@ class FunctionsTest {
 		@Test
 		void preconditionsShouldBeAsserted() {
 
-			assertThatIllegalArgumentException().isThrownBy(() -> Functions.count(null))
+			assertThatIllegalArgumentException().isThrownBy(() -> Functions.count((Expression) null))
 				.withMessage("The expression to count is required.");
 		}
 
@@ -101,7 +101,7 @@ class FunctionsTest {
 		@Test
 		void preconditionsShouldBeAsserted() {
 
-			assertThatIllegalArgumentException().isThrownBy(() -> Functions.collect(null))
+			assertThatIllegalArgumentException().isThrownBy(() -> Functions.collect((Expression) null))
 				.withMessage("The expression to collect is required.");
 		}
 


### PR DESCRIPTION
This also removes the `Expression` interface from both `Node` and `Relationship` which does not make sense on them. It closes #106.