### PR TITLE
Expose a set of interfaces that allow storing parts of queries in suppliers etc.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesCreate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesCreate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * A step exposing a {@link #create(PatternElement...)} method.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = EXPERIMENTAL, since = "1.0")
+public interface ExposesCreate {
+
+	/**
+	 * @param pattern patterns to create
+	 * @return An ongoing merge
+	 * @see Cypher#create(PatternElement...)
+	 */
+	<T extends StatementBuilder.OngoingUpdate & StatementBuilder.ExposesSet> T create(PatternElement... pattern);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesMatch.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesMatch.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * A step exposing a {@link #match(PatternElement...)} method. This is one of the main entry points of most Cypher queries.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = EXPERIMENTAL, since = "1.0")
+public interface ExposesMatch {
+
+	/**
+	 * Adds (another) match clause.
+	 *
+	 * @param pattern The patterns to match
+	 * @return An ongoing match that is used to specify an optional where and a required return clause
+	 */
+	StatementBuilder.OngoingReadingWithoutWhere match(PatternElement... pattern);
+
+	/**
+	 * Adds (another) optional match clause.
+	 *
+	 * @param pattern The patterns to match
+	 * @return An ongoing match that is used to specify an optional where and a required return clause
+	 */
+	StatementBuilder.OngoingReadingWithoutWhere optionalMatch(PatternElement... pattern);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesMerge.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesMerge.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * A step exposing a {@link #merge(PatternElement...)} method.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = EXPERIMENTAL, since = "1.0")
+public interface ExposesMerge {
+
+	/**
+	 * @param pattern patterns to merge
+	 * @return An ongoing merge
+	 * @see Cypher#merge(PatternElement...)
+	 */
+	<T extends StatementBuilder.OngoingUpdate & StatementBuilder.ExposesSet> T merge(PatternElement... pattern);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesReturning.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesReturning.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import static org.apiguardian.api.API.Status.*;
+import static org.neo4j.springframework.data.core.cypher.Expressions.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * Return part of a statement.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = EXPERIMENTAL, since = "1.0")
+public interface ExposesReturning {
+
+	default StatementBuilder.OngoingReadingAndReturn returning(String... variables) {
+		return returning(createSymbolicNames(variables));
+	}
+
+	default StatementBuilder.OngoingReadingAndReturn returning(Named... variables) {
+		return returning(createSymbolicNames(variables));
+	}
+
+	/**
+	 * Create a match that returns one or more expressions.
+	 *
+	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
+	 * @return A match that can be build now
+	 */
+	StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions);
+
+	default StatementBuilder.OngoingReadingAndReturn returningDistinct(String... variables) {
+		return returningDistinct(createSymbolicNames(variables));
+	}
+
+	default StatementBuilder.OngoingReadingAndReturn returningDistinct(Named... variables) {
+		return returningDistinct(createSymbolicNames(variables));
+	}
+
+	/**
+	 * Create a match that returns the distinct set of one or more expressions.
+	 *
+	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
+	 * @return A match that can be build now
+	 */
+	StatementBuilder.OngoingReadingAndReturn returningDistinct(Expression... expressions);
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesUnwind.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/ExposesUnwind.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.core.cypher;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * A step exposing a {@link #unwind(Expression...)},{@link #unwind(Expression)}, {@link #unwind(String)} and method.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+@API(status = EXPERIMENTAL, since = "1.0")
+public interface ExposesUnwind {
+
+	default StatementBuilder.OngoingUnwind unwind(Expression... expressions) {
+		return unwind(Cypher.listOf(expressions));
+	}
+
+	default StatementBuilder.OngoingUnwind unwind(String variable) {
+		return unwind(Cypher.name(variable));
+	}
+
+	StatementBuilder.OngoingUnwind unwind(Expression expression);
+}


### PR DESCRIPTION
This allows for creating suppliers or functions that return parts of queries that would naturally go into a `MATCH ... WITH a, b, c` block of a Cypher pipeline. It doesn't have any other functional changes but exposing those interfaces explicitly. 