### PR TITLE
Allow for spatial queries with Box and Polygon.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.query;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+
+/**
+ * This is a utility class that computes the bounding box of a polygon as a rectangle defined by the lower left and
+ * upper right point.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
+final class BoundingBox {
+
+	static BoundingBox of(Polygon p) {
+
+		return buildFrom(p.getPoints());
+	}
+
+	static BoundingBox of(Box b) {
+
+		return buildFrom(Arrays.asList(b.getFirst(), b.getSecond()));
+	}
+
+	private static BoundingBox buildFrom(Iterable<Point> points) {
+		double minX = Double.POSITIVE_INFINITY;
+		double maxX = Double.NEGATIVE_INFINITY;
+		double minY = Double.POSITIVE_INFINITY;
+		double maxY = Double.NEGATIVE_INFINITY;
+
+		for (Point point : points) {
+			minX = Math.min(point.getX(), minX);
+			maxX = Math.max(point.getX(), maxX);
+			minY = Math.min(point.getY(), minY);
+			maxY = Math.max(point.getY(), maxY);
+		}
+
+		return new BoundingBox(new Point(minX, minY), new Point(maxX, maxY));
+	}
+
+	private final Point lowerLeft;
+	private final Point upperRight;
+
+	private BoundingBox(Point lowerLeft, Point upperRight) {
+		this.lowerLeft = lowerLeft;
+		this.upperRight = upperRight;
+	}
+
+	public Point getLowerLeft() {
+		return lowerLeft;
+	}
+
+	public Point getUpperRight() {
+		return upperRight;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		BoundingBox that = (BoundingBox) o;
+		return lowerLeft.equals(that.lowerLeft) &&
+			upperRight.equals(that.upperRight);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(lowerLeft, upperRight);
+	}
+
+	@Override
+	public String toString() {
+		return "BoundingBox{" +
+			"ll=" + lowerLeft +
+			", ur=" + upperRight +
+			'}';
+	}
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
@@ -32,14 +32,14 @@ import org.springframework.data.geo.Polygon;
  * @author Michael J. Simons
  * @since 1.0
  */
