### PR TITLE
Rework property container.

### DIFF
--- a/examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java
+++ b/examples/docs/src/test/java/org/neo4j/doc/springframework/data/docs/repositories/cypherdsl/CypherDSLExamplesTest.java
@@ -43,7 +43,7 @@ class CypherDSLExamplesTest {
 	void playMovieGraphFind() {
 
 		// tag::cypher-dsl-e2[]
-		var tom = anyNode().named("tom").properties("name", literalOf("Tom Hanks"));
+		var tom = anyNode().named("tom").withProperties("name", literalOf("Tom Hanks"));
 		var statement = Cypher
 			.match(tom).returning(tom)
 			.build();
@@ -53,7 +53,7 @@ class CypherDSLExamplesTest {
 		// end::cypher-dsl-e2[]
 
 		// tag::cypher-dsl-e3[]
-		var cloudAtlas = anyNode().named("cloudAtlas").properties("title", literalOf("Cloud Atlas"));
+		var cloudAtlas = anyNode().named("cloudAtlas").withProperties("title", literalOf("Cloud Atlas"));
 		statement = Cypher
 			.match(cloudAtlas).returning(cloudAtlas)
 			.build();
@@ -93,7 +93,7 @@ class CypherDSLExamplesTest {
 	void playMovieGraphQuery() {
 
 		// tag::cypher-dsl-e6[]
-		var tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		var tom = node("Person").named("tom").withProperties("name", literalOf("Tom Hanks"));
 		var tomHanksMovies = anyNode("tomHanksMovies");
 		var statement = Cypher
 			.match(tom.relationshipTo(tomHanksMovies, "ACTED_IN"))
@@ -106,7 +106,7 @@ class CypherDSLExamplesTest {
 		// end::cypher-dsl-e6[]
 
 		// tag::cypher-dsl-e7[]
-		var cloudAtlas = anyNode("cloudAtlas").properties("title", literalOf("Cloud Atlas"));
+		var cloudAtlas = anyNode("cloudAtlas").withProperties("title", literalOf("Cloud Atlas"));
 		var directors = anyNode("directors");
 		statement = Cypher
 			.match(cloudAtlas.relationshipFrom(directors, "DIRECTED"))
@@ -118,7 +118,7 @@ class CypherDSLExamplesTest {
 		// end::cypher-dsl-e7[]
 
 		// tag::cypher-dsl-e8[]
-		tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		tom = node("Person").named("tom").withProperties("name", literalOf("Tom Hanks"));
 		var movie = anyNode("m");
 		var coActors = anyNode("coActors");
 		var people = node("Person").named("people");
@@ -133,7 +133,7 @@ class CypherDSLExamplesTest {
 		// end::cypher-dsl-e8[]
 
 		// tag::cypher-dsl-e9[]
-		cloudAtlas = node("Movie").properties("title", literalOf("Cloud Atlas"));
+		cloudAtlas = node("Movie").withProperties("title", literalOf("Cloud Atlas"));
 		people = node("Person").named("people");
 		var relatedTo = people.relationshipBetween(cloudAtlas).named("relatedTo");
 		statement = Cypher
@@ -151,7 +151,7 @@ class CypherDSLExamplesTest {
 	void playMovieGraphSolve() {
 
 		// tag::cypher-dsl-bacon[]
-		var bacon = node("Person").named("bacon").properties("name", literalOf("Kevin Bacon"));
+		var bacon = node("Person").named("bacon").withProperties("name", literalOf("Kevin Bacon"));
 		var hollywood = anyNode("hollywood");
 		var statement = Cypher
 			.match(bacon.relationshipBetween(hollywood).length(1, 4))
@@ -167,7 +167,7 @@ class CypherDSLExamplesTest {
 	void playMovieGraphRecommend() {
 
 		// tag::cypher-dsl-r[]
-		var tom = node("Person").named("tom").properties("name", literalOf("Tom Hanks"));
+		var tom = node("Person").named("tom").withProperties("name", literalOf("Tom Hanks"));
 		var coActors = anyNode("coActors");
 		var cocoActors = anyNode("cocoActors");
 		var strength = count(asterisk()).as("Strength");

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesProperties.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.opencypherdsl;
+
+/**
+ * A container that exposes methods to add properties with values to nodes or relationships.
+ *
+ * @author Michael J. Simons
+ * @param <T> type of the object holding the specified properties
+ * @soundtrack Daft Punk - Homework
+ * @since 1.1
+ */
+public interface ExposesProperties<T extends ExposesProperties<?> & PropertyContainer> {
+
+	/**
+	 * Creates a a copy of this property container with additional properties.
+	 * Creates a property container without properties when no properties are passed to this method.
+	 *
+	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
+	 * @return The new property container.
+	 */
+	T withProperties(MapExpression<?> newProperties);
+
+	/**
+	 * Creates a a copy of this property container with additional properties.
+	 * Creates a property container without properties when no properties are passed to this method.
+	 *
+	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
+	 * @return The new property container.
+	 */
+	T withProperties(Object... keysAndValues);
+}

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesRelationships.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExposesRelationships.java
@@ -26,11 +26,12 @@ import org.apiguardian.api.API;
  * A marker interface for things that expose methods to create new relationships to other elements.
  *
  * @author Michael J. Simons
- * @param <T> Typically a {@link Relationship} or {@link RelationshipChain}
+ * @param <T> The type of the resulting {@link RelationshipPattern}.
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public interface ExposesRelationships<T> {
+public interface ExposesRelationships<T extends RelationshipPattern> {
+
 	/**
 	 * Starts building an outgoing relationship to the {@code other} {@link Node node}.
 	 *

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Node.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Node.java
@@ -38,7 +38,7 @@ import org.neo4j.opencypherdsl.support.Visitor;
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class Node implements PatternElement, Named, ExposesRelationships<Relationship> {
+public final class Node implements PatternElement, PropertyContainer, ExposesRelationships<Relationship>, ExposesProperties<Node> {
 
 	static Node create(String primaryLabel, String... additionalLabels) {
 
@@ -113,32 +113,26 @@ public final class Node implements PatternElement, Named, ExposesRelationships<R
 		return new Node(newSymbolicName, properties, labels);
 	}
 
-	/**
-	 * Creates a a copy of this node with additional properties. Creates a node without properties when no properties
-	 * * are passed to this method.
-	 *
-	 * @param newProperties the new properties
-	 * @return The new node.
-	 */
-	public Node properties(MapExpression<?> newProperties) {
+	@Override
+	public Node withProperties(MapExpression<?> newProperties) {
 
 		return new Node(this.symbolicName, newProperties == null ? null : new Properties(newProperties), labels);
 	}
 
-	/**
-	 * Creates a a copy of this node with additional properties. Creates a node without properties when no properties
-	 * are passed to this method.
-	 *
-	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
-	 * @return The new node.
-	 */
-	public Node properties(Object... keysAndValues) {
+	@Override
+	public Node withProperties(Object... keysAndValues) {
 
 		MapExpression<?> newProperties = null;
 		if (keysAndValues != null && keysAndValues.length != 0) {
 			newProperties = MapExpression.create(keysAndValues);
 		}
-		return properties(newProperties);
+		return withProperties(newProperties);
+	}
+
+	@Override
+	public Property property(String name) {
+
+		return Property.create(this, name);
 	}
 
 	/**
@@ -170,20 +164,6 @@ public final class Node implements PatternElement, Named, ExposesRelationships<R
 	 */
 	public Optional<SymbolicName> getSymbolicName() {
 		return Optional.ofNullable(symbolicName);
-	}
-
-	/**
-	 * Creates a new {@link Property} associated with this property container.
-	 * <p>
-	 * Note: The property container does not track property creation and there is no possibility to enumerate all
-	 * properties that have been created for this node.
-	 *
-	 * @param name property name, must not be {@literal null} or empty.
-	 * @return a new {@link Property} associated with this {@link Node}.
-	 */
-	public Property property(String name) {
-
-		return Property.create(this, name);
 	}
 
 	public FunctionInvocation internalId() {

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Property.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Property.java
@@ -38,7 +38,7 @@ public final class Property implements Expression {
 			"A property derived from a node or a relationship needs a parent with a symbolic name.");
 		Assert.hasText(name, "The properties name is required.");
 
-		return new Property(parentContainer.getSymbolicName().get(), new PropertyLookup((name)));
+		return new Property(parentContainer.getRequiredSymbolicName(), new PropertyLookup((name)));
 	}
 
 	static Property create(Expression container, String name) {

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PropertyContainer.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/PropertyContainer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.opencypherdsl;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * A container having properties. A property container must be {@link Named} with a non empty name to be able to refer
+ * to properties.
+ *
+ * @author Andreas Berger
+ * @author Michael J. Simons
+ * @since 1.1
+ */
+@API(status = EXPERIMENTAL, since = "1.1")
+public interface PropertyContainer extends Named {
+
+	/**
+	 * Creates a new {@link Property} associated with this property container. This property can be used as a lookup in
+	 * other expressions. It does not add a value to the property.
+	 * <p>
+	 * Note: The property container does not track property creation and there is no possibility to enumerate all
+	 * properties that have been created for this property container.
+	 *
+	 * @param name property name, must not be {@literal null} or empty.
+	 * @return a new {@link Property} associated with this {@link Relationship}.
+	 */
+	Property property(String name);
+}

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Relationship.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Relationship.java
@@ -36,7 +36,7 @@ import org.neo4j.opencypherdsl.support.Visitor;
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class Relationship implements RelationshipPattern, Named {
+public final class Relationship implements RelationshipPattern, PropertyContainer, ExposesProperties<Relationship> {
 
 	/**
 	 * While the direction in the schema package is centered around the node, the direction here is the direction between two nodes.
@@ -173,35 +173,30 @@ public final class Relationship implements RelationshipPattern, Named {
 		return new Relationship(this.left, this.details.min(minimum).max(maximum), this.right);
 	}
 
-	/**
-	 * Creates a a copy of this relationship with additional properties. Creates a relationship without properties when no properties
-	 * are passed to this method.
-	 *
-	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
-	 * @return The new relationship.
-	 */
-	public Relationship properties(MapExpression<?> newProperties) {
+	@Override
+	public Relationship withProperties(MapExpression<?> newProperties) {
 
 		if (newProperties == null && this.details.getProperties() == null) {
 			return this;
 		}
-		return new Relationship(this.left, this.details.with(newProperties == null ? null : new Properties(newProperties)), this.right);
+		return new Relationship(this.left,
+			this.details.with(newProperties == null ? null : new Properties(newProperties)), this.right);
 	}
 
-	/**
-	 * Creates a a copy of this relationship with additional properties. Creates a relationship without properties when no properties
-	 * are passed to this method.
-	 *
-	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
-	 * @return The new relationship.
-	 */
-	public Relationship properties(Object... keysAndValues) {
+	@Override
+	public Relationship withProperties(Object... keysAndValues) {
 
 		MapExpression<?> newProperties = null;
 		if (keysAndValues != null && keysAndValues.length != 0) {
 			newProperties = MapExpression.create(keysAndValues);
 		}
-		return properties(newProperties);
+		return withProperties(newProperties);
+	}
+
+	@Override
+	public Property property(String name) {
+
+		return Property.create(this, name);
 	}
 
 	@Override
@@ -253,20 +248,5 @@ public final class Relationship implements RelationshipPattern, Named {
 	 */
 	public MapProjection project(Object... entries) {
 		return MapProjection.create(this.getRequiredSymbolicName(), entries);
-	}
-
-	/**
-	 * Creates a new {@link Property} associated with this property container.
-	 * <p>
-	 * Note: The property container does not track property creation and there is no possibility to enumerate all
-	 * properties that have been created for this relationship.
-	 *
-	 * @param name property name, must not be {@literal null} or empty.
-	 * @return a new {@link Property} associated with this {@link Relationship}.
-	 * @since 1.0.1
-	 */
-	public Property property(String name) {
-
-		return Property.create(this, name);
 	}
 }

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipChain.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipChain.java
@@ -124,7 +124,7 @@ public final class RelationshipChain implements RelationshipPattern, ExposesRela
 	public RelationshipChain properties(MapExpression<?> newProperties) {
 
 		Relationship lastElement = this.relationships.removeLast();
-		return this.add(lastElement.properties(newProperties));
+		return this.add(lastElement.withProperties(newProperties));
 	}
 
 	/**
@@ -136,7 +136,7 @@ public final class RelationshipChain implements RelationshipPattern, ExposesRela
 	public RelationshipChain properties(Object... keysAndValues) {
 
 		Relationship lastElement = this.relationships.removeLast();
-		return this.add(lastElement.properties(keysAndValues));
+		return this.add(lastElement.withProperties(keysAndValues));
 	}
 
 	@Override

--- a/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/CypherIT.java
+++ b/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/CypherIT.java
@@ -106,7 +106,7 @@ class CypherIT {
 			void relationshipWithProperties() {
 				Statement statement = Cypher
 					.match(userNode.relationshipTo(bikeNode, "OWNS")
-						.properties(mapOf("boughtOn", literalOf("2019-04-16"))))
+						.withProperties(mapOf("boughtOn", literalOf("2019-04-16"))))
 					.returning(bikeNode, userNode)
 					.build();
 
@@ -151,7 +151,7 @@ class CypherIT {
 			void relationshipWithLengthAndProperties() {
 				Statement statement = Cypher
 					.match(userNode.relationshipTo(bikeNode, "OWNS").length(3, 5)
-						.properties(mapOf("boughtOn", literalOf("2019-04-16"))))
+						.withProperties(mapOf("boughtOn", literalOf("2019-04-16"))))
 					.returning(bikeNode, userNode)
 					.build();
 
@@ -1111,7 +1111,7 @@ class CypherIT {
 
 			@Test
 			void doc3651And() {
-				Node timothy = Cypher.node("Person").named("timothy").properties("name", literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1135,7 +1135,7 @@ class CypherIT {
 
 			@Test
 			void doc3651Or() {
-				Node timothy = Cypher.node("Person").named("timothy").properties("name", literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1159,7 +1159,7 @@ class CypherIT {
 
 			@Test
 			void doc3651XOr() {
-				Node timothy = Cypher.node("Person").named("timothy").properties("name", literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1178,7 +1178,7 @@ class CypherIT {
 			void doc3652() {
 
 				Node person = Cypher.node("Person").named("person");
-				Node peter = Cypher.node("Person").named("peter").properties("name", literalOf("Peter"));
+				Node peter = Cypher.node("Person").named("peter").withProperties("name", literalOf("Peter"));
 
 				Statement statement;
 
@@ -1199,7 +1199,7 @@ class CypherIT {
 				Statement statement;
 
 				statement = Cypher.match(person)
-					.where(person.relationshipBetween(anyNode().properties("name", literalOf("Timothy")), "KNOWS"))
+					.where(person.relationshipBetween(anyNode().withProperties("name", literalOf("Timothy")), "KNOWS"))
 					.returning(person.property("name"), person.property("age"))
 					.build();
 
@@ -1228,7 +1228,7 @@ class CypherIT {
 			@Test
 			void afterWith() {
 
-				Node timothy = Cypher.node("Person").named("timothy").properties("name", literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1257,7 +1257,7 @@ class CypherIT {
 		void inPatternComprehensions() {
 
 			Statement statement;
-			Node a = Cypher.node("Person").properties("name", literalOf("Keanu Reeves")).named("a");
+			Node a = Cypher.node("Person").withProperties("name", literalOf("Keanu Reeves")).named("a");
 			Node b = Cypher.anyNode("b");
 
 			statement = Cypher.match(a)
@@ -2052,8 +2052,8 @@ class CypherIT {
 
 			for (Node nodeWithProperties : new Node[] {
 				Cypher.node("Test", mapOf("a", literalOf("b"))),
-				Cypher.node("Test").properties(mapOf("a", literalOf("b"))),
-				Cypher.node("Test").properties("a", literalOf("b"))
+				Cypher.node("Test").withProperties(mapOf("a", literalOf("b"))),
+				Cypher.node("Test").withProperties("a", literalOf("b"))
 			}) {
 
 				Statement statement;
@@ -2078,7 +2078,7 @@ class CypherIT {
 		@Test
 		void nestedProperties() {
 
-			Node nodeWithProperties = Cypher.node("Test").properties("outer", mapOf("a", literalOf("b")));
+			Node nodeWithProperties = Cypher.node("Test").withProperties("outer", mapOf("a", literalOf("b")));
 
 			Statement statement;
 			statement = Cypher.match(nodeWithProperties)
@@ -2093,7 +2093,7 @@ class CypherIT {
 		@Test
 		void shouldNotRenderPropertiesInReturn() {
 
-			Node nodeWithProperties = bikeNode.properties("a", literalOf("b"));
+			Node nodeWithProperties = bikeNode.withProperties("a", literalOf("b"));
 
 			Statement statement;
 			statement = Cypher.match(nodeWithProperties, nodeWithProperties.relationshipFrom(userNode, "OWNS"))
@@ -2143,7 +2143,7 @@ class CypherIT {
 			Statement statement;
 			statement = Cypher.unwind(Cypher.literalOf(1), Cypher.literalTrue(), Cypher.literalFalse())
 				.as("n")
-				.merge(bikeNode.properties("b", name("n")))
+				.merge(bikeNode.withProperties("b", name("n")))
 				.returning(bikeNode)
 				.build();
 
@@ -2158,7 +2158,7 @@ class CypherIT {
 			Statement statement;
 			statement = Cypher.unwind(Cypher.literalOf(1), Cypher.literalTrue(), Cypher.literalFalse())
 				.as("n")
-				.create(bikeNode.properties("b", name("n")))
+				.create(bikeNode.withProperties("b", name("n")))
 				.returning(bikeNode)
 				.build();
 
@@ -2333,21 +2333,21 @@ class CypherIT {
 				Node movie = node("Movie").named("movie");
 
 				statement = Cypher
-					.match(actor.properties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(actor.withProperties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor
 						.project("name", "realName", "movies", Functions.collect(movie.project("title", "released"))))
 					.build();
 				assertThat(cypherRenderer.render(statement)).isEqualTo(expected);
 
 				statement = Cypher
-					.match(actor.properties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(actor.withProperties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor.project("name", "realName", "movies",
 						Functions.collect(movie.project(movie.property("title"), movie.property("released")))))
 					.build();
 				assertThat(cypherRenderer.render(statement)).isEqualTo(expected);
 
 				statement = Cypher
-					.match(actor.properties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(actor.withProperties("name", literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor.project("name", "realName", "movies",
 						Functions.collect(movie.project("title", "year", movie.property("released")))))
 					.build();
@@ -2595,7 +2595,7 @@ class CypherIT {
 		void simple() {
 
 			Statement statement;
-			Node a = Cypher.node("Person").properties("name", literalOf("Keanu Reeves")).named("a");
+			Node a = Cypher.node("Person").withProperties("name", literalOf("Keanu Reeves")).named("a");
 			Node b = Cypher.anyNode("b");
 
 			statement = Cypher.match(a)
@@ -2610,7 +2610,7 @@ class CypherIT {
 		void simpleWithWhere() {
 
 			Statement statement;
-			Node a = Cypher.node("Person").properties("name", literalOf("Keanu Reeves")).named("a");
+			Node a = Cypher.node("Person").withProperties("name", literalOf("Keanu Reeves")).named("a");
 			Node b = Cypher.anyNode("b");
 
 			statement = Cypher.match(a)
@@ -2830,7 +2830,7 @@ class CypherIT {
 
 		@Test
 		void gh167() {
-			final Node app = node("Location").named("app").properties("uuid", parameter("app_uuid"));
+			final Node app = node("Location").named("app").withProperties("uuid", parameter("app_uuid"));
 			final Node locStart = node("Location").named("loc_start");
 			final Node resume = node("Resume").named("r");
 			final Node offer = node("Offer").named("o");
@@ -2842,7 +2842,7 @@ class CypherIT {
 			Statement statement = match(aFl, lFr)
 				.withDistinct(resume, locStart, app)
 				.match(resume
-					.relationshipTo(offer.properties("is_valid", literalTrue()), "IN_COHORT_OF")
+					.relationshipTo(offer.withProperties("is_valid", literalTrue()), "IN_COHORT_OF")
 					.relationshipTo(anyNode("app"), "IN")
 				)
 				.withDistinct(resume, locStart, app, offer)

--- a/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/RelationshipTest.java
+++ b/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/RelationshipTest.java
@@ -19,8 +19,21 @@
 package org.neo4j.opencypherdsl;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
+import static org.neo4j.opencypherdsl.Cypher.*;
 
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.opencypherdsl.support.Visitable;
+import org.neo4j.opencypherdsl.support.Visitor;
 
 /**
  * @author Michael J. Simons
@@ -30,9 +43,75 @@ class RelationshipTest {
 	@Test
 	void preconditionsShouldBeAsserted() {
 
-		assertThatIllegalArgumentException().isThrownBy(() -> Relationship.create(null, null, Node.create("a"), new String[0]))
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> Relationship.create(null, null, Node.create("a"), new String[0]))
 			.withMessage("Left node is required.");
-		assertThatIllegalArgumentException().isThrownBy(() -> Relationship.create(Node.create("a"), null, null, new String[0]))
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> Relationship.create(Node.create("a"), null, null, new String[0]))
 			.withMessage("Right node is required.");
+	}
+
+	@Nested
+	@TestInstance(PER_CLASS)
+	class PropertiesShouldBeHandled {
+
+		private Stream<Arguments> createNodesWithProperties() {
+			return Stream.of(
+				Arguments.of(Node.create("N").named("n").relationshipTo(Cypher.anyNode())
+					.withProperties("p", literalTrue())),
+				Arguments.of(Node.create("N").named("n").relationshipTo(Cypher.anyNode())
+					.withProperties(MapExpression.create("p", literalTrue())))
+			);
+		}
+
+		@ParameterizedTest
+		@MethodSource("createNodesWithProperties")
+		void shouldAddProperties(Relationship relationship) {
+
+			AtomicBoolean failTest = new AtomicBoolean(true);
+			relationship.accept(new Visitor() {
+				Class<?> expectedTypeOfNextSegment = null;
+
+				@Override
+				public void enter(Visitable segment) {
+					if (segment instanceof SymbolicName) {
+						assertThat(((SymbolicName) segment).getValue()).isEqualTo("n");
+					} else if (segment instanceof NodeLabel) {
+						assertThat(((NodeLabel) segment).getValue()).isEqualTo("N");
+					} else if (segment instanceof KeyValueMapEntry) {
+						assertThat(((KeyValueMapEntry) segment).getKey()).isEqualTo("p");
+						expectedTypeOfNextSegment = BooleanLiteral.class;
+					} else if (expectedTypeOfNextSegment != null) {
+						assertThat(segment).isInstanceOf(expectedTypeOfNextSegment);
+						failTest.getAndSet(false);
+					}
+				}
+
+				@Override
+				public void leave(Visitable segment) {
+					if (expectedTypeOfNextSegment == BooleanLiteral.class) {
+						failTest.getAndSet(true);
+						expectedTypeOfNextSegment = Node.class;
+					}
+				}
+			});
+			assertThat(failTest).isFalse();
+		}
+
+		@Test
+		void shouldCreateProperty() {
+
+			Relationship relationship = Node.create("N").named("n").relationshipTo(Cypher.anyNode()).named("r");
+			Property property = relationship.property("p");
+
+			java.util.Set<Object> expected = new HashSet<>();
+			expected.add(property.getName());
+			expected.add(relationship.getRequiredSymbolicName());
+			expected.add(property);
+
+			property.accept(expected::remove);
+
+			assertThat(expected).isEmpty();
+		}
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/schema/CypherGenerator.java
@@ -182,7 +182,7 @@ public enum CypherGenerator {
 
 			} else {
 				return updateDecorator.apply(
-					Cypher.merge(rootNode.properties(nameOfIdProperty, idParameter))
+					Cypher.merge(rootNode.withProperties(nameOfIdProperty, idParameter))
 						.set(rootNode, parameter(NAME_OF_PROPERTIES_PARAM))
 				).returning(rootNode.internalId()).build();
 			}
@@ -245,7 +245,7 @@ public enum CypherGenerator {
 		String row = "entity";
 		return Cypher
 			.unwind(parameter(NAME_OF_ENTITY_LIST_PARAM)).as(row)
-			.merge(rootNode.properties(nameOfIdProperty, property(row, NAME_OF_ID)))
+			.merge(rootNode.withProperties(nameOfIdProperty, property(row, NAME_OF_ID)))
 			.set(rootNode, property(row, NAME_OF_PROPERTIES_PARAM))
 			.returning(Functions.collect(rootNode.property(nameOfIdProperty)).as(NAME_OF_IDS))
 			.build();


### PR DESCRIPTION
This commit introduces two new concepts:

1. The `PropertyContainer`: A `PropertyContainer` can produce references to properties which can be used in expressions etc. It needs to be named.
2. The builder like `ExposesProperties` mixin: This allows adding properties with defined values to a property container.

In the refactoring, method names have been clariefied. New properties are now added with `withProperties`, which is a breaking change for users that might be on the experimental API.

Co-authored-by: Andreas Berger <andreas@berger-ecommerce.com>