### PR TITLE
Fail on start if required id property is missing.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentEntity.java
@@ -56,26 +56,35 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 	private static final Set<Class<?>> VALID_GENERATED_ID_TYPES = Collections.unmodifiableSet(new HashSet<>(
 		Arrays.asList(Long.class, long.class)));
 
+	/**
+	 * If an entity is annotated with {@link Node}, we consider this as an explicit entity
+	 * that should get validated more strictly.
+	 */
+	private final Boolean isExplicitEntity;
+
+	/**
+	 * The label that describes the label most concrete.
+	 */
 	private final String primaryLabel;
 
+	private final Lazy<List<String>> additionalLabels;
+
+	/**
+	 * Projections need to be also be eligible entities but don't define id fields.
+	 */
 	@Nullable
 	private IdDescription idDescription;
 
 	private final Lazy<Collection<GraphPropertyDescription>> graphProperties;
 
-	private final Lazy<List<String>> additionalLabels;
-
 	private final Set<NodeDescription<?>> childNodeDescriptions = new HashSet<>();
 
 	private NodeDescription<?> parentNodeDescription;
-	/**
-	 * A view on all simple properties stored on a node.
-	 */
-	private Lazy<Collection<GraphPropertyDescription>> properties;
 
 	DefaultNeo4jPersistentEntity(TypeInformation<T> information) {
 		super(information);
 
+		this.isExplicitEntity = this.isAnnotationPresent(Node.class);
 		this.primaryLabel = computePrimaryLabel();
 		this.additionalLabels = Lazy.of(this::computeAdditionalLabels);
 		this.graphProperties = Lazy.of(this::computeGraphProperties);
@@ -245,12 +254,16 @@ class DefaultNeo4jPersistentEntity<T> extends BasicPersistentEntity<T, Neo4jPers
 		return nodeAnnotation.labels().length < 1 && !hasText(nodeAnnotation.primaryLabel());
 	}
 
+	@Nullable
 	private IdDescription computeIdDescription() {
 
 		Neo4jPersistentProperty idProperty = this.getIdProperty();
-		if (idProperty == null) {
+		if (idProperty == null && isExplicitEntity) {
+			throw new IllegalStateException("Missing id property on " + this.getUnderlyingClass() + ".");
+		} else if (idProperty == null) {
 			return null;
 		}
+
 		GeneratedValue generatedValueAnnotation = idProperty.findAnnotation(GeneratedValue.class);
 
 		// Assigned ids

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jPersistentProperty.java
@@ -124,6 +124,11 @@ class DefaultNeo4jPersistentProperty extends AnnotationBasedPersistentProperty<N
 		return this.isAssociation.orElse(false);
 	}
 
+	@Override
+	public boolean isEntity() {
+		return super.isEntity() && isAssociation();
+	}
+
 	/**
 	 * Computes the target name of this property.
 	 *

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/core/mapping/Neo4jMappingContextTest.java
@@ -128,6 +128,15 @@ public class Neo4jMappingContextTest {
 	}
 
 	@Test
+	void missingIdDefinitionShouldRaiseError() {
+
+		Neo4jMappingContext schema = new Neo4jMappingContext();
+		assertThatIllegalStateException()
+			.isThrownBy(() -> schema.getPersistentEntity(MissingId.class))
+			.withMessage("Missing id property on " + MissingId.class + ".");
+	}
+
+	@Test
 	void targetTypeOfAssociationsShouldBeKnownToTheMappingContext() {
 
 		Neo4jMappingContext schema = new Neo4jMappingContext();
@@ -281,6 +290,10 @@ public class Neo4jMappingContextTest {
 	}
 
 	@Node
+	static class MissingId {
+	}
+
+	@Node
 	static class EntityWithConvertibleProperty {
 
 		@Id @GeneratedValue
@@ -290,6 +303,5 @@ public class Neo4jMappingContextTest {
 	}
 
 	static class ConvertibleType {
-
 	}
 }


### PR DESCRIPTION
If a class is annotated with `@Node` we can assume that it is the intention of the user to map this entity later. This will mark the entity as an explicit entity and we could apply stricter verification if needed.
This PR uses this mechanism for throwing an exception if the id property is missing.

closes #224 