### PR TITLE
Make where clause of PatternComprehensions consistent with match.

### DIFF
--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesLogicalOperators.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesLogicalOperators.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.opencypherdsl;
+
+/**
+ * A step exposing logical operators {@code and} and {@code or} after a {@code where} clause.
+ *
+ * @author Michael J. Simons
+ * @param <T> The type being returned after the new condition has been chained
+ * @since 1.1
+ */
+public interface ExposesLogicalOperators<T> {
+
+	/**
+	 * Adds an additional condition to the existing conditions, connected by an {@literal and}.
+	 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+	 * conditions used another logical operator.
+	 *
+	 * @param condition An additional condition
+	 * @return The ongoing definition of a match
+	 */
+	T and(Condition condition);
+
+	/**
+	 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal and}.
+	 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+	 * conditions used another logical operator.
+	 *
+	 * @param pathPattern An additional pattern to include in the conditions
+	 * @return The ongoing definition of a match
+	 */
+	default T and(RelationshipPattern pathPattern) {
+		return this.and(new RelationshipPatternCondition(pathPattern));
+	}
+
+	/**
+	 * Adds an additional condition to the existing conditions, connected by an {@literal or}.
+	 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+	 * conditions used another logical operator.
+	 *
+	 * @param condition An additional condition
+	 * @return The ongoing definition of a match
+	 */
+	T or(Condition condition);
+
+	/**
+	 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal or}.
+	 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
+	 * conditions used another logical operator.
+	 *
+	 * @param pathPattern An additional pattern to include in the conditions
+	 * @return The ongoing definition of a match
+	 */
+	default T or(RelationshipPattern pathPattern) {
+		return this.or(new RelationshipPatternCondition(pathPattern));
+	}
+}

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PatternComprehension.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PatternComprehension.java
@@ -55,7 +55,7 @@ public final class PatternComprehension implements Expression {
 	/**
 	 * Provides the final step of defining a pattern comprehension.
 	 */
-	public interface OngoingDefinitionWithoutReturn  {
+	public interface OngoingDefinitionWithoutReturn {
 
 		/**
 		 * @param variables the elements to be returned from the pattern

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PatternComprehension.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PatternComprehension.java
@@ -53,17 +53,9 @@ public final class PatternComprehension implements Expression {
 	}
 
 	/**
-	 * Allows to add a where clause into the definition of the pattern.
-	 */
-	public interface OngoingDefinitionWithPattern extends OngoingDefinitionWithoutReturn {
-
-		OngoingDefinitionWithoutReturn where(Condition condition);
-	}
-
-	/**
 	 * Provides the final step of defining a pattern comprehension.
 	 */
-	public interface OngoingDefinitionWithoutReturn {
+	public interface OngoingDefinitionWithoutReturn  {
 
 		/**
 		 * @param variables the elements to be returned from the pattern
@@ -82,24 +74,51 @@ public final class PatternComprehension implements Expression {
 	}
 
 	/**
+	 * Allows to add a where clause into the definition of the pattern.
+	 */
+	public interface OngoingDefinitionWithPattern extends OngoingDefinitionWithoutReturn {
+
+		OngoingDefinitionWithPatternAndWhere where(Condition condition);
+	}
+
+	/**
+	 * Intermediate step that allows expressing additional, logical operators.
+	 */
+	public interface OngoingDefinitionWithPatternAndWhere extends OngoingDefinitionWithoutReturn, ExposesLogicalOperators<OngoingDefinitionWithPatternAndWhere>  {
+	}
+
+	/**
 	 * Ongoing definition of a pattern comprehension. Can be defined without a where-clause now.
 	 */
-	private static class Builder implements OngoingDefinitionWithPattern {
+	private static class Builder implements OngoingDefinitionWithPattern, OngoingDefinitionWithPatternAndWhere  {
 		private final RelationshipPattern pattern;
-		private Where where;
+		private final DefaultStatementBuilder.ConditionBuilder conditionBuilder = new DefaultStatementBuilder.ConditionBuilder();
 
 		private Builder(RelationshipPattern pattern) {
 			this.pattern = pattern;
 		}
 
-		public OngoingDefinitionWithoutReturn where(Condition condition) {
-			this.where = new Where(condition);
+		@Override
+		public OngoingDefinitionWithPatternAndWhere where(Condition condition) {
+			conditionBuilder.where(condition);
+			return this;
+		}
+
+		@Override
+		public OngoingDefinitionWithPatternAndWhere and(Condition condition) {
+			conditionBuilder.and(condition);
+			return this;
+		}
+
+		@Override
+		public OngoingDefinitionWithPatternAndWhere or(Condition condition) {
+			conditionBuilder.or(condition);
 			return this;
 		}
 
 		@Override
 		public PatternComprehension returning(Expression... expressions) {
-
+			Where where = conditionBuilder.buildCondition().map(Where::new).orElse(null);
 			return new PatternComprehension(pattern, where, listOrSingleExpression(expressions));
 		}
 	}

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/StatementBuilder.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/StatementBuilder.java
@@ -85,58 +85,8 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 	 * A match that has a non-empty {@code where}-part. THe returning clause is still open.
 	 * @since 1.0
 	 */
-	interface OngoingReadingWithWhere extends OngoingReading, ExposesMatch, ExposesConditions<OngoingReadingWithWhere> {
-	}
-
-	/**
-	 * @param <T> Type of ongoing query.
-	 * @since 1.0
-	 */
-	interface ExposesConditions<T> {
-
-		/**
-		 * Adds an additional condition to the existing conditions, connected by an {@literal and}.
-		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
-		 * conditions used another logical operator.
-		 *
-		 * @param condition An additional condition
-		 * @return The ongoing definition of a match
-		 */
-		T and(Condition condition);
-
-		/**
-		 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal and}.
-		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
-		 * conditions used another logical operator.
-		 *
-		 * @param pathPattern An additional pattern to include in the conditions
-		 * @return The ongoing definition of a match
-		 */
-		default T and(RelationshipPattern pathPattern) {
-			return this.and(new RelationshipPatternCondition(pathPattern));
-		}
-
-		/**
-		 * Adds an additional condition to the existing conditions, connected by an {@literal or}.
-		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
-		 * conditions used another logical operator.
-		 *
-		 * @param condition An additional condition
-		 * @return The ongoing definition of a match
-		 */
-		T or(Condition condition);
-
-		/**
-		 * Adds an additional condition based on a path pattern to the existing conditions, connected by an {@literal or}.
-		 * Existing conditions will be logically grouped by using {@code ()} in the statement if previous
-		 * conditions used another logical operator.
-		 *
-		 * @param pathPattern An additional pattern to include in the conditions
-		 * @return The ongoing definition of a match
-		 */
-		default T or(RelationshipPattern pathPattern) {
-			return this.or(new RelationshipPatternCondition(pathPattern));
-		}
+	interface OngoingReadingWithWhere extends OngoingReading, ExposesMatch,
+		ExposesLogicalOperators<OngoingReadingWithWhere> {
 	}
 
 	/**
@@ -198,11 +148,11 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 
 	/**
 	 * @see OrderableOngoingReadingAndWith
-	 * @see ExposesConditions
+	 * @see ExposesLogicalOperators
 	 * @since 1.0
 	 */
 	interface OrderableOngoingReadingAndWithWithWhere
-		extends OrderableOngoingReadingAndWith, ExposesConditions<OrderableOngoingReadingAndWithWithWhere> {
+		extends OrderableOngoingReadingAndWith, ExposesLogicalOperators<OrderableOngoingReadingAndWithWithWhere> {
 	}
 
 	/**


### PR DESCRIPTION
This change allows chaining and nesting condition after the `where`-part of a pattern comprehension and not only inside, so that this part of the API is consistent with the general match clauses.