### PR TITLE
Fix bidirectional relationship save.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -489,7 +489,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 	private boolean hasProcessed(Set<Object> processedObjects, @Nullable Collection<?> valuesToStore) {
 		// there can be null elements in the unified collection of values to store.
 		if (valuesToStore == null) {
-			return true;
+			return false;
 		}
 		return processedObjects.containsAll(valuesToStore);
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/Neo4jTemplate.java
@@ -234,11 +234,11 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 
 		PersistentPropertyAccessor<T> propertyAccessor = entityMetaData.getPropertyAccessor(entityToBeSaved);
 		if (!entityMetaData.isUsingInternalIds()) {
-			processAssociations(entityMetaData, entityToBeSaved, inDatabase);
+			processRelations(entityMetaData, entityToBeSaved, inDatabase);
 			return entityToBeSaved;
 		} else {
 			propertyAccessor.setProperty(entityMetaData.getRequiredIdProperty(), optionalInternalId.get());
-			processAssociations(entityMetaData, entityToBeSaved, inDatabase);
+			processRelations(entityMetaData, entityToBeSaved, inDatabase);
 
 			return propertyAccessor.getBean();
 		}
@@ -312,9 +312,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 			.run();
 
 		// Save related
-		entitiesToBeSaved.forEach(entityToBeSaved -> {
-			processAssociations(entityMetaData, entityToBeSaved, databaseName);
-		});
+		entitiesToBeSaved.forEach(entityToBeSaved -> processRelations(entityMetaData, entityToBeSaved, databaseName));
 
 		SummaryCounters counters = resultSummary.counters();
 		log.debug(() -> String
@@ -401,12 +399,12 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 		return toExecutableQuery(preparedQuery);
 	}
 
-	private void processAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
+	private void processRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
 
-		processNestedAssociations(neo4jPersistentEntity, parentObject, inDatabase, new NestedRelationshipProcessState());
+		processNestedRelations(neo4jPersistentEntity, parentObject, inDatabase, new NestedRelationshipProcessState());
 	}
 
-	private void processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+	private void processNestedRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
 		@Nullable String inDatabase, NestedRelationshipProcessState processState) {
 
 		PersistentPropertyAccessor<?> propertyAccessor = neo4jPersistentEntity.getPropertyAccessor(parentObject);
@@ -478,7 +476,7 @@ public final class Neo4jTemplate implements Neo4jOperations, BeanFactoryAware {
 					targetPropertyAccessor
 						.setProperty(targetNodeDescription.getRequiredIdProperty(), relatedInternalId);
 				}
-				processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase, processState);
+				processNestedRelations(targetNodeDescription, valueToBeSaved, inDatabase, processState);
 			}
 		});
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
  * the algorithm.
  *
  * @author Philipp Tölle
