### PR TITLE
Use idDescription when mapping relations

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -49,6 +49,7 @@ import org.neo4j.driver.types.Relationship;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.convert.Neo4jConverter;
+import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
@@ -470,10 +471,15 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 			for (Value relatedEntity : list.asList(Function.identity())) {
 				Neo4jPersistentProperty idProperty = concreteTargetNodeDescription.getRequiredIdProperty();
 
+				String relatedEntityIdKey = Optional.ofNullable(concreteTargetNodeDescription.getIdDescription())
+					.flatMap(IdDescription::getOptionalGraphPropertyName)
+					.orElse(concreteTargetNodeDescription.getRequiredIdProperty().getName());
+
 				// internal (generated) id or external set
 				Object idValue = idProperty.isInternalIdProperty()
 					? relatedEntity.get(NAME_OF_INTERNAL_ID)
-					: relatedEntity.get(idProperty.getName());
+					: relatedEntity.get(relatedEntityIdKey);
+
 				Object valueEntry = knownObjects.computeIfAbsent(idValue,
 					() -> map(relatedEntity, concreteTargetNodeDescription, knownObjects));
 

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -49,7 +49,6 @@ import org.neo4j.driver.types.Relationship;
 import org.neo4j.driver.types.TypeSystem;
 import org.neo4j.springframework.data.core.convert.Neo4jConversions;
 import org.neo4j.springframework.data.core.convert.Neo4jConverter;
-import org.neo4j.springframework.data.core.schema.IdDescription;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
@@ -471,14 +470,13 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 			for (Value relatedEntity : list.asList(Function.identity())) {
 				Neo4jPersistentProperty idProperty = concreteTargetNodeDescription.getRequiredIdProperty();
 
-				String relatedEntityIdKey = Optional.ofNullable(concreteTargetNodeDescription.getIdDescription())
-					.flatMap(IdDescription::getOptionalGraphPropertyName)
-					.orElse(idProperty.getName());
-
 				// internal (generated) id or external set
-				Object idValue = idProperty.isInternalIdProperty()
-					? relatedEntity.get(NAME_OF_INTERNAL_ID)
-					: relatedEntity.get(relatedEntityIdKey);
+				String relatedEntityIdKey = idProperty.isInternalIdProperty()
+					? NAME_OF_INTERNAL_ID
+					: concreteTargetNodeDescription.getIdDescription()
+						.getOptionalGraphPropertyName()
+						.orElse(idProperty.getName());
+				Object idValue = relatedEntity.get(relatedEntityIdKey);
 
 				Object valueEntry = knownObjects.computeIfAbsent(idValue,
 					() -> map(relatedEntity, concreteTargetNodeDescription, knownObjects));

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/mapping/DefaultNeo4jConverter.java
@@ -473,7 +473,7 @@ final class DefaultNeo4jConverter implements Neo4jConverter {
 
 				String relatedEntityIdKey = Optional.ofNullable(concreteTargetNodeDescription.getIdDescription())
 					.flatMap(IdDescription::getOptionalGraphPropertyName)
-					.orElse(concreteTargetNodeDescription.getRequiredIdProperty().getName());
+					.orElse(idProperty.getName());
 
 				// internal (generated) id or external set
 				Object idValue = idProperty.isInternalIdProperty()

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
@@ -156,15 +156,5 @@ class DefaultNeo4jConverterIT {
 			return neo4jConnectionSupport.getDriver();
 		}
 
-		// If someone wants to use the plain driver or the delegating mechanism of the client, than they must provide a couple of more beans.
-		@Bean
-		public Neo4jPersistenceExceptionTranslator neo4jPersistenceExceptionTranslator() {
-			return new Neo4jPersistenceExceptionTranslator();
-		}
-
-		@Bean
-		public PersistenceExceptionTranslationPostProcessor persistenceExceptionTranslationPostProcessor() {
-			return new PersistenceExceptionTranslationPostProcessor();
-		}
 	}
 }

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
@@ -35,14 +35,12 @@ import org.neo4j.springframework.data.core.schema.Property;
 import org.neo4j.springframework.data.core.schema.Relationship;
 import org.neo4j.springframework.data.repository.Neo4jRepository;
 import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
-import org.neo4j.springframework.data.repository.support.Neo4jPersistenceExceptionTranslator;
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.integration.imperative;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.neo4j.springframework.data.test.Neo4jExtension.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.config.AbstractNeo4jConfig;
+import org.neo4j.springframework.data.core.schema.Id;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.neo4j.springframework.data.core.schema.Property;
+import org.neo4j.springframework.data.core.schema.Relationship;
+import org.neo4j.springframework.data.repository.Neo4jRepository;
+import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
+import org.neo4j.springframework.data.repository.support.Neo4jPersistenceExceptionTranslator;
+import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Davide Fantuzzi
+ * @author Andrea Santurbano
+ */
+@Neo4jIntegrationTest
+class DefaultNeo4jConverterIT {
+
+	protected static Neo4jConnectionSupport neo4jConnectionSupport;
+
+	@Test
+	void itShouldReturnsAllTheRelatedEntities(@Autowired Entity2Repository entity2Repository) {
+		Entity1 firstEntity1 = new Entity1("1-2-3");
+		Entity1 secondEntity1 = new Entity1("4-5-6");
+		final Set<Entity1> entity1List = new HashSet<>(Arrays.asList(firstEntity1, secondEntity1));
+		Entity2 entity2 = new Entity2("7-8-9", entity1List);
+
+		entity2Repository.save(entity2);
+		Entity2 entity2fromDb = entity2Repository.findById(entity2.id).get();
+
+		assertThat(entity2fromDb.entity1List).isEqualTo(entity1List);
+	}
+
+	@Node
+	private static class Entity1 {
+		@Id
+		@Property("my_internal_id")
+		private final String id;
+
+		Entity1(String id) {
+			this.id = id;
+		}
+
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Entity1 entity1 = (Entity1) o;
+			return Objects.equals(id, entity1.id);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id);
+		}
+
+		@Override public String toString() {
+			return "Entity1{" +
+				"id='" + id + '\'' +
+				'}';
+		}
+	}
+
+	@Node
+	private static class Entity2 {
+		@Id
+		private final String id;
+
+		@Relationship(value = "REL", direction = Relationship.Direction.INCOMING)
+		private final Set<Entity1> entity1List;
+
+		Entity2(String id, Set<Entity1> entity1List) {
+			this.id = id;
+			this.entity1List = entity1List;
+		}
+
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Entity2 entity2 = (Entity2) o;
+			return Objects.equals(id, entity2.id) &&
+				Objects.equals(entity1List, entity2.entity1List);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, entity1List);
+		}
+
+		@Override public String toString() {
+			return "Entity2{" +
+				"id='" + id + '\'' +
+				", entity1List=" + entity1List +
+				'}';
+		}
+	}
+
+	@Repository
+	interface Entity2Repository extends Neo4jRepository<Entity2, String> {
+	}
+
+	@Configuration
+	@EnableNeo4jRepositories(
+		considerNestedRepositories = true,
+		includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = Entity2Repository.class)
+	)
+	@EnableTransactionManagement
+	static class Config extends AbstractNeo4jConfig {
+
+		@Bean
+		public Driver driver() {
+			return neo4jConnectionSupport.getDriver();
+		}
+
+		// If someone wants to use the plain driver or the delegating mechanism of the client, than they must provide a couple of more beans.
+		@Bean
+		public Neo4jPersistenceExceptionTranslator neo4jPersistenceExceptionTranslator() {
+			return new Neo4jPersistenceExceptionTranslator();
+		}
+
+		@Bean
+		public PersistenceExceptionTranslationPostProcessor persistenceExceptionTranslationPostProcessor() {
+			return new PersistenceExceptionTranslationPostProcessor();
+		}
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/integration/imperative/DefaultNeo4jConverterIT.java
@@ -24,6 +24,7 @@ import static org.neo4j.springframework.data.test.Neo4jExtension.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -38,9 +39,7 @@ import org.neo4j.springframework.data.repository.config.EnableNeo4jRepositories;
 import org.neo4j.springframework.data.test.Neo4jIntegrationTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -57,13 +56,14 @@ class DefaultNeo4jConverterIT {
 	void itShouldReturnsAllTheRelatedEntities(@Autowired Entity2Repository entity2Repository) {
 		Entity1 firstEntity1 = new Entity1("1-2-3");
 		Entity1 secondEntity1 = new Entity1("4-5-6");
-		final Set<Entity1> entity1List = new HashSet<>(Arrays.asList(firstEntity1, secondEntity1));
+		Set<Entity1> entity1List = new HashSet<>(Arrays.asList(firstEntity1, secondEntity1));
 		Entity2 entity2 = new Entity2("7-8-9", entity1List);
 
 		entity2Repository.save(entity2);
-		Entity2 entity2fromDb = entity2Repository.findById(entity2.id).get();
+		Optional<Entity2> optionalEntity2 = entity2Repository.findById(entity2.id);
 
-		assertThat(entity2fromDb.entity1List).isEqualTo(entity1List);
+		assertThat(optionalEntity2).isPresent();
+		assertThat(optionalEntity2).map(e -> e.entity1List).contains(entity1List);
 	}
 
 	@Node
@@ -142,10 +142,7 @@ class DefaultNeo4jConverterIT {
 	}
 
 	@Configuration
-	@EnableNeo4jRepositories(
-		considerNestedRepositories = true,
-		includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = Entity2Repository.class)
-	)
+	@EnableNeo4jRepositories(considerNestedRepositories = true)
 	@EnableTransactionManagement
 	static class Config extends AbstractNeo4jConfig {
 


### PR DESCRIPTION
We noticed that `createInstanceOfRelationships` in `DefaultNeo4jConverter` uses requiredIdProperty to match the related entities.

If the node entity uses `@Property` on an id field this won't be correctly resolved by the method.
Look at the test that reproduces the use case.

Thanks to @conker84 for the help.