### PR TITLE
Use built-in converters for identifier fields.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -189,7 +189,9 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 
 		// in case of relationship properties ignore internal id property
 		if (nodeDescription.hasIdProperty()) {
-			parameters.put(NAME_OF_ID_PARAM, propertyAccessor.getProperty(nodeDescription.getRequiredIdProperty()));
+			Neo4jPersistentProperty idProperty = nodeDescription.getRequiredIdProperty();
+			parameters.put(NAME_OF_ID,
+				writeValueFromProperty(propertyAccessor.getProperty(idProperty), idProperty.getTypeInformation()));
 		}
 		// in case of relationship properties ignore internal id property
 		if (nodeDescription.hasVersionProperty()) {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Constants.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/Constants.java
@@ -38,8 +38,8 @@ public final class Constants {
 
 	public static final String NAME_OF_INTERNAL_ID = "__internalNeo4jId__";
 	public static final String NAME_OF_LABELS = "__nodeLabels__";
-	public static final String NAME_OF_IDS_RESULT = "__ids__";
-	public static final String NAME_OF_ID_PARAM = "__id__";
+	public static final String NAME_OF_IDS = "__ids__";
+	public static final String NAME_OF_ID = "__id__";
 	public static final String NAME_OF_VERSION_PARAM = "__version__";
 	public static final String NAME_OF_PROPERTIES_PARAM = "__properties__";
 	public static final String NAME_OF_ENTITY_LIST_PARAM = "__entities__";

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
@@ -119,7 +119,7 @@ public enum CypherGenerator {
 
 		Node rootNode = node(primaryLabel, additionalLabels).named(NAME_OF_ROOT_NODE);
 		IdDescription idDescription = nodeDescription.getIdDescription();
-		Parameter idParameter = parameter(NAME_OF_ID_PARAM);
+		Parameter idParameter = parameter(NAME_OF_ID);
 
 		if (!idDescription.isInternallyGeneratedId()) {
 			String nameOfIdProperty = idDescription.getOptionalGraphPropertyName()
@@ -218,9 +218,9 @@ public enum CypherGenerator {
 		String row = "entity";
 		return Cypher
 			.unwind(parameter(NAME_OF_ENTITY_LIST_PARAM)).as(row)
-			.merge(rootNode.properties(nameOfIdProperty, property(row, NAME_OF_ID_PARAM)))
+			.merge(rootNode.properties(nameOfIdProperty, property(row, NAME_OF_ID)))
 			.set(rootNode, property(row, NAME_OF_PROPERTIES_PARAM))
-			.returning(Functions.collect(rootNode.property(nameOfIdProperty)).as(NAME_OF_IDS_RESULT))
+			.returning(Functions.collect(rootNode.property(nameOfIdProperty)).as(NAME_OF_IDS))
 			.build();
 	}
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/EntityWithConvertedId.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/EntityWithConvertedId.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import org.neo4j.springframework.data.core.schema.Id;
+
+/**
+ * @author Gerrit Meier
+ */
+public class EntityWithConvertedId {
+
+	@Id
+	private IdentifyingEnum identifyingEnum;
+
+	public IdentifyingEnum getIdentifyingEnum() {
+		return identifyingEnum;
+	}
+
+	public void setIdentifyingEnum(
+		IdentifyingEnum identifyingEnum) {
+		this.identifyingEnum = identifyingEnum;
+	}
+
+	/**
+	 * Could also be another type that gets converted inside the framework
+	 */
+	public enum IdentifyingEnum {
+		A,
+		B
+	}
+}


### PR DESCRIPTION
When using find(All)ById(s) the converter was not invoked to transparently
convert the provided parameter to the database/driver compatible type.

closes #202