### PR TITLE
Conversion support for complex types.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -64,7 +64,7 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 		this.isAssociation = Lazy.of(() -> {
 
 			Class<?> targetType = getActualType();
-			return !simpleTypeHolder.isSimpleType(targetType);
+			return !(simpleTypeHolder.isSimpleType(targetType) || mappingContext.hasRegisteredConverter(targetType));
 		});
 		this.mappingContext = mappingContext;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -64,7 +64,7 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 		this.isAssociation = Lazy.of(() -> {
 
 			Class<?> targetType = getActualType();
-			return !(simpleTypeHolder.isSimpleType(targetType) || mappingContext.hasRegisteredConverter(targetType));
+			return !(simpleTypeHolder.isSimpleType(targetType) || mappingContext.hasCustomWriteTarget(targetType));
 		});
 		this.mappingContext = mappingContext;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -93,7 +93,7 @@ public final class Neo4jMappingContext
 		return converter;
 	}
 
-	boolean hasRegisteredConverter(Class<?> targetType) {
+	boolean hasCustomWriteTarget(Class<?> targetType) {
 		return neo4jConversions.hasCustomWriteTarget(targetType);
 	}
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContext.java
@@ -73,6 +73,8 @@ public final class Neo4jMappingContext
 	 */
 	private final Neo4jConverter converter;
 
+	private final Neo4jConversions neo4jConversions;
+
 	private @Nullable AutowireCapableBeanFactory beanFactory;
 
 	public Neo4jMappingContext() {
@@ -83,11 +85,16 @@ public final class Neo4jMappingContext
 	public Neo4jMappingContext(Neo4jConversions neo4jConversions) {
 
 		super.setSimpleTypeHolder(Neo4jSimpleTypes.HOLDER);
+		this.neo4jConversions = neo4jConversions;
 		this.converter = new DefaultNeo4jConverter(neo4jConversions, nodeDescriptionStore);
 	}
 
 	public Neo4jConverter getConverter() {
 		return converter;
+	}
+
+	boolean hasRegisteredConverter(Class<?> targetType) {
+		return neo4jConversions.hasCustomWriteTarget(targetType);
 	}
 
 	/*

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/ReactiveStringBasedNeo4jQuery.java
@@ -157,7 +157,12 @@ final class ReactiveStringBasedNeo4jQuery extends AbstractReactiveNeo4jQuery {
 	Map<String, Object> bindParameters(Neo4jParameterAccessor parameterAccessor) {
 
 		final Parameters<?, ?> formalParameters = parameterAccessor.getParameters();
-		Map<String, Object> resolvedParameters = new HashMap<>(spelEvaluator.evaluate(parameterAccessor.getValues()));
+		Map<String, Object> resolvedParameters = new HashMap<>();
+
+		// Values from the parameter accessor can only get converted after evaluation
+		for (Map.Entry<String, Object> evaluatedParam : spelEvaluator.evaluate(parameterAccessor.getValues()).entrySet()) {
+			resolvedParameters.put(evaluatedParam.getKey(), super.convertParameter(evaluatedParam.getValue()));
+		}
 		formalParameters.stream()
 			.filter(Parameter::isBindable)
 			.forEach(parameter -> {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/StringBasedNeo4jQuery.java
@@ -157,7 +157,13 @@ final class StringBasedNeo4jQuery extends AbstractNeo4jQuery {
 	Map<String, Object> bindParameters(Neo4jParameterAccessor parameterAccessor) {
 
 		final Parameters<?, ?> formalParameters = parameterAccessor.getParameters();
-		Map<String, Object> resolvedParameters = new HashMap<>(spelEvaluator.evaluate(parameterAccessor.getValues()));
+		Map<String, Object> resolvedParameters = new HashMap<>();
+
+		// Values from the parameter accessor can only get converted after evaluation
+		for (Map.Entry<String, Object> evaluatedParam : spelEvaluator.evaluate(parameterAccessor.getValues()).entrySet()) {
+			resolvedParameters.put(evaluatedParam.getKey(), super.convertParameter(evaluatedParam.getValue()));
+		}
+
 		formalParameters.stream()
 			.filter(Parameter::isBindable)
 			.forEach(parameter -> {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -175,7 +175,7 @@ public class Neo4jMappingContextTest {
 				// no implementation needed for this test
 				return null;
 			}
-		};
+		}
 
 		Neo4jMappingContext schema = new Neo4jMappingContext(new Neo4jConversions(singleton(new ConvertibleTypeConverter())));
 		Neo4jPersistentEntity<?> entity = schema.getPersistentEntity(EntityWithConvertibleProperty.class);

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.springframework.data.core.mapping;
 
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
@@ -26,8 +27,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
 import org.neo4j.springframework.data.core.schema.GraphPropertyDescription;
 import org.neo4j.springframework.data.core.schema.Id;
@@ -37,6 +41,8 @@ import org.neo4j.springframework.data.core.schema.NodeDescription;
 import org.neo4j.springframework.data.core.schema.Property;
 import org.neo4j.springframework.data.core.schema.Relationship;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mapping.Association;
 
@@ -155,6 +161,38 @@ public class Neo4jMappingContextTest {
 	}
 
 	@Test
+	void complexPropertyWithConverterShouldNotBeConsideredAsAssociation() {
+
+		class ConvertibleTypeConverter implements GenericConverter {
+			@Override
+			public Set<ConvertiblePair> getConvertibleTypes() {
+				// in the real world this should also define the opposite way
+				return singleton(new ConvertiblePair(ConvertibleType.class, StringValue.class));
+			}
+
+			@Override
+			public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+				// no implementation needed for this test
+				return null;
+			}
+		};
+
+		Neo4jMappingContext schema = new Neo4jMappingContext(new Neo4jConversions(singleton(new ConvertibleTypeConverter())));
+		Neo4jPersistentEntity<?> entity = schema.getPersistentEntity(EntityWithConvertibleProperty.class);
+
+		assertThat(entity.getPersistentProperty("convertibleType").isRelationship()).isFalse();
+	}
+
+	@Test
+	void complexPropertyWithoutConverterShouldBeConsideredAsAssociation() {
+
+		Neo4jMappingContext schema = new Neo4jMappingContext(new Neo4jConversions());
+		Neo4jPersistentEntity<?> entity = schema.getPersistentEntity(EntityWithConvertibleProperty.class);
+
+		assertThat(entity.getPersistentProperty("convertibleType").isRelationship()).isTrue();
+	}
+
+	@Test
 	void shouldHonourTransientAnnotation() {
 
 		Neo4jMappingContext schema = new Neo4jMappingContext();
@@ -240,5 +278,18 @@ public class Neo4jMappingContextTest {
 
 		@Id @GeneratedValue
 		private String id;
+	}
+
+	@Node
+	static class EntityWithConvertibleProperty {
+
+		@Id @GeneratedValue
+		private Long id;
+
+		private ConvertibleType convertibleType;
+	}
+
+	static class ConvertibleType {
+
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Neo4jConversionsITBase.java
@@ -141,10 +141,18 @@ public abstract class Neo4jConversionsITBase {
 		SPATIAL_TYPES = Collections.unmodifiableMap(hlp);
 	}
 
+	protected static final Map<String, Object> CUSTOM_TYPES;
+	static {
+		Map<String, Object> hlp = new HashMap<>();
+		hlp.put("customType", ThingWithCustomTypes.CustomType.of("ABCD"));
+		CUSTOM_TYPES = Collections.unmodifiableMap(hlp);
+	}
+
 	protected static long ID_OF_CYPHER_TYPES_NODE;
 	protected static long ID_OF_ADDITIONAL_TYPES_NODE;
 	protected static long ID_OF_SPATIAL_TYPES_NODE;
 	protected static long ID_OF_NON_EXISTING_PRIMITIVES_NODE;
+	protected static long ID_OF_CUSTOM_TYPE_NODE;
 
 	@BeforeAll
 	static void prepareData() {
@@ -218,6 +226,12 @@ public abstract class Neo4jConversionsITBase {
 					+ " n.geo3d = point({latitude: $clarion.latitude, longitude: $clarion.longitude, height: 27}),"
 					+ " n.car2d = point({x: 10, y: 20}),"
 					+ " n.car3d = point({x: 30, y: 40, z: 50})"
+					+ " RETURN id(n) AS id", parameters).single().get("id").asLong();
+
+				parameters = new HashMap<>();
+				parameters.put("customType", "ABCD");
+				ID_OF_CUSTOM_TYPE_NODE = w.run("CREATE (n:CustomTypes) SET "
+					+ " n.customType = $customType"
 					+ " RETURN id(n) AS id", parameters).single().get("id").asLong();
 				w.commit();
 				return null;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
@@ -114,4 +114,48 @@ public class ThingWithCustomTypes {
 			}
 		}
 	}
+
+	/**
+	 * A type that is not bound anywhere but has a converter
+	 */
+	public static class DifferentType {
+
+		private final String value;
+
+		public static DifferentType of(String value) {
+			return new DifferentType(value);
+		}
+
+		private DifferentType(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * Converter for an arbitrary type not bound to any property
+	 */
+	public static class DifferentTypeConverter implements GenericConverter {
+
+		@Override
+		public Set<ConvertiblePair> getConvertibleTypes() {
+			Set<ConvertiblePair> convertiblePairs = new HashSet<>();
+			convertiblePairs.add(new ConvertiblePair(Value.class, DifferentType.class));
+			convertiblePairs.add(new ConvertiblePair(DifferentType.class, Value.class));
+			return convertiblePairs;
+		}
+
+		@Override
+		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+
+			if (Value.class.isAssignableFrom(sourceType.getType())) {
+				return CustomType.of(((Value) source).asString());
+			} else {
+				return Values.value(((DifferentType) source).getValue());
+			}
+		}
+	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.value.StringValue;
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
+
+/**
+ * @author Gerrit Meier
+ */
+@Node("CustomTypes")
+public class ThingWithCustomTypes {
+
+	@Id @GeneratedValue private final Long id;
+
+	private CustomType customType;
+
+	public ThingWithCustomTypes(Long id, CustomType customType) {
+		this.id = id;
+		this.customType = customType;
+	}
+
+	public ThingWithCustomTypes withId(Long id) {
+		return new ThingWithCustomTypes(id, this.customType);
+	}
+
+	public CustomType getCustomType() {
+		return customType;
+	}
+
+	public static class CustomType {
+
+		private final String value;
+
+		public static CustomType of(String value) {
+			return new CustomType(value);
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		private CustomType(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			CustomType that = (CustomType) o;
+			return value.equals(that.value);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(value);
+		}
+	}
+
+	public static class CustomTypeConverter implements GenericConverter {
+
+		@Override
+		public Set<ConvertiblePair> getConvertibleTypes() {
+			Set<ConvertiblePair> convertiblePairs = new HashSet<>();
+			convertiblePairs.add(new ConvertiblePair(Value.class, CustomType.class));
+			convertiblePairs.add(new ConvertiblePair(CustomType.class, Value.class));
+			return convertiblePairs;
+		}
+
+		@Override
+		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+
+			if (StringValue.class.isAssignableFrom(sourceType.getType())) {
+				return CustomType.of(((StringValue) source).asString());
+			} else {
+				return Values.value(((CustomType) source).getValue());
+			}
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithCustomTypes.java
@@ -46,14 +46,17 @@ public class ThingWithCustomTypes {
 		this.customType = customType;
 	}
 
-	public ThingWithCustomTypes withId(Long id) {
-		return new ThingWithCustomTypes(id, this.customType);
+	public ThingWithCustomTypes withId(Long newId) {
+		return new ThingWithCustomTypes(newId, this.customType);
 	}
 
 	public CustomType getCustomType() {
 		return customType;
 	}
 
+	/**
+	 * Custom type to convert
+	 */
 	public static class CustomType {
 
 		private final String value;
@@ -88,6 +91,9 @@ public class ThingWithCustomTypes {
 		}
 	}
 
+	/**
+	 * Converter that converts the custom type.
+	 */
 	public static class CustomTypeConverter implements GenericConverter {
 
 		@Override


### PR DESCRIPTION
Introduce conversion for
a) complex types as properties
b) complex types in query parameters

Both are enabled by providing a custom conversion and registering it with the `Neo4jConversions` instantiation.
The `GenericConversion` implementation has to support both ways (`ConvertiblePair`).