### PR TITLE
Support path pattern in conditions.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Condition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Condition.java
@@ -31,16 +31,76 @@ import org.apiguardian.api.API;
 @API(status = EXPERIMENTAL, since = "1.0")
 public interface Condition extends Expression {
 
+	/**
+	 * Adds a condition to this condition with an {@literal AND}.
+	 *
+	 * @param condition The new condition to add, must not be {@literal null}.
+	 * @return A new condition.
+	 */
 	default Condition and(Condition condition) {
 		return CompoundCondition.create(this, Operator.AND, condition);
 	}
 
+	/**
+	 * Adds a condition to this condition with an {@literal OR}.
+	 *
+	 * @param condition The new condition to add, must not be {@literal null}.
+	 * @return A new condition.
+	 */
 	default Condition or(Condition condition) {
 		return CompoundCondition.create(this, Operator.OR, condition);
 	}
 
+	/**
+	 * Adds a condition to this condition with a {@literal XOR}.
+	 *
+	 * @param condition The new condition to add, must not be {@literal null}.
+	 * @return A new condition.
+	 */
 	default Condition xor(Condition condition) {
 		return CompoundCondition.create(this, Operator.XOR, condition);
+	}
+
+	/**
+	 * Adds a condition based on a path pattern to this condition with an {@literal AND}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Using path patterns in WHERE</a>.
+	 *
+	 * @param pathPattern The path pattern to add to the where clause.
+	 *                    This path pattern must not be {@literal null} and must
+	 *                    not introduce new variables not available in the match.
+	 * @return A new condition.
+	 * @since 1.0.1
+	 */
+	default Condition and(RelationshipPattern pathPattern) {
+		return CompoundCondition.create(this, Operator.AND, new RelationshipPatternCondition(pathPattern));
+	}
+
+	/**
+	 * Adds a condition based on a path pattern to this condition with an {@literal OR}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Using path patterns in WHERE</a>.
+	 *
+	 * @param pathPattern The path pattern to add to the where clause.
+	 *                    This path pattern must not be {@literal null} and must
+	 *                    not introduce new variables not available in the match.
+	 * @return A new condition.
+	 * @since 1.0.1
+	 */
+	default Condition or(RelationshipPattern pathPattern) {
+		return CompoundCondition.create(this, Operator.OR, new RelationshipPatternCondition(pathPattern));
+	}
+
+	/**
+	 * Adds a condition based on a path pattern to this condition with a {@literal XOR}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Using path patterns in WHERE</a>.
+	 *
+	 * @param pathPattern The path pattern to add to the where clause.
+	 *                    This path pattern must not be {@literal null} and must
+	 *                    not introduce new variables not available in the match.
+	 * @return A new condition.
+	 * @since 1.0.1
+	 */
+	default Condition xor(RelationshipPattern pathPattern) {
+		return CompoundCondition.create(this, Operator.XOR, new RelationshipPatternCondition(pathPattern));
 	}
 
 	default Condition not() {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
@@ -218,6 +218,7 @@ class DefaultStatementBuilder
 	@Override
 	public OngoingReadingWithWhere where(Condition newCondition) {
 
+		Assert.notNull(newCondition, "The new condition must not be null.");
 		this.currentOngoingMatch.conditionBuilder.where(newCondition);
 		return this;
 	}
@@ -497,6 +498,7 @@ class DefaultStatementBuilder
 		@Override
 		public OrderableOngoingReadingAndWithWithWhere where(Condition newCondition) {
 
+			Assert.notNull(newCondition, "The new condition must not be null.");
 			conditionBuilder.where(newCondition);
 			return this;
 		}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/DefaultStatementBuilder.java
@@ -218,7 +218,6 @@ class DefaultStatementBuilder
 	@Override
 	public OngoingReadingWithWhere where(Condition newCondition) {
 
-		Assert.notNull(newCondition, "The new condition must not be null.");
 		this.currentOngoingMatch.conditionBuilder.where(newCondition);
 		return this;
 	}
@@ -498,7 +497,6 @@ class DefaultStatementBuilder
 		@Override
 		public OrderableOngoingReadingAndWithWithWhere where(Condition newCondition) {
 
-			Assert.notNull(newCondition, "The new condition must not be null.");
 			conditionBuilder.where(newCondition);
 			return this;
 		}
@@ -832,6 +830,7 @@ class DefaultStatementBuilder
 
 		void where(Condition newCondition) {
 
+			Assert.notNull(newCondition, "The new condition must not be null.");
 			this.condition = newCondition;
 		}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Node.java
@@ -175,7 +175,7 @@ public final class Node implements PatternElement, Named, ExposesRelationships<R
 	}
 
 	/**
-	 * Creates a new {@link Property} associated with this property container..
+	 * Creates a new {@link Property} associated with this property container.
 	 * <p>
 	 * Note: The property container does not track property creation and there is no possibility to enumerate all
 	 * properties that have been created for this node.

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Property.java
@@ -33,10 +33,10 @@ import org.springframework.util.Assert;
 @API(status = EXPERIMENTAL, since = "1.0")
 public final class Property implements Expression {
 
-	static Property create(Node parentContainer, String name) {
+	static Property create(Named parentContainer, String name) {
 
 		Assert.isTrue(parentContainer.getSymbolicName().isPresent(),
-			"A property derived from a node needs a parent with a symbolic name.");
+			"A property derived from a node or a relationship needs a parent with a symbolic name.");
 		Assert.hasText(name, "The properties name is required.");
 
 		return new Property(parentContainer.getSymbolicName().get(), new PropertyLookup((name)));

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/Relationship.java
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class Relationship implements RelationshipPattern, Named, ExposesRelationships<RelationshipChain> {
+public final class Relationship implements RelationshipPattern, Named {
 
 	/**
 	 * While the direction in the schema package is centered around the node, the direction here is the direction between two nodes.
@@ -256,5 +256,20 @@ public final class Relationship implements RelationshipPattern, Named, ExposesRe
 	 */
 	public MapProjection project(Object... entries) {
 		return MapProjection.create(this.getRequiredSymbolicName(), entries);
+	}
+
+	/**
+	 * Creates a new {@link Property} associated with this property container.
+	 * <p>
+	 * Note: The property container does not track property creation and there is no possibility to enumerate all
+	 * properties that have been created for this relationship.
+	 *
+	 * @param name property name, must not be {@literal null} or empty.
+	 * @return a new {@link Property} associated with this {@link Relationship}.
+	 * @since 1.0.1
+	 */
+	public Property property(String name) {
+
+		return Property.create(this, name);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipPattern.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipPattern.java
@@ -25,11 +25,13 @@ import org.apiguardian.api.API;
 /**
  * A shared, public interface for  {@link Relationship relationships} and {@link RelationshipChain chains of relationships}.
  * This interface reassembles the <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipPattern.html">RelationshipPattern</a>.
+ * <p>
+ * This interface can be used synonmous with the concept of a <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Path Pattern</a>.
  *
  * @author Michael J. Simons
  * @soundtrack Mine & Fatoni - Alle Liebe nachträglich
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public interface RelationshipPattern extends PatternElement {
+public interface RelationshipPattern extends PatternElement, ExposesRelationships<RelationshipChain> {
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipPatternCondition.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/RelationshipPatternCondition.java
@@ -18,26 +18,32 @@
  */
 package org.neo4j.springframework.data.core.cypher;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.apiguardian.api.API.Status.*;
 
-import org.junit.jupiter.api.Test;
+import org.apiguardian.api.API;
+import org.neo4j.springframework.data.core.cypher.support.Visitor;
 
 /**
+ * Internal wrapper for marking a path pattern as a condition.
+ *
  * @author Michael J. Simons
+ * @soundtrack Red Hot Chili Peppers - Red Hot Chili Peppers: Greatest Hits
+ * @since 1.0.1
  */
-class PropertyTest {
+@API(status = INTERNAL, since = "1.0")
+final class RelationshipPatternCondition implements Condition {
 
-	@Test
-	void preconditionsShouldBeAsserted() {
+	private final RelationshipPattern pathPattern;
 
-		assertThatIllegalArgumentException().isThrownBy(() -> Property.create(Node.create("a"), ""))
-			.withMessage("A property derived from a node or a relationship needs a parent with a symbolic name.");
-		String expectedMessage = "The properties name is required.";
-		assertThatIllegalArgumentException().isThrownBy(() -> Property.create(Node.create("a").named("s"), null))
-			.withMessage(
-				expectedMessage);
-		assertThatIllegalArgumentException().isThrownBy(() -> Property.create(Node.create("a").named("s"), "\t"))
-			.withMessage(
-				expectedMessage);
+	RelationshipPatternCondition(RelationshipPattern pathPattern) {
+		this.pathPattern = pathPattern;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		pathPattern.accept(visitor);
+		visitor.leave(this);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/cypher/StatementBuilder.java
@@ -23,6 +23,7 @@ import static org.neo4j.springframework.data.core.cypher.Expressions.*;
 
 import org.apiguardian.api.API;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * @author Michael J. Simons
@@ -60,10 +61,26 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 		/**
 		 * Adds a where clause to this match.
 		 *
-		 * @param condition The new condition
+		 * @param condition The new condition, must not be {@literal null}
 		 * @return A match restricted by a where clause with no return items yet.
 		 */
 		OngoingReadingWithWhere where(Condition condition);
+
+		/**
+		 * Adds a where clause based on a path pattern to this match.
+		 * See <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Using path patterns in WHERE</a>.
+		 *
+		 * @param pathPattern The path pattern to add to the where clause.
+		 *                    This path pattern must not be {@literal null} and must
+		 *                    not introduce new variables not available in the match.
+		 * @return A match restricted by a where clause with no return items yet.
+		 * @since 1.0.1
+		 */
+		default OngoingReadingWithWhere where(RelationshipPattern pathPattern) {
+
+			Assert.notNull(pathPattern, "The path pattern must not be null.");
+			return this.where(new RelationshipPatternCondition(pathPattern));
+		}
 	}
 
 	/**
@@ -78,6 +95,7 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 	 * @since 1.0
 	 */
 	interface ExposesConditions<T> {
+
 		/**
 		 * Adds an additional condition to the existing conditions, connected by an {@literal and}.
 		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
@@ -89,6 +107,18 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 		T and(Condition condition);
 
 		/**
+		 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal and}.
+		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+		 * conditions used another logical operator.
+		 *
+		 * @param pathPattern An additional pattern to include in the conditions
+		 * @return The ongoing definition of a match
+		 */
+		default T and(RelationshipPattern pathPattern) {
+			return this.and(new RelationshipPatternCondition(pathPattern));
+		}
+
+		/**
 		 * Adds an additional condition to the existing conditions, connected by an {@literal or}.
 		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
 		 * conditions used another logical operator.
@@ -97,6 +127,18 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 		 * @return The ongoing definition of a match
 		 */
 		T or(Condition condition);
+
+		/**
+		 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal or}.
+		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+		 * conditions used another logical operator.
+		 *
+		 * @param pathPattern An additional pattern to include in the conditions
+		 * @return The ongoing definition of a match
+		 */
+		default T or(RelationshipPattern pathPattern) {
+			return this.or(new RelationshipPatternCondition(pathPattern));
+		}
 	}
 
 	/**
@@ -126,6 +168,7 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 
 	/**
 	 * A match that knows what to pipe to the next part of a multi part query.
+	 *
 	 * @since 1.0
 	 */
 	interface OrderableOngoingReadingAndWithWithoutWhere extends OrderableOngoingReadingAndWith {
@@ -133,10 +176,26 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 		/**
 		 * Adds a where clause to this match.
 		 *
-		 * @param condition The new condition
+		 * @param condition The new condition, must not be {@literal null}
 		 * @return A match restricted by a where clause with no return items yet.
 		 */
 		OrderableOngoingReadingAndWithWithWhere where(Condition condition);
+
+		/**
+		 * Adds a where clause based on a path pattern to this match.
+		 * See <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Using path patterns in WHERE</a>.
+		 *
+		 * @param pathPattern The path pattern to add to the where clause.
+		 *                    This path pattern must not be {@literal null} and must
+		 *                    not introduce new variables not available in the match.
+		 * @return A match restricted by a where clause with no return items yet.
+		 * @since 1.0.1
+		 */
+		default OrderableOngoingReadingAndWithWithWhere where(RelationshipPattern pathPattern) {
+
+			Assert.notNull(pathPattern, "The path pattern must not be null.");
+			return this.where(new RelationshipPatternCondition(pathPattern));
+		}
 	}
 
 	/**

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -61,6 +61,7 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 /**
  * A Cypher-DSL based implementation of the {@link AbstractQueryCreator} that eventually creates Cypher queries as strings
@@ -230,7 +231,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 	}
 
 	@Override
-	protected QueryAndParameters complete(Condition condition, Sort sort) {
+	protected QueryAndParameters complete(@Nullable Condition condition, Sort sort) {
 
 		Statement statement = createStatement(condition, sort);
 
@@ -241,14 +242,14 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 	}
 
 	@NonNull
-	private Statement createStatement(Condition condition, Sort sort) {
+	private Statement createStatement(@Nullable Condition condition, Sort sort) {
 		CypherGenerator cypherGenerator = CypherGenerator.INSTANCE;
 
 		// all the ways we could query for
 		Node startNode = Cypher.node(nodeDescription.getPrimaryLabel(), nodeDescription.getAdditionalLabels())
 			.named(NAME_OF_ROOT_NODE);
 
-		ExposesReturning matchAndCondition = Cypher.match(startNode).where(condition);
+		ExposesReturning matchAndCondition = Cypher.match(startNode).where(Optional.ofNullable(condition).orElseGet(Conditions::noCondition));
 		StatementBuilder.OngoingReadingWithoutWhere matches = null;
 
 		Iterator<PropertyPathWrapper> wrapperIterator = propertyPathWrappers.iterator();


### PR DESCRIPTION
This change adds additional overloads for `where` and `and`, `or` and `xor` in the `StatementBuilder` and on the `Condition` interfaces.

These allow a `RelationshipPattern` to be used in condition as described in the Neo4j 4.0 docs chapter 3.6.5 and closes #206.

The `RelationshipPattern` corresponds directly with the "path pattern" mentioned in the docs. The name is taken from the OpenCypher spec.

In addition to this change, the `ExposesRelationships` has been moved to the `RelationshipPattern` to allow for easier chaining.

Furthermore, it was noted that in the Spring Data related parts, `org.neo4j.springframework.data.repository.query.CypherQueryCreator#complete` did not cater for the fact that the last - or only condition - might be null.

Please, @romain-rossi have a look. 