### PR TITLE
Derived finder method support for relationship properties

### DIFF
--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipPattern.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipPattern.java
@@ -34,4 +34,6 @@ import org.apiguardian.api.API;
  */
 @API(status = EXPERIMENTAL, since = "1.0")
 public interface RelationshipPattern extends PatternElement, ExposesRelationships<RelationshipChain> {
+
+	ExposesRelationships<RelationshipChain> named(String name);
 }


### PR DESCRIPTION
If `RelationshipProperties` are used the derived finder methods to query for property on related entities will fail to get instantiated because SDN-RX tries to query for the given property on the related node type of the `Map` (key) but the Spring Data Commons infrastructure moves towards the `RelationshipProperties` type (value).
This PR fixes this behaviour and creates queries for the relationship properties accordingly to the behaviour of Spring Data Commons.