### PR TITLE
Add named paths and missing predicate functions.

### DIFF
--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/BooleanFunctionCondition.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/BooleanFunctionCondition.java
@@ -30,8 +30,8 @@ import org.neo4j.opencypherdsl.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = EXPERIMENTAL, since = "1.0")
-public final class BooleanFunctionCondition implements Condition {
+@API(status = INTERNAL, since = "1.0")
+final class BooleanFunctionCondition implements Condition {
 
 	private final FunctionInvocation delegate;
 

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Conditions.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Conditions.java
@@ -23,8 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 import org.apiguardian.api.API;
 
 /**
- * Builder for various conditions. Used internally from properties and other expressions that should take part in
- * conditions.
+ * Builder for various conditions.
  *
  * @author Michael J. Simons
  * @author Gerrit Meier
@@ -123,7 +122,7 @@ public final class Conditions {
 		return condition.not();
 	}
 
-	 public static Condition not(PatternElement patternElement) {
+	public static Condition not(PatternElement patternElement) {
 
 		Assert.notNull(patternElement, "Pattern to negate must not be null.");
 		return new ExcludedPattern(patternElement);
@@ -204,28 +203,6 @@ public final class Conditions {
 	static Condition isEmpty(Expression expression) {
 
 		return Functions.size(expression).isEqualTo(Cypher.literalOf(0L));
-	}
-
-	/**
-	 * A condition that evaluates to true if the property {@code property} exists.
-	 *
-	 * @param property The property to check whether it exists or not
-	 * @return A new condition.
-	 */
-	public static Condition exists(Property property) {
-
-		return new BooleanFunctionCondition(Predicates.exists(property));
-	}
-
-	/**
-	 * A condition that evaluates to true if the pattern {@code pattern} exists.
-	 *
-	 * @param pattern The pattern to check whether it exists or not
-	 * @return A new condition.
-	 */
-	public static Condition exists(RelationshipPattern pattern) {
-
-		return new BooleanFunctionCondition(Predicates.exists(pattern));
 	}
 
 	/**

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Cypher.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Cypher.java
@@ -34,7 +34,6 @@ import org.neo4j.opencypherdsl.StatementBuilder.OrderableOngoingReadingAndWith;
 
 /**
  * The main entry point into the Cypher DSL.
- *
  * The Cypher Builder API is intended for framework usage to produce Cypher statements required for database operations.
  *
  * @author Michael J. Simons
@@ -115,6 +114,28 @@ public final class Cypher {
 	 */
 	public static Property property(Expression expression, String name) {
 		return Property.create(expression, name);
+	}
+
+	/**
+	 * Starts defining a named path by indicating a name.
+	 *
+	 * @param name The name of the new path
+	 * @return An ongoing definition of a named path
+	 * @since 1.1
+	 */
+	public static NamedPath.OngoingDefinitionWithName path(String name) {
+		return NamedPath.named(name);
+	}
+
+	/**
+	 * Starts defining a named path by indicating a name.
+	 *
+	 * @param name The name of the new path
+	 * @return An ongoing definition of a named path
+	 * @since 1.1
+	 */
+	public static NamedPath.OngoingDefinitionWithName path(SymbolicName name) {
+		return NamedPath.named(name);
 	}
 
 	/**
@@ -211,6 +232,7 @@ public final class Cypher {
 	/**
 	 * Starts building a statement starting with an {@code UNWIND} clause. The expressions passed will be turned into a
 	 * list expression
+	 *
 	 * @param expressions expressions to unwind
 	 * @return a new instance of {@link OngoingUnwind}
 	 */

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExpressionList.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ExpressionList.java
@@ -28,6 +28,8 @@ import org.neo4j.opencypherdsl.support.Visitable;
 /**
  * Represents a list of expressions. When visited, the expressions are treated as named expression if they have declared
  * a symbolic name as variable or as unnamed expression when nameless.
+ * <p>
+ * Not to be mixed up with the the actual {@link ListExpression}, which itself is an expression.
  *
  * @author Michael J. Simons
  * @since 1.0

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Functions.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Functions.java
@@ -66,7 +66,7 @@ public final class Functions {
 	}
 
 	/**
-	 * Creates a function invocation for {@code id{}}.
+	 * Creates a function invocation for {@code labels{}}.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-labels">labels</a>.
 	 *
 	 * @param node The node for which the labels should be retrieved
@@ -457,6 +457,21 @@ public final class Functions {
 		Assert.notNull(expression, "The expression for last is required.");
 
 		return new FunctionInvocation("last", expression);
+	}
+
+	/**
+	 * Creates a function invocation for {@code nodes{}}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-nodes">labels</a>.
+	 *
+	 * @param path The path for which the number of nodes should be retrieved
+	 * @return A function call for {@code nodes()} on a node.
+	 * @since 1.1
+	 */
+	public static FunctionInvocation nodes(NamedPath path) {
+
+		Assert.notNull(path, "The path for nodes is required.");
+		return path.getSymbolicName().map(n -> new FunctionInvocation("nodes", n))
+			.orElseThrow(() -> new IllegalArgumentException("The path needs to be named!"));
 	}
 
 	private Functions() {

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ListLiteral.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ListLiteral.java
@@ -26,6 +26,8 @@ import java.util.stream.StreamSupport;
 import org.apiguardian.api.API;
 
 /**
+ * A list of literals.
+ *
  * @author Gerrit Meier
  * @author Michael J. Simons
  * @since 1.0

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ListPredicate.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/ListPredicate.java
@@ -24,43 +24,45 @@ import org.apiguardian.api.API;
 import org.neo4j.opencypherdsl.support.Visitor;
 
 /**
- * Represents a list expression as in {@code [expression1, expression2, ..., expressionN]}
+ * A list predicate.
  *
  * @author Michael J. Simons
- * @soundtrack Queen - Jazz
- * @since 1.0
+ * @soundtrack Freddie Mercury - Never Boring
+ * @since 1.1
+ * /
  */
-@API(status = EXPERIMENTAL, since = "1.0")
-public final class ListExpression implements Expression {
+@API(status = INTERNAL, since = "1.1")
+final class ListPredicate implements Expression {
 
-	static Expression listOrSingleExpression(Expression... expressions) {
+	/**
+	 * The variable for the where part.
+	 */
+	private final SymbolicName variable;
 
-		Assert.notNull(expressions, "Expressions are required.");
-		Assert.notEmpty(expressions, "At least one expression is required.");
+	/**
+	 * The list expression. No further assertions are taken to check beforehand if it is actually a Cypher List atm.
+	 */
+	private final Expression listExpression;
 
-		if (expressions.length == 1) {
-			return expressions[0];
-		} else {
-			return ListExpression.create(expressions);
-		}
-	}
+	/**
+	 * Filtering on the list.
+	 */
+	private final Where where;
 
-	static ListExpression create(Expression... expressions) {
+	ListPredicate(SymbolicName variable, Expression listExpression, Where where) {
 
-		return new ListExpression(new ExpressionList<>(expressions));
-	}
-
-	private final ExpressionList<?> content;
-
-	private ListExpression(ExpressionList<?> content) {
-		this.content = content;
+		this.variable = variable;
+		this.listExpression = listExpression;
+		this.where = where;
 	}
 
 	@Override
 	public void accept(Visitor visitor) {
-
 		visitor.enter(this);
-		this.content.accept(visitor);
+		this.variable.accept(visitor);
+		Operator.IN.accept(visitor);
+		this.listExpression.accept(visitor);
+		this.where.accept(visitor);
 		visitor.leave(this);
 	}
 }

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/NamedPath.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/NamedPath.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.opencypherdsl;
+
+import static org.apiguardian.api.API.Status.*;
+
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.neo4j.opencypherdsl.support.Visitor;
+
+/**
+ * Represents a named named path as in {@code p := (a)-->(b)}.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Freddie Mercury - Never Boring
+ * @since 1.1
+ */
+@API(status = EXPERIMENTAL, since = "1.1")
+public final class NamedPath implements PatternElement, Named {
+
+	/**
+	 * The name of this path expression.
+	 */
+	private final SymbolicName name;
+
+	/**
+	 * The pattern defining this path.
+	 */
+	private final RelationshipPattern pattern;
+
+	static OngoingDefinitionWithName named(String name) {
+
+		return named(SymbolicName.create(name));
+	}
+
+	static OngoingDefinitionWithName named(SymbolicName name) {
+
+		Assert.notNull(name, "A name is required");
+		return new Builder(name);
+	}
+
+	/**
+	 * Partial path that has a name ({@code p = }).
+	 */
+	public interface OngoingDefinitionWithName {
+
+		NamedPath definedBy(RelationshipPattern pattern);
+	}
+
+	private static class Builder implements OngoingDefinitionWithName {
+
+		private final SymbolicName name;
+
+		private Builder(SymbolicName name) {
+			this.name = name;
+		}
+
+		@Override
+		public NamedPath definedBy(RelationshipPattern pattern) {
+			return new NamedPath(name, pattern);
+		}
+	}
+
+	private NamedPath(SymbolicName name, RelationshipPattern pattern) {
+		this.name = name;
+		this.pattern = pattern;
+	}
+
+	@Override
+	public Optional<SymbolicName> getSymbolicName() {
+		return Optional.of(name);
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		this.name.accept(visitor);
+		Operator.EQUALS.accept(visitor);
+		this.pattern.accept(visitor);
+		visitor.leave(this);
+	}
+}

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Operator.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Operator.java
@@ -77,6 +77,7 @@ public enum Operator implements Visitable {
 	REMOVE_LABEL("", Type.LABEL),
 
 	// Misc
+	EQUALS("="), // Read as in `p := (a)-->(b)`
 	PIPE("|");
 
 	private final String representation;

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Predicates.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/Predicates.java
@@ -35,30 +35,186 @@ import org.apiguardian.api.API;
 public final class Predicates {
 
 	/**
-	 * Creates a function invocation for the {@code exists()} function.
+	 * Creates a new condition based on a function invocation for the {@code exists()} function.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-exists">exists</a>.
 	 *
 	 * @param property The property to be passed to {@code exists()}
 	 * @return A function call for {@code exists()} for one property
 	 */
-	public static FunctionInvocation exists(Property property) {
+	public static Condition exists(Property property) {
 
 		Assert.notNull(property, "The property for exists() is required.");
 
-		return new FunctionInvocation("exists", property);
+		return new BooleanFunctionCondition(new FunctionInvocation("exists", property));
 	}
 
 	/**
-	 * Creates a function invocation for the {@code exists()} function.
+	 * Creates a new condition based on a function invocation for the {@code exists()} function.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-exists">exists</a>.
 	 *
 	 * @param pattern The pattern to be passed to {@code exists()}
 	 * @return A function call for {@code exists()} for one pattern
 	 */
-	public static FunctionInvocation exists(RelationshipPattern pattern) {
+	public static Condition exists(RelationshipPattern pattern) {
 
 		Assert.notNull(pattern, "The pattern for exists() is required.");
 
-		return new FunctionInvocation("exists", new Pattern(Collections.singletonList(pattern)));
+		return new BooleanFunctionCondition(
+			new FunctionInvocation("exists", new Pattern(Collections.singletonList(pattern))));
+	}
+
+	/**
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code all()} predicate function
+	 * @see #all(SymbolicName)
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction all(String variable) {
+
+		return all(SymbolicName.create(variable));
+	}
+
+	/**
+	 * Starts building a new condition based on a function invocation for the {@code all()} function.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-all">exists</a>.
+	 *
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code all()} predicate function
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction all(SymbolicName variable) {
+
+		return new Builder("all", variable);
+	}
+
+	/**
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code any()} predicate function
+	 * @see #any(SymbolicName)
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction any(String variable) {
+
+		return any(SymbolicName.create(variable));
+	}
+
+	/**
+	 * Starts building a new condition based on a function invocation for the {@code any()} function.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-any">exists</a>.
+	 *
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code any()} predicate function
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction any(SymbolicName variable) {
+
+		return new Builder("any", variable);
+	}
+
+	/**
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code none()} predicate function
+	 * @see #none(SymbolicName)
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction none(String variable) {
+
+		return none(SymbolicName.create(variable));
+	}
+
+	/**
+	 * Starts building a new condition based on a function invocation for the {@code none()} function.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-none">exists</a>.
+	 *
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code none()} predicate function
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction none(SymbolicName variable) {
+
+		return new Builder("none", variable);
+	}
+
+	/**
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code single()} predicate function
+	 * @see #single(SymbolicName)
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction single(String variable) {
+
+		return single(SymbolicName.create(variable));
+	}
+
+	/**
+	 * Starts building a new condition based on a function invocation for the {@code single()} function.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-single">exists</a>.
+	 *
+	 * @param variable The variable referring to elements of a list
+	 * @return A builder for the {@code single()} predicate function
+	 * @since 1.1
+	 */
+	public static OngoingListBasedPredicateFunction single(SymbolicName variable) {
+
+		return new Builder("single", variable);
+	}
+
+	/**
+	 * Allows to define the source of the list predicate.
+	 */
+	public interface OngoingListBasedPredicateFunction {
+
+		/**
+		 * @param list A list
+		 * @return A builder to specify the where condition for the list based predicate
+		 */
+		OngoingListBasedPredicateFunctionWithList in(Expression list);
+	}
+
+	/**
+	 * Allows to specify the where condition for the list based predicate.
+	 */
+	public interface OngoingListBasedPredicateFunctionWithList {
+
+		/**
+		 * @param condition The condition for the list based predicate.
+		 * @return The final list based predicate function
+		 */
+		Condition where(Condition condition);
+	}
+
+	private static class Builder implements OngoingListBasedPredicateFunction,
+		OngoingListBasedPredicateFunctionWithList {
+
+		private final String predicate;
+		private final SymbolicName name;
+		private Expression listExpression;
+
+		Builder(String predicate, SymbolicName name) {
+
+			Assert.notNull(predicate, "The predicate is required");
+			Assert.notNull(name, "The name is required");
+			this.predicate = predicate;
+			this.name = name;
+		}
+
+		@Override
+		public OngoingListBasedPredicateFunctionWithList in(Expression list) {
+
+			Assert.notNull(list, "The list expression is required");
+			this.listExpression = list;
+			return this;
+		}
+
+		@Override
+		public Condition where(Condition condition) {
+
+			Assert.notNull(condition, "The condition is required");
+			return new BooleanFunctionCondition(
+				new FunctionInvocation(predicate, new ListPredicate(name, listExpression, new Where(condition))));
+		}
+	}
+
+	private Predicates() {
 	}
 }

--- a/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipPattern.java
+++ b/neo4j-opencypher-dsl/src/main/java/org/neo4j/opencypherdsl/RelationshipPattern.java
@@ -26,7 +26,7 @@ import org.apiguardian.api.API;
  * A shared, public interface for  {@link Relationship relationships} and {@link RelationshipChain chains of relationships}.
  * This interface reassembles the <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/RelationshipPattern.html">RelationshipPattern</a>.
  * <p>
- * This interface can be used synonmous with the concept of a <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Path Pattern</a>.
+ * This interface can be used synonymous with the concept of a <a href="https://neo4j.com/docs/cypher-manual/4.0/clauses/where/#query-where-patterns">Path Pattern</a>.
  *
  * @author Michael J. Simons
  * @soundtrack Mine & Fatoni - Alle Liebe nachträglich

--- a/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/PredicatesTest.java
+++ b/neo4j-opencypher-dsl/src/test/java/org/neo4j/opencypherdsl/PredicatesTest.java
@@ -58,8 +58,9 @@ class PredicatesTest {
 	void functionInvocationsShouldBeCreated(String functionName, Class<?> argumentType) {
 
 		Method method = ReflectionUtils.findMethod(Predicates.class, functionName, argumentType);
-		FunctionInvocation invocation = (FunctionInvocation) ReflectionUtils
+		BooleanFunctionCondition invocation = (BooleanFunctionCondition) ReflectionUtils
 			.invokeMethod(method, null, mock(argumentType));
-		assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, functionName);
+		assertThat(invocation).extracting("delegate")
+			.hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, functionName);
 	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/query/CypherQueryCreator.java
@@ -333,7 +333,7 @@ final class CypherQueryCreator extends AbstractQueryCreator<QueryAndParameters, 
 				return toCypherProperty(persistentProperty, ignoreCase)
 					.endsWith(toCypherParameter(nextRequiredParameter(actualParameters), ignoreCase));
 			case EXISTS:
-				return Conditions.exists(toCypherProperty(persistentProperty));
+				return Predicates.exists(toCypherProperty(persistentProperty));
 			case FALSE:
 				return toCypherProperty(persistentProperty, ignoreCase).isFalse();
 			case GREATER_THAN_EQUAL:

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DynamicLabelsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DynamicLabelsIT.java
@@ -19,9 +19,9 @@
 package org.neo4j.springframework.data.integration.imperative;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.neo4j.opencypherdsl.Conditions.*;
 import static org.neo4j.opencypherdsl.Conditions.not;
 import static org.neo4j.opencypherdsl.Cypher.*;
+import static org.neo4j.opencypherdsl.Predicates.*;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,12 +38,12 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
-import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
-import org.neo4j.springframework.data.core.Neo4jTemplate;
 import org.neo4j.opencypherdsl.Condition;
 import org.neo4j.opencypherdsl.Cypher;
 import org.neo4j.opencypherdsl.Node;
 import org.neo4j.opencypherdsl.renderer.Renderer;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.core.Neo4jTemplate;
 import org.neo4j.springframework.data.integration.shared.EntitiesWithDynamicLabels.*;
 import org.neo4j.springframework.data.test.Neo4jExtension;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicLabelsIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/reactive/ReactiveDynamicLabelsIT.java
@@ -19,8 +19,8 @@
 package org.neo4j.springframework.data.integration.reactive;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.neo4j.opencypherdsl.Conditions.*;
 import static org.neo4j.opencypherdsl.Conditions.not;
+import static org.neo4j.opencypherdsl.Predicates.*;
 import static org.neo4j.springframework.data.test.Neo4jExtension.*;
 
 import reactor.core.publisher.Flux;
@@ -41,12 +41,12 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.reactive.RxSession;
-import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
-import org.neo4j.springframework.data.core.ReactiveNeo4jTemplate;
 import org.neo4j.opencypherdsl.Condition;
 import org.neo4j.opencypherdsl.Cypher;
 import org.neo4j.opencypherdsl.Node;
 import org.neo4j.opencypherdsl.renderer.Renderer;
+import org.neo4j.springframework.data.config.AbstractReactiveNeo4jConfig;
+import org.neo4j.springframework.data.core.ReactiveNeo4jTemplate;
 import org.neo4j.springframework.data.integration.shared.EntitiesWithDynamicLabels.*;
 import org.neo4j.springframework.data.test.Neo4jExtension;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
This adds the ability to use named paths as defined in 3.1.4.8 of the docs.

Based on those (and other expressions), all list based predicates have been added as well (`any`, `all`, `single` and `none)`.
The existing `exists` predicate for properties and patterns have been moved from the `Conditions` to `Predicates` as well.

This closes #247.