### PR TITLE
Automatically generate UUIDs.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/GeneratedValue.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.UUID;
 
 import org.apiguardian.api.API;
 import org.springframework.core.annotation.AliasFor;
@@ -72,6 +73,20 @@ public @interface GeneratedValue {
 		@Override
 		public Void generateId(String primaryLabel, Object entity) {
 			return null;
+		}
+	}
+
+	/**
+	 * This generator is automatically applied when a field of type {@link java.util.UUID} is annotated with
+	 * {@link Id @Id} and {@link GeneratedValue @GeneratedValue}.
+	 *
+	 * @since 1.0.1
+	 */
+	final class UUIDGenerator implements IdGenerator<UUID> {
+
+		@Override
+		public UUID generateId(String primaryLabel, Object entity) {
+			return UUID.randomUUID();
 		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/IdDescription.java
@@ -86,7 +86,7 @@ public final class IdDescription {
 		}
 	}
 
-	public IdDescription(
+	private IdDescription(
 		@Nullable Class<? extends IdGenerator<?>> idGeneratorClass,
 		@Nullable String idGeneratorRef,
 		@Nullable String graphPropertyName

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/TypeConversionIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/TypeConversionIT.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicContainer;
@@ -44,6 +45,7 @@ import org.neo4j.springframework.data.integration.shared.ThingWithAllCypherTypes
 import org.neo4j.springframework.data.integration.shared.ThingWithAllSpatialTypes;
 import org.neo4j.springframework.data.integration.shared.ThingWithCustomTypes;
 import org.neo4j.springframework.data.integration.shared.ThingWithNonExistingPrimitives;
+import org.neo4j.springframework.data.integration.shared.ThingWithUUIDID;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
@@ -185,6 +187,19 @@ class TypeConversionIT extends Neo4jConversionsITBase {
 				.single().get("cnt").asLong();
 			assertThat(cnt).isEqualTo(1L);
 		}
+	}
+
+	@Test
+	void idsShouldBeConverted(@Autowired ConvertedIDsRepository repository) {
+
+		ThingWithUUIDID thing = repository.save(new ThingWithUUIDID("a thing"));
+		assertThat(thing.getId()).isNotNull();
+
+		assertThat(repository.findById(thing.getId())).isPresent();
+	}
+
+	public interface ConvertedIDsRepository
+		extends Neo4jRepository<ThingWithUUIDID, UUID> {
 	}
 
 	public interface CypherTypesRepository

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithUUIDID.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/shared/ThingWithUUIDID.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.shared;
+
+import java.util.UUID;
+
+import org.neo4j.springframework.data.core.schema.GeneratedValue;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Samy Deluxe - Samy Deluxe
+ */
+@Node
+public class ThingWithUUIDID {
+
+	@Id @GeneratedValue
+	private UUID id;
+
+	private String name;
+
+	public ThingWithUUIDID(String name) {
+		this.name = name;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+}


### PR DESCRIPTION
In a scenario where a user has defined a class with an id of type `java.util.UUID` annotated with `@Id @GeneratedValue`, we can safely assume they want to have those UUIDs generated by us as long as they haven’t defined their own generator (by class or by ref).

This change now treats those ids as externally generated without the need to apply an execplict generator.