### PR TITLE
Add a startup logger to the repository extensions.

### DIFF
--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/Neo4jRepositoryConfigurationExtension.java
@@ -61,6 +61,11 @@ public final class Neo4jRepositoryConfigurationExtension extends RepositoryConfi
 	 */
 	static final String DEFAULT_MAPPING_CONTEXT_BEAN_NAME = "neo4jMappingContext";
 
+	public Neo4jRepositoryConfigurationExtension() {
+
+		new StartupLogger(StartupLogger.Mode.IMPERATIVE).logStarting();
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config14.RepositoryConfigurationExtension#getRepositoryFactoryBeanClassName()

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/ReactiveNeo4jRepositoryConfigurationExtension.java
@@ -61,6 +61,11 @@ public final class ReactiveNeo4jRepositoryConfigurationExtension extends Reposit
 	 */
 	static final String DEFAULT_MAPPING_CONTEXT_BEAN_NAME = "neo4jMappingContext";
 
+	public ReactiveNeo4jRepositoryConfigurationExtension() {
+
+		new StartupLogger(StartupLogger.Mode.REACTIVE).logStarting();
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config14.RepositoryConfigurationExtension#getRepositoryFactoryBeanClassName()

--- a/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/StartupLogger.java
+++ b/spring-data-neo4j-rx/src/main/java/org/neo4j/springframework/data/repository/config/StartupLogger.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.config;
+
+import java.util.Optional;
+
+import org.apache.commons.logging.LogFactory;
+import org.neo4j.driver.Driver;
+import org.neo4j.springframework.data.core.schema.Node;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.data.mapping.context.AbstractMappingContext;
+import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
+
+/**
+ * Logs startup information.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Helge & Hardcore - Jazz
+ */
+final class StartupLogger {
+
+	enum Mode {
+		IMPERATIVE("imperative"), REACTIVE("reactive");
+
+		final String displayValue;
+
+		Mode(String displayValue) {
+			this.displayValue = displayValue;
+		}
+	}
+
+	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(StartupLogger.class));
+
+	private final Mode mode;
+
+	StartupLogger(Mode mode) {
+		this.mode = mode;
+	}
+
+	void logStarting() {
+
+		if (!logger.isDebugEnabled()) {
+			return;
+		}
+		logger.debug(() -> getStartingMessage());
+	}
+
+	String getStartingMessage() {
+
+		StringBuilder sb = new StringBuilder();
+
+		String sdnRx = getVersionOf(Node.class).map(v -> "SDN/RX v" + v).orElse("an unknown version of SDN/RX");
+		String sdC = getVersionOf(AbstractMappingContext.class).map(v -> "Spring Data Commons v" + v)
+			.orElse("an unknown version of Spring Data Commons");
+		String driver = getVersionOf(Driver.class).map(v -> "Neo4j Driver v" + v)
+			.orElse("an unknown version of the Neo4j Java Driver");
+		RepositoryConfigurationExtensionSupport f;
+		sb.append("Bootstrapping ").append(mode.displayValue).append(" Neo4j repositories based on ")
+			.append(sdnRx)
+			.append(" with ").append(sdC)
+			.append(" and ").append(driver).append(".");
+
+		return sb.toString();
+	}
+
+	private Optional<String> getVersionOf(Class<?> clazz) {
+
+		return Optional.ofNullable(clazz)
+			.map(Class::getPackage)
+			.map(Package::getImplementationVersion)
+			.map(String::trim)
+			.filter(v -> !v.isEmpty());
+	}
+}

--- a/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/config/StartupLoggerTest.java
+++ b/spring-data-neo4j-rx/src/test/java/org/neo4j/springframework/data/repository/config/StartupLoggerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.springframework.data.repository.config.StartupLogger.Mode;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Helge & Hardcore - Jazz
+ */
+class StartupLoggerTest {
+
+	@Test
+	void startingMessageShouldFit() {
+
+		String message = new StartupLogger(Mode.IMPERATIVE).getStartingMessage();
+		assertThat(message).matches(
+			"Bootstrapping imperative Neo4j repositories based on an unknown version of SDN\\/RX with Spring Data Commons v2\\.\\d+\\.\\d+.RELEASE and Neo4j Driver v4\\.\\d+\\.\\d+(?:-.*)\\.");
+	}
+}


### PR DESCRIPTION
This logs something like this

```
Bootstrapping reactive Neo4j repositories based on an unknown version of SDN/RX with Spring Data Commons v2.3.1.RELEASE and Neo4j Driver v4.0.1-979f102fbfd27e6393f672da8c7d59f6fabbbe0e.
```

on debug during bootstrap.