### PR TITLE
Multi data module support

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 
 import org.apiguardian.api.API;
 import org.neo4j.springframework.data.core.schema.Node;
-import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.neo4j.springframework.data.repository.support.ReactiveNeo4jRepositoryFactoryBean;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -86,7 +86,7 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 
 	@Override
 	protected Collection<Class<?>> getIdentifyingTypes() {
-		return Collections.singleton(Neo4jRepository.class);
+		return Collections.singleton(ReactiveNeo4jRepository.class);
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -46,7 +46,7 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
  * @author Michael J. Simons
  * @since 1.0
  */
-public class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupport {
+final class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupport {
 
 	private final ReactiveNeo4jOperations neo4jOperations;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactory.java
@@ -32,8 +32,8 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.ReactiveRepositoryFactorySupport;
 import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
-import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.core.support.RepositoryFragment;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
@@ -46,7 +46,7 @@ import org.springframework.data.repository.query.QueryMethodEvaluationContextPro
  * @author Michael J. Simons
  * @since 1.0
  */
-final class ReactiveNeo4jRepositoryFactory extends RepositoryFactorySupport {
+public class ReactiveNeo4jRepositoryFactory extends ReactiveRepositoryFactorySupport {
 
 	private final ReactiveNeo4jOperations neo4jOperations;
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -41,7 +41,7 @@ import org.springframework.lang.Nullable;
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
-public class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
 	extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
 	private ReactiveNeo4jOperations neo4jOperations;

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -41,7 +41,7 @@ import org.springframework.lang.Nullable;
  * @since 1.0
  */
 @API(status = API.Status.INTERNAL, since = "1.0")
-public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+public class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
 	extends TransactionalRepositoryFactoryBeanSupport<T, S, ID> {
 
 	private ReactiveNeo4jOperations neo4jOperations;
@@ -72,4 +72,6 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
 		return new ReactiveNeo4jRepositoryFactory(neo4jOperations, neo4jMappingContext);
 	}
+
+
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/support/ReactiveNeo4jRepositoryFactoryBean.java
@@ -72,6 +72,4 @@ public final class ReactiveNeo4jRepositoryFactoryBean<T extends Repository<S, ID
 	protected RepositoryFactorySupport doCreateRepositoryFactory() {
 		return new ReactiveNeo4jRepositoryFactory(neo4jOperations, neo4jMappingContext);
 	}
-
-
 }

--- a/spring-data-neo4j-rx/src/main/resources/META-INF/spring.factories
+++ b/spring-data-neo4j-rx/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.neo4j.springframework.data.repository.support.Neo4jRepositoryFactory

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/AuditingIT.java
@@ -31,13 +31,13 @@ import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
 import org.neo4j.springframework.data.integration.shared.AuditingITBase;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -120,11 +120,11 @@ class AuditingIT extends AuditingITBase {
 		verifyDatabase(idOfExistingThingWithGeneratedId, thing);
 	}
 
-	interface ImmutableEntityTestRepository extends CrudRepository<ImmutableAuditableThing, Long> {
+	interface ImmutableEntityTestRepository extends Neo4jRepository<ImmutableAuditableThing, Long> {
 	}
 
 	interface ImmutableEntityWithGeneratedIdRepository
-		extends CrudRepository<ImmutableAuditableThingWithGeneratedId, String> {
+		extends Neo4jRepository<ImmutableAuditableThingWithGeneratedId, String> {
 	}
 
 	@Configuration

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveAuditingIT.java
@@ -38,13 +38,13 @@ import org.neo4j.springframework.data.config.EnableNeo4jAuditing;
 import org.neo4j.springframework.data.integration.shared.AuditingITBase;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThing;
 import org.neo4j.springframework.data.integration.shared.ImmutableAuditableThingWithGeneratedId;
+import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.neo4j.springframework.data.repository.config.EnableReactiveNeo4jRepositories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.reactive.TransactionalOperator;
@@ -166,11 +166,11 @@ class ReactiveAuditingIT extends AuditingITBase {
 				DEFAULT_CREATION_AND_MODIFICATION_DATE, "A user", "A new name"));
 	}
 
-	interface ImmutableEntityTestRepository extends ReactiveCrudRepository<ImmutableAuditableThing, Long> {
+	interface ImmutableEntityTestRepository extends ReactiveNeo4jRepository<ImmutableAuditableThing, Long> {
 	}
 
 	interface ImmutableEntityWithGeneratedIdTestRepository
-		extends ReactiveCrudRepository<ImmutableAuditableThingWithGeneratedId, String> {
+		extends ReactiveNeo4jRepository<ImmutableAuditableThingWithGeneratedId, String> {
 	}
 
 	@Configuration


### PR DESCRIPTION
Create `spring.factories` to make SDN/RX in general visible to the Spring Data mechanism for considering it when checking if there are multiple Spring Data modules, so it switches to strict-mode.

Also some clean ups in the infrastructure code.