-final class BoundingBox {
+public final class BoundingBox {
 
-	static BoundingBox of(Polygon p) {
+	public static BoundingBox of(Polygon p) {
 
 		return buildFrom(p.getPoints());
 	}
 
-	static BoundingBox of(Box b) {
+	public static BoundingBox of(Box b) {
 
 		return buildFrom(Arrays.asList(b.getFirst(), b.getSecond()));
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/BoundingBox.java
@@ -45,15 +45,19 @@ public final class BoundingBox {
 	}
 
 	private static BoundingBox buildFrom(Iterable<Point> points) {
+
 		double minX = Double.POSITIVE_INFINITY;
-		double maxX = Double.NEGATIVE_INFINITY;
 		double minY = Double.POSITIVE_INFINITY;
+
+		double maxX = Double.NEGATIVE_INFINITY;
 		double maxY = Double.NEGATIVE_INFINITY;
 
 		for (Point point : points) {
+
 			minX = Math.min(point.getX(), minX);
-			maxX = Math.max(point.getX(), maxX);
 			minY = Math.min(point.getY(), minY);
+
+			maxX = Math.max(point.getX(), maxX);
 			maxY = Math.max(point.getY(), maxY);
 		}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -358,7 +358,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 			Expression distanceFunction = Functions
 				.distance(toCypherProperty(persistentProperty, false), referencePoint);
 			return distanceFunction.lte(createCypherParameter(area.nameOrIndex + ".radius", false));
-		} else if (area.hasValueOfType(Polygon.class) || area.hasValueOfType(Box.class)) {
+		} else if (area.hasValueOfType(BoundingBox.class) || area.hasValueOfType(Box.class)) {
 			Expression llx = createCypherParameter(area.nameOrIndex + ".llx", false);
 			Expression lly = createCypherParameter(area.nameOrIndex + ".lly", false);
 			Expression urx = createCypherParameter(area.nameOrIndex + ".urx", false);
@@ -368,8 +368,10 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 			Expression y = Cypher.property(toCypherProperty(persistentProperty, false), "y");
 
 			return llx.lte(x).and(x.lte(urx)).and(lly.lte(y)).and(y.lte(ury));
+		} else if (area.hasValueOfType(Polygon.class)) {
+			throw new IllegalArgumentException(String.format("The WITHIN operation does not support a %s. You might want to pass a bounding box instead: %s.of(polygon).", Polygon.class, BoundingBox.class));
 		} else {
-			throw new IllegalArgumentException(String.format("The WITHIN operation requires an area of type %s, %s or %s.", Circle.class, Polygon.class, Box.class));
+			throw new IllegalArgumentException(String.format("The WITHIN operation requires an area of type %s or %s.", Circle.class, Box.class));
 		}
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -57,8 +57,10 @@ import org.neo4j.springframework.data.repository.query.Neo4jQueryMethod.Neo4jPar
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Polygon;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
@@ -345,7 +347,6 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 
 	private Condition createWithinCondition(GraphPropertyDescription persistentProperty,
 		Iterator<Object> actualParameters) {
-
 		Parameter area = nextRequiredParameter(actualParameters);
 		if (area.hasValueOfType(Circle.class)) {
 			// We don't know the CRS of the point, so we assume the same as the reference toCypherProperty
@@ -357,9 +358,18 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 			Expression distanceFunction = Functions
 				.distance(toCypherProperty(persistentProperty, false), referencePoint);
 			return distanceFunction.lte(createCypherParameter(area.nameOrIndex + ".radius", false));
+		} else if (area.hasValueOfType(Polygon.class) || area.hasValueOfType(Box.class)) {
+			Expression llx = createCypherParameter(area.nameOrIndex + ".llx", false);
+			Expression lly = createCypherParameter(area.nameOrIndex + ".lly", false);
+			Expression urx = createCypherParameter(area.nameOrIndex + ".urx", false);
+			Expression ury = createCypherParameter(area.nameOrIndex + ".ury", false);
+
+			Expression x = Cypher.property(toCypherProperty(persistentProperty, false), "x");
+			Expression y = Cypher.property(toCypherProperty(persistentProperty, false), "y");
+
+			return llx.lte(x).and(x.lte(urx)).and(lly.lte(y)).and(y.lte(ury));
 		} else {
-			throw new IllegalArgumentException(
-				String.format("The WITHIN operation requires an area of type %s or %s.", Circle.class));
+			throw new IllegalArgumentException(String.format("The WITHIN operation requires an area of type %s, %s or %s.", Circle.class, Polygon.class, Box.class));
 		}
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
@@ -39,7 +39,6 @@ import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
-import org.springframework.data.geo.Polygon;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -146,9 +145,8 @@ abstract class Neo4jQuerySupport {
 			return ((Instant) parameter).atOffset(ZoneOffset.UTC);
 		} else if (parameter instanceof Box) {
 			return convertBox((Box) parameter);
-		} else if (parameter instanceof Polygon) {
-			log.warn("A within condition for a box or a polygon only checks the bounding box of the polygon, so you might end up with more results than expected.");
-			return convertPolygon((Polygon) parameter);
+		} else if (parameter instanceof BoundingBox) {
+			return convertBoundingBox((BoundingBox) parameter);
 		}
 
 		// Good hook to check the NodeManager whether the thing is an entity and we replace the value with a known id.
@@ -174,16 +172,10 @@ abstract class Neo4jQuerySupport {
 	private Map<String, Object> convertBox(Box box) {
 
 		BoundingBox boundingBox = BoundingBox.of(box);
-		return bondingBoxToMap(boundingBox);
+		return convertBoundingBox(boundingBox);
 	}
 
-	private Map<String, Object> convertPolygon(Polygon polygon) {
-
-		BoundingBox boundingBox = BoundingBox.of(polygon);
-		return bondingBoxToMap(boundingBox);
-	}
-
-	private Map<String, Object> bondingBoxToMap(BoundingBox boundingBox) {
+	private Map<String, Object> convertBoundingBox(BoundingBox boundingBox) {
 		Map<String, Object> map = new HashMap<>();
 
 		map.put("llx", convertParameter(boundingBox.getLowerLeft().getX()));

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/Neo4jQuerySupport.java
@@ -176,6 +176,7 @@ abstract class Neo4jQuerySupport {
 	}
 
 	private Map<String, Object> convertBoundingBox(BoundingBox boundingBox) {
+
 		Map<String, Object> map = new HashMap<>();
 
 		map.put("llx", convertParameter(boundingBox.getLowerLeft().getX()));

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -76,9 +76,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Range.Bound;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Polygon;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -2028,12 +2030,13 @@ class RepositoryIT {
 		assertThat(persons)
 			.containsExactly(person1);
 
-		persons = repository.findAllByPlaceNear(MINC, new Distance(200.0 / 1000.0, Metrics.KILOMETERS));
+		Distance distance = new Distance(200.0 / 1000.0, Metrics.KILOMETERS);
+		persons = repository.findAllByPlaceNear(MINC, distance);
 		assertThat(persons)
 			.hasSize(1)
 			.contains(person1);
 
-		persons = repository.findAllByPlaceNear(CLARION, new Distance(200.0 / 1000.0, Metrics.KILOMETERS));
+		persons = repository.findAllByPlaceNear(CLARION, distance);
 		assertThat(persons).isEmpty();
 
 		persons = repository.findAllByPlaceNear(MINC,
@@ -2057,12 +2060,45 @@ class RepositoryIT {
 			.hasSize(1)
 			.contains(person2);
 
-		persons = repository.findAllByPlaceWithin(new Circle(new org.springframework.data.geo.Point(MINC.x(), MINC.y()), new Distance(200.0 / 1000.0, Metrics.KILOMETERS)));
+		persons = repository.findAllByPlaceWithin(new Circle(new org.springframework.data.geo.Point(MINC.x(), MINC.y()), distance));
 		assertThat(persons)
 			.hasSize(1)
 			.contains(person1);
 
-		persons = repository.findAllByPlaceNear(CLARION, new Distance(200.0 / 1000.0, Metrics.KILOMETERS));
+		Box b = new Box(
+			new org.springframework.data.geo.Point(MINC.x() - distance.getValue(), MINC.y() - distance.getValue()),
+			new org.springframework.data.geo.Point(MINC.x() + distance.getValue(), MINC.y() + distance.getValue()));
+		persons = repository.findAllByPlaceWithin(b);
+		assertThat(persons)
+			.hasSize(1)
+			.contains(person1);
+
+		b = new Box(
+			new org.springframework.data.geo.Point(NEO4J_HQ.x(), NEO4J_HQ.y()),
+			new org.springframework.data.geo.Point(SFO.x(), SFO.y())
+		);
+		persons = repository.findAllByPlaceWithin(b);
+		assertThat(persons)
+			.hasSize(2);
+
+		Polygon p = new Polygon(
+			new org.springframework.data.geo.Point(12.993747, 55.6122746),
+			new org.springframework.data.geo.Point(12.9927492, 55.6110566),
+			new org.springframework.data.geo.Point(12.9953456, 55.6106688),
+			new org.springframework.data.geo.Point(12.9946482, 55.6110505),
+			new org.springframework.data.geo.Point(12.9959786, 55.6112748),
+			new org.springframework.data.geo.Point(12.9951847, 55.6122261),
+			new org.springframework.data.geo.Point(12.9942727, 55.6122382),
+			new org.springframework.data.geo.Point(12.9937685, 55.6122685),
+			new org.springframework.data.geo.Point(12.993747, 55.6122746)
+		);
+
+		persons = repository.findAllByPlaceWithin(p);
+		assertThat(persons)
+			.hasSize(1)
+			.contains(person1);
+
+		persons = repository.findAllByPlaceNear(CLARION, distance);
 		assertThat(persons).isEmpty();
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/RepositoryIT.java
@@ -59,6 +59,7 @@ import org.neo4j.springframework.data.integration.imperative.repositories.ThingR
 import org.neo4j.springframework.data.integration.shared.*;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.repository.query.BoundingBox;
 import org.neo4j.springframework.data.repository.query.Query;
 import org.neo4j.springframework.data.test.Neo4jExtension.Neo4jConnectionSupport;
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
@@ -2093,10 +2094,13 @@ class RepositoryIT {
 			new org.springframework.data.geo.Point(12.993747, 55.6122746)
 		);
 
-		persons = repository.findAllByPlaceWithin(p);
+		persons = repository.findAllByPlaceWithin(BoundingBox.of(p));
 		assertThat(persons)
 			.hasSize(1)
 			.contains(person1);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> repository.findAllByPlaceWithin(p))
+			.withMessage("The WITHIN operation does not support a class org.springframework.data.geo.Polygon. You might want to pass a bounding box instead: class org.neo4j.springframework.data.repository.query.BoundingBox.of(polygon).");
 
 		persons = repository.findAllByPlaceNear(CLARION, distance);
 		assertThat(persons).isEmpty();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/repositories/PersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/repositories/PersonRepository.java
@@ -34,6 +34,7 @@ import org.neo4j.springframework.data.integration.shared.PersonWithNoConstructor
 import org.neo4j.springframework.data.integration.shared.PersonWithWither;
 import org.neo4j.springframework.data.integration.shared.ThingWithGeneratedId;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.query.BoundingBox;
 import org.neo4j.springframework.data.repository.query.Query;
 import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.springframework.data.domain.Page;
@@ -215,6 +216,8 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 	List<PersonWithAllConstructor> findAllByPlaceWithin(Circle circle);
 
 	List<PersonWithAllConstructor> findAllByPlaceWithin(Box box);
+
+	List<PersonWithAllConstructor> findAllByPlaceWithin(BoundingBox box);
 
 	List<PersonWithAllConstructor> findAllByPlaceWithin(Polygon polygon);
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/repositories/PersonRepository.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/repositories/PersonRepository.java
@@ -39,8 +39,10 @@ import org.neo4j.springframework.data.types.GeographicPoint2d;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Range;
+import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Polygon;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -211,6 +213,10 @@ public interface PersonRepository extends Neo4jRepository<PersonWithAllConstruct
 	List<PersonWithAllConstructor> findAllByPlaceNearAndFirstNameAllIgnoreCase(Point p, String firstName);
 
 	List<PersonWithAllConstructor> findAllByPlaceWithin(Circle circle);
+
+	List<PersonWithAllConstructor> findAllByPlaceWithin(Box box);
+
+	List<PersonWithAllConstructor> findAllByPlaceWithin(Polygon polygon);
 
 	List<PersonWithAllConstructor> findAllByOrderByFirstNameAscBornOnDesc();
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/BoundingBoxTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/query/BoundingBoxTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+
+/**
+ * @author Michael J. Simons
+ */
+class BoundingBoxTest {
+
+	@ParameterizedTest
+	@MethodSource("polygonsToTest")
+	void builderShouldWorkForPolygons(Polygon p, Point ll, Point ur) {
+
+		BoundingBox boundingBox = BoundingBox.of(p);
+		assertThat(boundingBox.getLowerLeft()).isEqualTo(ll);
+		assertThat(boundingBox.getUpperRight()).isEqualTo(ur);
+	}
+
+	@ParameterizedTest
+	@MethodSource("boxesToTest")
+	void builderShouldWorkForBoxes(Box b, Point ll, Point ur) {
+
+		BoundingBox boundingBox = BoundingBox.of(b);
+		assertThat(boundingBox.getLowerLeft()).isEqualTo(ll);
+		assertThat(boundingBox.getUpperRight()).isEqualTo(ur);
+	}
+
+	private static Stream<Arguments> polygonsToTest() {
+		return Stream.of(
+			Arguments.of(
+				new Polygon(new Point(1, 1), new Point(5, 1), new Point(5, 5), new Point(5, 1)),
+				new Point(1, 1), new Point(5, 5)
+			),
+			Arguments.of(
+				new Polygon(new Point(3, 6), new Point(6, 2), new Point(8, 3), new Point(8, 6), new Point(2, 9)),
+				new Point(2, 2), new Point(8, 9)
+			),
+			Arguments.of(
+				new Polygon(new Point(3, 4), new Point(7, 1), new Point(9, 4), new Point(10, 8), new Point(8, 10)),
+				new Point(3, 1), new Point(10, 10)
+			)
+		);
+	}
+
+	private static Stream<Arguments> boxesToTest() {
+		return Stream.of(
+			Arguments.of(
+				new Box(new Point(1, 1), new Point(5, 5)),
+				new Point(1, 1), new Point(5, 5)
+			),
+			Arguments.of(
+				new Box(new Point(8, 3), new Point(2, 9)),
+				new Point(2, 3), new Point(8, 9)
+			),
+			Arguments.of(
+				new Box(new Point(3, 4), new Point(10, 8)),
+				new Point(3, 4), new Point(10, 8)
+			)
+		);
+	}
+}


### PR DESCRIPTION
This brings support for the spatial queries within a box or a polygon.

We cannot yet transform those into native spatial queries, so we compute the bounding box of the box or the polygon and use that. In case of polygons, this might lead to „false positive“ depending on the orientation of the polygon.

This closes #191.