### PR TITLE
Add support for dynamic one-to-many relationships.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -31,6 +31,7 @@ import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.Lazy;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -116,6 +117,20 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 			.ifPresent(relationship -> relationship.setRelationshipObverse(relationshipDescription));
 
 		return relationshipDescription;
+	}
+
+	@Override
+	public Class<?> getAssociationTargetType() {
+
+		Class<?> associationTargetType = super.getAssociationTargetType();
+		if (associationTargetType != null) {
+			return associationTargetType;
+		} else if (isDynamicOneToManyAssociation()) {
+			TypeInformation<?> actualType = getTypeInformation().getRequiredActualType();
+			return actualType.getRequiredComponentType().getType();
+		} else {
+			return null;
+		}
 	}
 
 	@Override

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/Neo4jPersistentProperty.java
@@ -44,6 +44,18 @@ public interface Neo4jPersistentProperty
 	}
 
 	/**
+	 * Dynamic one-to-many associations are associations to non-simple types stored in a map
+	 * with a key type of {@literal java.lang.String} and values of {@literal java.util.Collection}.
+	 *
+	 * @return True, if this association is a dynamic association with multple values per type.
+	 * @since 1.0.1
+	 */
+	default boolean isDynamicOneToManyAssociation() {
+
+		return this.isDynamicAssociation() && getTypeInformation().getRequiredActualType().isCollectionLike();
+	}
+
+	/**
 	 * see if the association has a property class
 	 *
 	 * @return True, if this association has properties

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
@@ -18,6 +18,9 @@
  */
 package org.neo4j.springframework.data.core.support;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -42,7 +45,15 @@ public final class Relationships {
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
 		if (property.isDynamicAssociation()) {
-			unifiedValue = ((Map<String, Object>) rawValue).entrySet();
+			if (property.isDynamicOneToManyAssociation()) {
+				unifiedValue = ((Map<String, Collection<?>>) rawValue)
+					.entrySet()
+					.stream()
+					.flatMap(e -> e.getValue().stream().map(v -> new SimpleEntry(e.getKey(), v)))
+					.collect(toList());
+			} else {
+				unifiedValue = ((Map<String, Object>) rawValue).entrySet();
+			}
 		} else if (property.isRelationshipWithProperties()) {
 			unifiedValue = ((Map<Object, Object>) rawValue).entrySet();
 		} else if (property.isCollectionLike()) {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -49,7 +49,7 @@ import org.springframework.data.mapping.Association;
 /**
  * @author Michael J. Simons
  */
-public class Neo4jMappingContextTest {
+class Neo4jMappingContextTest {
 
 	@Test
 	void initializationOfSchemaShouldWork() {

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicRelationshipsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicRelationshipsIT.java
@@ -63,11 +63,11 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 
 		repository.findById(idOfExistingPerson)
 			.as(StepVerifier::create)
-			.consumeNextWith(personWithRelatives -> {
-				assertThat(personWithRelatives).isNotNull();
-				assertThat(personWithRelatives.getName()).isEqualTo("A");
+			.consumeNextWith(person -> {
+				assertThat(person).isNotNull();
+				assertThat(person.getName()).isEqualTo("A");
 
-				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				Map<String, Person> relatives = person.getRelatives();
 				assertThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
 				assertThat(relatives.get("HAS_WIFE").getFirstName()).isEqualTo("B");
 				assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C");
@@ -80,11 +80,11 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 
 		repository.findById(idOfExistingPerson)
 			.as(StepVerifier::create)
-			.consumeNextWith(personWithRelatives -> {
-				assertThat(personWithRelatives).isNotNull();
-				assertThat(personWithRelatives.getName()).isEqualTo("A");
+			.consumeNextWith(person -> {
+				assertThat(person).isNotNull();
+				assertThat(person.getName()).isEqualTo("A");
 
-				Map<String, List<Pet>> pets = personWithRelatives.getPets();
+				Map<String, List<Pet>> pets = person.getPets();
 				assertThat(pets).containsOnlyKeys("CATS", "DOGS");
 				assertThat(pets.get("CATS")).extracting(Pet::getName).containsExactlyInAnyOrder("Tom", "Garfield");
 				assertThat(pets.get("DOGS")).extracting(Pet::getName).containsExactlyInAnyOrder("Benji", "Lassie");
@@ -96,11 +96,11 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 	void shouldUpdateDynamicRelationships(@Autowired PersonWithRelativesRepository repository) {
 
 		repository.findById(idOfExistingPerson)
-			.map(personWithRelatives -> {
-				assumeThat(personWithRelatives).isNotNull();
-				assumeThat(personWithRelatives.getName()).isEqualTo("A");
+			.map(person -> {
+				assumeThat(person).isNotNull();
+				assumeThat(person.getName()).isEqualTo("A");
 
-				Map<String, Person> relatives = personWithRelatives.getRelatives();
+				Map<String, Person> relatives = person.getRelatives();
 				assumeThat(relatives).containsOnlyKeys("HAS_WIFE", "HAS_DAUGHTER");
 
 				relatives.remove("HAS_WIFE");
@@ -108,12 +108,12 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 				ReflectionTestUtils.setField(d, "firstName", "D");
 				relatives.put("HAS_SON", d);
 				ReflectionTestUtils.setField(relatives.get("HAS_DAUGHTER"), "firstName", "C2");
-				return personWithRelatives;
+				return person;
 			})
 			.flatMap(repository::save)
 			.as(StepVerifier::create)
-			.consumeNextWith(personWithRelatives -> {
-				Map<String, Person> relatives = personWithRelatives.getRelatives();
+			.consumeNextWith(person -> {
+				Map<String, Person> relatives = person.getRelatives();
 				assertThat(relatives).containsOnlyKeys("HAS_DAUGHTER", "HAS_SON");
 				assertThat(relatives.get("HAS_DAUGHTER").getFirstName()).isEqualTo("C2");
 				assertThat(relatives.get("HAS_SON").getFirstName()).isEqualTo("D");
@@ -125,11 +125,11 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 	void shouldUpdateDynamicCollectionRelationships(@Autowired PersonWithRelativesRepository repository) {
 
 		repository.findById(idOfExistingPerson)
-			.map(personWithRelatives -> {
-				assumeThat(personWithRelatives).isNotNull();
-				assumeThat(personWithRelatives.getName()).isEqualTo("A");
+			.map(person -> {
+				assumeThat(person).isNotNull();
+				assumeThat(person.getName()).isEqualTo("A");
 
-				Map<String, List<Pet>> pets = personWithRelatives.getPets();
+				Map<String, List<Pet>> pets = person.getPets();
 				assertThat(pets).containsOnlyKeys("CATS", "DOGS");
 
 				pets.remove("DOGS");
@@ -137,12 +137,12 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 
 				pets.put("FISH", Collections.singletonList(new Pet("Nemo")));
 
-				return personWithRelatives;
+				return person;
 			})
 			.flatMap(repository::save)
 			.as(StepVerifier::create)
-			.consumeNextWith(personWithRelatives -> {
-				Map<String, List<Pet>> pets = personWithRelatives.getPets();
+			.consumeNextWith(person -> {
+				Map<String, List<Pet>> pets = person.getPets();
 				assertThat(pets).containsOnlyKeys("CATS", "FISH");
 				assertThat(pets.get("CATS")).extracting(Pet::getName).containsExactlyInAnyOrder("Tom", "Garfield", "Delilah");
 				assertThat(pets.get("FISH")).extracting(Pet::getName).containsExactlyInAnyOrder("Nemo");
@@ -154,8 +154,7 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 	void shouldWriteDynamicRelationships(@Autowired PersonWithRelativesRepository repository) {
 
 		PersonWithRelatives newPerson = new PersonWithRelatives("Test");
-		Person d;
-		d = new Person();
+		Person d = new Person();
 		ReflectionTestUtils.setField(d, "firstName", "R1");
 		newPerson.getRelatives().put("RELATIVE_1", d);
 		d = new Person();
@@ -187,8 +186,7 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 	void shouldWriteDynamicCollectionRelationships(@Autowired PersonWithRelativesRepository repository) {
 
 		PersonWithRelatives newPerson = new PersonWithRelatives("Test");
-		Map<String, List<Pet>> pets;
-		pets = newPerson.getPets();
+		Map<String, List<Pet>> pets = newPerson.getPets();
 
 		List<Pet> monsters = pets.computeIfAbsent("MONSTERS", s -> new ArrayList<>());
 		monsters.add(new Pet("Godzilla"));
@@ -201,8 +199,8 @@ class ReactiveDynamicRelationshipsIT extends DynamicRelationshipsITBase {
 		repository.save(newPerson)
 			.as(StepVerifier::create)
 			.recordWith(() -> recorded)
-			.consumeNextWith(personWithRelatives -> {
-				Map<String, List<Pet>> writtenPets = personWithRelatives.getPets();
+			.consumeNextWith(person -> {
+				Map<String, List<Pet>> writtenPets = person.getPets();
 				assertThat(writtenPets).containsOnlyKeys("MONSTERS", "FISH");
 			})
 			.verifyComplete();

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DynamicRelationshipsITBase.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/DynamicRelationshipsITBase.java
@@ -51,7 +51,13 @@ public abstract class DynamicRelationshipsITBase {
 				+ "CREATE (t:PersonWithRelatives {name: 'A'}) WITH t "
 				+ "CREATE (t) - [:HAS_WIFE] -> (w:Person {firstName: 'B'}) "
 				+ "CREATE (t) - [:HAS_DAUGHTER] -> (d:Person {firstName: 'C'}) "
-				+ " RETURN id(t) as id").single().get("id").asLong();
+				+ "WITH t "
+				+ "UNWIND ['Tom', 'Garfield'] AS cat "
+				+ "CREATE (t) - [:CATS] -> (w:Pet {name: cat}) "
+				+ "WITH DISTINCT t "
+				+ "UNWIND ['Benji', 'Lassie'] AS dog "
+				+ "CREATE (t) - [:DOGS] -> (w:Pet {name: dog}) "
+				+ "RETURN DISTINCT id(t) as id").single().get("id").asLong();
 			transaction.commit();
 		}
 	}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Person.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/Person.java
@@ -52,4 +52,14 @@ public class Person {
 	public String getLastName() {
 		return lastName;
 	}
+
+	@Override
+	public String toString() {
+		return "Person{" +
+			"id=" + id +
+			", firstName='" + firstName + '\'' +
+			", lastName='" + lastName + '\'' +
+			", address=" + address +
+			'}';
+	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelatives.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/PersonWithRelatives.java
@@ -19,6 +19,7 @@
 package org.neo4j.springframework.data.integration.shared;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.springframework.data.core.schema.GeneratedValue;
@@ -38,6 +39,8 @@ public class PersonWithRelatives {
 
 	private Map<String, Person> relatives = new HashMap<>();
 
+	private Map<String, List<Pet>> pets = new HashMap<>();
+
 	public PersonWithRelatives(String name) {
 		this.name = name;
 	}
@@ -52,5 +55,9 @@ public class PersonWithRelatives {
 
 	public Map<String, Person> getRelatives() {
 		return relatives;
+	}
+
+	public Map<String, List<Pet>> getPets() {
+		return pets;
 	}
 }


### PR DESCRIPTION
The core of this change is are `isDynamicOneToManyAssociation` on the `Neo4jPersistentProperty`and the override of `getAssociationTargetType` on `DefaultNeo4jPersistentProperty.java`.

The later returns `null` by default as Spring Data Commons `AbstractPersistentProperty` filters out collection like map values during construction from the `entityTypeInformation` field.

When we encounter an association that is dynamic (as defined before: A map with String to something mappings) and that has collection like values, we extract the required type from that collection and create the association to that one.

This affects of course the `DefaultNeo4jConverter` during reads (it has to create collections in a map)

The writes happen in both the imperative and reactive templates. So for a first implementation, we unroll the list of values into entry sets to keep the existing mechanism during write. This may has some room for improvemenets in large collections at a future point in time.

This commit closes #216.