+ * @author Gerrit Meier
  * @since 1.0
  */
 final class NestedRelationshipContext {

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipContext.java
@@ -25,6 +25,7 @@ import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
 import org.neo4j.springframework.data.core.schema.RelationshipDescription;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.lang.Nullable;
 
 /**
  * Working on nested relationships happens in a certain algorithmic context.
@@ -43,7 +44,7 @@ final class NestedRelationshipContext {
 
 	private final boolean inverseValueIsEmpty;
 
-	private NestedRelationshipContext(Neo4jPersistentProperty inverse, Object value,
+	private NestedRelationshipContext(Neo4jPersistentProperty inverse, @Nullable Object value,
 		RelationshipDescription relationship, Class<?> associationTargetType, boolean inverseValueIsEmpty) {
 		this.inverse = inverse;
 		this.value = value;
@@ -56,6 +57,7 @@ final class NestedRelationshipContext {
 		return inverse;
 	}
 
+	@Nullable
 	Object getValue() {
 		return value;
 	}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipProcessState.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipProcessState.java
@@ -1,4 +1,102 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.springframework.data.core;
 
-public class NestedRelationshipProcessState {
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.neo4j.springframework.data.core.schema.RelationshipDescription;
+import org.springframework.lang.Nullable;
+
+/**
+ * This stores all processed nested relations and objects during save of objects so that the recursive descent can be
+ * stopped accordingly.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Helge Schneider - Heart Attack No. 1
+ */
+final class NestedRelationshipProcessState {
+
+	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+	private final Lock read = lock.readLock();
+	private final Lock write = lock.writeLock();
+
+	/**
+	 * The set of already processed relationships.
+	 */
+	private final Set<RelationshipDescription> processedRelationshipDescriptions = new HashSet<>();
+
+	/**
+	 * The set of already processed related objects.
+	 */
+	private final Set<Object> processedObjects = new HashSet<>();
+
+	/**
+	 * @param relationshipDescription Check whether this relationship description has been processed
+	 * @param valuesToStore           Check whether all the values in the collection have been processed
+	 * @return True, if either the relationship has been already process or all of the values to store.
+	 */
+	boolean hasProcessedEither(RelationshipDescription relationshipDescription, @Nullable Collection<?> valuesToStore) {
+
+		try {
+			read.lock();
+			return hasProcessed(relationshipDescription) || hasProcessedAllOf(valuesToStore);
+		} finally {
+			read.unlock();
+		}
+	}
+
+	/**
+	 * Marks the passed objects as processed
+	 *
+	 * @param relationshipDescription To be marked as processed
+	 * @param valuesToStore           If not {@literal null}, all non-null values will be marked as processed
+	 */
+	void markAsProcessed(RelationshipDescription relationshipDescription, @Nullable Collection<?> valuesToStore) {
+
+		try {
+			write.lock();
+			this.processedRelationshipDescriptions.add(relationshipDescription);
+			if (valuesToStore != null) {
+				valuesToStore.stream().filter(v -> v != null).forEach(processedObjects::add);
+			}
+		} finally {
+			write.unlock();
+		}
+	}
+
+	private boolean hasProcessedAllOf(@Nullable Collection<?> valuesToStore) {
+		// there can be null elements in the unified collection of values to store.
+		if (valuesToStore == null) {
+			return false;
+		}
+		return processedObjects.containsAll(valuesToStore);
+	}
+
+	private boolean hasProcessed(RelationshipDescription relationshipDescription) {
+
+		if (relationshipDescription != null) {
+			return processedRelationshipDescriptions.contains(relationshipDescription);
+		}
+		return false;
+	}
 }

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipProcessState.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/NestedRelationshipProcessState.java
@@ -1,0 +1,4 @@
+package org.neo4j.springframework.data.core;
+
+public class NestedRelationshipProcessState {
+}

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/ReactiveNeo4jTemplate.java
@@ -247,15 +247,14 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 
 
 				if (!entityMetaData.isUsingInternalIds()) {
-					return idMono.then(processAssociations(entityMetaData, entity, inDatabase))
-						.thenReturn(entity);
+					return idMono.then(processRelations(entityMetaData, entity, inDatabase)).thenReturn(entity);
 				} else {
 					return idMono.map(internalId -> {
 						PersistentPropertyAccessor<T> propertyAccessor = entityMetaData.getPropertyAccessor(entity);
 						propertyAccessor.setProperty(entityMetaData.getRequiredIdProperty(), internalId);
 
 						return propertyAccessor.getBean();
-					}).flatMap(savedEntity -> processAssociations(entityMetaData, savedEntity, inDatabase)
+					}).flatMap(savedEntity -> processRelations(entityMetaData, savedEntity, inDatabase)
 						.thenReturn(savedEntity));
 				}
 			});
@@ -406,12 +405,12 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 		return this.toExecutableQuery(preparedQuery);
 	}
 
-	private Mono<Void> processAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
+	private Mono<Void> processRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject, @Nullable String inDatabase) {
 
-		return processNestedAssociations(neo4jPersistentEntity, parentObject, inDatabase, new NestedRelationshipProcessState());
+		return processNestedRelations(neo4jPersistentEntity, parentObject, inDatabase, new NestedRelationshipProcessState());
 	}
 
-	private Mono<Void> processNestedAssociations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
+	private Mono<Void> processNestedRelations(Neo4jPersistentEntity<?> neo4jPersistentEntity, Object parentObject,
 		@Nullable String inDatabase, NestedRelationshipProcessState processState) {
 
 		return Mono.defer(() -> {
@@ -490,7 +489,7 @@ public final class ReactiveNeo4jTemplate implements ReactiveNeo4jOperations, Bea
 											.run();
 
 										return relationshipCreationMonoNested.checkpoint()
-											.then(processNestedAssociations(targetNodeDescription, valueToBeSaved, inDatabase, processState));
+											.then(processNestedRelations(targetNodeDescription, valueToBeSaved, inDatabase, processState));
 									}).checkpoint()));
 				}
 			});

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/core/support/Relationships.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.springframework.data.core.mapping.Neo4jPersistentProperty;
+import org.springframework.lang.Nullable;
 
 /**
  * @author Michael J. Simons
@@ -42,6 +43,7 @@ public final class Relationships {
 	 * @return A unified collection (Either a collection of Map.Entry for dynamic and relationships with properties
 	 * or a list of related values)
 	 */
+	@Nullable
 	public static Collection<?> unifyRelationshipValue(Neo4jPersistentProperty property, Object rawValue) {
 		Collection<?> unifiedValue;
 		if (property.isDynamicAssociation()) {


### PR DESCRIPTION
If a bidirectional relationship on the same type gets modelled as OUTGOING
the mapping will run endless following the relationship until a stack overflow occurs.

This for now closes #254 but a follow up issue will get created to base the work for undirected relationships on because there is a difference between `UNDIRECTED` with one relationship ignoring the database relationship direction and bidirectional that is modelled as two outgoing relationships from each side.